### PR TITLE
Fix descending semester order on education timeline

### DIFF
--- a/frontend/homepage/src/views/EducationView.vue
+++ b/frontend/homepage/src/views/EducationView.vue
@@ -116,13 +116,14 @@ const coursesBySemester = computed(() => {
     grouped[course.semester].push(course)
   })
 
-  // Sort semesters in descending order (most recent first)
-  const sortedSemesters = Object.keys(grouped).sort((a, b) => {
-    const [yearA, seasonA] = a.split('-')
-    const [yearB, seasonB] = b.split('-')
+  const getSemesterNumber = (semesterLabel: string): number => {
+    const match = semesterLabel.match(/semester\s+(\d+)/i)
+    return match ? parseInt(match[1], 10) : 0
+  }
 
-    if (yearA !== yearB) return parseInt(yearB) - parseInt(yearA) // Descending year order
-    return seasonB === 'Spring' || seasonB === 'Vår' ? 1 : -1 // Spring comes after Autumn
+  // Sort semesters in descending order (Semester 6 -> Semester 1)
+  const sortedSemesters = Object.keys(grouped).sort((a, b) => {
+    return getSemesterNumber(b) - getSemesterNumber(a)
   })
 
   return sortedSemesters.map(semester => ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update timeline course grouping sort logic to parse semester numbers from labels
- display semesters in descending order so Semester 6 appears first and Semester 1 appears last

## Testing
- npm run build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f41f9fa-9379-419d-85a3-35c4a41aa4fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f41f9fa-9379-419d-85a3-35c4a41aa4fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

