### PR TITLE
fix: clearer Chroma errors on Railway + docs for IPv6 binding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ SPRING_DATASOURCE_PASSWORD=root
 # CHROMA_HTTP_HOST=http://localhost
 # CHROMA_PORT=8100
 # CHROMA_COLLECTION=portfolio-documents
+# Set to false when Chroma is not deployed (chat works without RAG; admin document APIs return 501).
+# CHROMA_ENABLED=false
+# Railway: if Chroma uses private networking and the Java backend gets I/O errors, bind Chroma to IPv6, e.g.:
+# CHROMA_HOST_ADDR=::
 
 # --- Optional: OTLP tracing (Spring Boot management.otlp; gRPC). Default matches local Phoenix in docker-compose (4317). ---
 # Local Phoenix on host: http://localhost:4317

--- a/backend/src/main/java/com/kevinmazali/portfolio/config/ConfigLogging.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/ConfigLogging.java
@@ -1,5 +1,6 @@
 package com.kevinmazali.portfolio.config;
 
+import com.kevinmazali.portfolio.util.ChromaClientDiagnostics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
@@ -57,6 +58,11 @@ public class ConfigLogging implements ApplicationRunner {
             environment.getProperty("spring.ai.vectorstore.chroma.client.host", "<unset>"));
         log.info("Config: spring.ai.vectorstore.chroma.client.port={}",
             environment.getProperty("spring.ai.vectorstore.chroma.client.port", "<unset>"));
+        int chromaPort = environment.getProperty("spring.ai.vectorstore.chroma.client.port", Integer.class, 8100);
+        log.info("Config: Chroma REST client base URL (host:port, same as ChromaApi)={}",
+            ChromaClientDiagnostics.baseUrl(
+                environment.getProperty("spring.ai.vectorstore.chroma.client.host"),
+                chromaPort));
         log.info("Config: management.otlp.tracing.endpoint={}",
             environment.getProperty("management.otlp.tracing.endpoint", "<unset>"));
     }

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/ChromaHealthController.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/ChromaHealthController.java
@@ -2,6 +2,7 @@ package com.kevinmazali.portfolio.controller;
 
 import com.kevinmazali.portfolio.config.PortfolioChromaProperties;
 import com.kevinmazali.portfolio.model.ChromaHealthResponse;
+import com.kevinmazali.portfolio.util.ChromaClientDiagnostics;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chroma.vectorstore.ChromaApi;
 import org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreProperties;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChromaHealthController {
 
   private final ObjectProvider<ChromaApi> chromaApiProvider;
+  private final Environment environment;
   private final ChromaVectorStoreProperties chromaStoreProperties;
   private final PortfolioChromaProperties portfolioChromaProperties;
 
@@ -73,8 +76,16 @@ public class ChromaHealthController {
       long safeCount = count == null ? 0L : count;
       return ResponseEntity.ok(new ChromaHealthResponse(true, collectionName, safeCount, null));
     } catch (Exception e) {
+      String base = chromaClientBaseUrl();
+      String message = ChromaClientDiagnostics.healthFailureMessage(e, base);
       return ResponseEntity.status(503).body(new ChromaHealthResponse(
-          false, collectionName, null, e.getMessage()));
+          false, collectionName, null, message));
     }
+  }
+
+  private String chromaClientBaseUrl() {
+    String host = environment.getProperty("spring.ai.vectorstore.chroma.client.host", "");
+    int port = environment.getProperty("spring.ai.vectorstore.chroma.client.port", Integer.class, 8100);
+    return ChromaClientDiagnostics.baseUrl(host, port);
   }
 }

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerAdvice.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerAdvice.java
@@ -2,10 +2,14 @@ package com.kevinmazali.portfolio.controller;
 
 import com.kevinmazali.portfolio.exception.ChromaFeatureDisabledException;
 import com.kevinmazali.portfolio.model.ApiError;
+import com.kevinmazali.portfolio.util.ChromaClientDiagnostics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
 
 /**
@@ -13,7 +17,10 @@ import org.springframework.web.client.RestClientException;
  * consistent with {@link ChromaHealthController} behavior.
  */
 @RestControllerAdvice(assignableTypes = DocumentPipelineController.class)
+@RequiredArgsConstructor
 public class DocumentPipelineControllerAdvice {
+
+  private final Environment environment;
 
   /** Chroma disabled via {@code portfolio.chroma.enabled=false}. */
   @ExceptionHandler(ChromaFeatureDisabledException.class)
@@ -27,9 +34,23 @@ public class DocumentPipelineControllerAdvice {
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new ApiError(ex.getMessage()));
   }
 
+  /** Low-level I/O to Chroma (timeouts, connection refused); message often lacks detail without wrapping. */
+  @ExceptionHandler(ResourceAccessException.class)
+  public ResponseEntity<ApiError> resourceAccess(ResourceAccessException ex) {
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body(new ApiError(ChromaClientDiagnostics.describeChromaFailure(ex, chromaClientBaseUrl())));
+  }
+
   /** Network or HTTP errors when calling the Chroma REST API from the admin pipeline. */
   @ExceptionHandler(RestClientException.class)
   public ResponseEntity<ApiError> restClient(RestClientException ex) {
-    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new ApiError(ex.getMessage()));
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body(new ApiError(ChromaClientDiagnostics.apiErrorBodyMessage(ex, chromaClientBaseUrl())));
+  }
+
+  private String chromaClientBaseUrl() {
+    String host = environment.getProperty("spring.ai.vectorstore.chroma.client.host", "");
+    int port = environment.getProperty("spring.ai.vectorstore.chroma.client.port", Integer.class, 8100);
+    return ChromaClientDiagnostics.baseUrl(host, port);
   }
 }

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/DocumentIngestionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/DocumentIngestionService.java
@@ -3,6 +3,7 @@ package com.kevinmazali.portfolio.service;
 import com.kevinmazali.portfolio.config.PortfolioChromaProperties;
 import com.kevinmazali.portfolio.config.VectorStoreProperties;
 import com.kevinmazali.portfolio.exception.ChromaFeatureDisabledException;
+import com.kevinmazali.portfolio.util.ChromaClientDiagnostics;
 import com.kevinmazali.portfolio.model.ChromaCollectionSummary;
 import com.kevinmazali.portfolio.model.ChunkItem;
 import com.kevinmazali.portfolio.model.ChunkListResponse;
@@ -22,6 +23,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ByteArrayResource;
@@ -29,6 +31,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -67,6 +70,7 @@ public class DocumentIngestionService implements ApplicationRunner {
 
   private final VectorStore vectorStore;
   private final ObjectProvider<ChromaApi> chromaApiProvider;
+  private final Environment environment;
   private final ChromaVectorStoreProperties chromaStoreProperties;
   private final VectorStoreProperties vectorStoreProperties;
   private final PortfolioChromaProperties portfolioChromaProperties;
@@ -74,11 +78,13 @@ public class DocumentIngestionService implements ApplicationRunner {
   public DocumentIngestionService(
       @Lazy VectorStore vectorStore,
       ObjectProvider<ChromaApi> chromaApiProvider,
+      Environment environment,
       ChromaVectorStoreProperties chromaStoreProperties,
       VectorStoreProperties vectorStoreProperties,
       PortfolioChromaProperties portfolioChromaProperties) {
     this.vectorStore = vectorStore;
     this.chromaApiProvider = chromaApiProvider;
+    this.environment = environment;
     this.chromaStoreProperties = chromaStoreProperties;
     this.vectorStoreProperties = vectorStoreProperties;
     this.portfolioChromaProperties = portfolioChromaProperties;
@@ -92,8 +98,10 @@ public class DocumentIngestionService implements ApplicationRunner {
     }
     ChromaApi api = chromaApiProvider.getIfAvailable();
     if (api == null) {
+      String chromaUrl = chromaClientBaseUrl();
       throw new IllegalStateException(
-          "ChromaApi bean is missing while portfolio.chroma.enabled=true; check Chroma autoconfiguration.");
+          "ChromaApi bean is missing while portfolio.chroma.enabled=true; check Chroma autoconfiguration. "
+              + "Configured Chroma client URL (host:port): " + chromaUrl);
     }
     return api;
   }
@@ -625,15 +633,27 @@ public class DocumentIngestionService implements ApplicationRunner {
     return resp != null && resp.ids() != null && !resp.ids().isEmpty();
   }
 
+  private String chromaClientBaseUrl() {
+    String host = environment.getProperty("spring.ai.vectorstore.chroma.client.host", "");
+    int port = environment.getProperty("spring.ai.vectorstore.chroma.client.port", Integer.class, 8100);
+    return ChromaClientDiagnostics.baseUrl(host, port);
+  }
+
   private String requireCollectionId() {
-    ChromaApi.Collection col = chromaApi().getCollection(
-        chromaStoreProperties.getTenantName(),
-        chromaStoreProperties.getDatabaseName(),
-        chromaStoreProperties.getCollectionName());
-    if (col == null) {
-      throw new IllegalStateException("Chroma collection not found: " + chromaStoreProperties.getCollectionName());
+    String base = chromaClientBaseUrl();
+    try {
+      ChromaApi.Collection col = chromaApi().getCollection(
+          chromaStoreProperties.getTenantName(),
+          chromaStoreProperties.getDatabaseName(),
+          chromaStoreProperties.getCollectionName());
+      if (col == null) {
+        throw new IllegalStateException("Chroma collection not found: " + chromaStoreProperties.getCollectionName()
+            + " (Chroma URL: " + base + ")");
+      }
+      return col.id();
+    } catch (RestClientException e) {
+      throw new IllegalStateException(ChromaClientDiagnostics.describeChromaFailure(e, base), e);
     }
-    return col.id();
   }
 
   private List<Resource> resolveClasspathResources() throws IOException {

--- a/backend/src/main/java/com/kevinmazali/portfolio/util/ChromaClientDiagnostics.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/util/ChromaClientDiagnostics.java
@@ -1,0 +1,80 @@
+package com.kevinmazali.portfolio.util;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Builds the Chroma HTTP client base URL and human-readable errors when the REST client fails with
+ * empty or generic messages (common for {@link java.net.ConnectException} on Railway private networking).
+ */
+public final class ChromaClientDiagnostics {
+
+  private ChromaClientDiagnostics() {
+  }
+
+  /** Same format as {@code ChromaApi} base URL: {@code host:port}. */
+  public static String baseUrl(@Nullable String host, int port) {
+    if (!StringUtils.hasText(host)) {
+      return "<unset-host>:" + port;
+    }
+    return host + ":" + port;
+  }
+
+  /**
+   * Message for health checks and wrapped service exceptions when Chroma cannot be reached.
+   */
+  public static String describeChromaFailure(Throwable throwable, String chromaBaseUrl) {
+    String detail = summarizeThrowable(throwable);
+    return "Cannot reach Chroma at " + chromaBaseUrl + ". " + detail + railwayPrivateNetworkingHint();
+  }
+
+  /**
+   * Body text for {@link RestClientException} on admin routes: avoid raw {@code "...": null} from Spring's
+   * RestClient and add an ops hint.
+   */
+  public static String apiErrorBodyMessage(RestClientException ex, String chromaBaseUrl) {
+    String raw = ex.getMessage();
+    if (!StringUtils.hasText(raw) || raw.endsWith(": null")) {
+      return describeChromaFailure(ex, chromaBaseUrl);
+    }
+    return raw + railwayPrivateNetworkingHint();
+  }
+
+  /**
+   * For {@code /health/chroma}: keep normal exception messages; only enrich Chroma client / I/O style failures.
+   */
+  public static String healthFailureMessage(Throwable e, String chromaBaseUrl) {
+    if (e instanceof RestClientException rce) {
+      return apiErrorBodyMessage(rce, chromaBaseUrl);
+    }
+    String raw = e.getMessage();
+    if (!StringUtils.hasText(raw) || raw.endsWith(": null")) {
+      return describeChromaFailure(e, chromaBaseUrl);
+    }
+    return raw;
+  }
+
+  private static String railwayPrivateNetworkingHint() {
+    return " Hint: on Railway private networking, bind Chroma to IPv6 (e.g. CHROMA_HOST_ADDR=::) or set CHROMA_ENABLED=false if Chroma is not deployed.";
+  }
+
+  private static String summarizeThrowable(Throwable throwable) {
+    if (throwable == null) {
+      return "Unknown error.";
+    }
+    if (StringUtils.hasText(throwable.getMessage())) {
+      return throwable.getMessage();
+    }
+    Throwable cursor = throwable.getCause();
+    int depth = 0;
+    while (cursor != null && depth++ < 8) {
+      if (StringUtils.hasText(cursor.getMessage())) {
+        return cursor.getClass().getSimpleName() + ": " + cursor.getMessage();
+      }
+      cursor = cursor.getCause();
+    }
+    return throwable.getClass().getSimpleName()
+        + " (no detail message — often connection refused, timeout, or DNS failure).";
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/ChromaHealthControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/ChromaHealthControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chroma.vectorstore.ChromaApi;
 import org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreProperties;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -31,7 +30,7 @@ class ChromaHealthControllerTest {
 	private MockMvc mockMvc;
 
 	@MockBean
-	private ObjectProvider<ChromaApi> chromaApiProvider;
+	private ChromaApi chromaApi;
 
 	@MockBean
 	private ChromaVectorStoreProperties chromaStoreProperties;
@@ -39,12 +38,8 @@ class ChromaHealthControllerTest {
 	@MockBean
 	private PortfolioChromaProperties portfolioChromaProperties;
 
-	private ChromaApi chromaApi;
-
 	@BeforeEach
 	void wireChromaApi() {
-		chromaApi = mock(ChromaApi.class);
-		when(chromaApiProvider.getIfAvailable()).thenReturn(chromaApi);
 		when(portfolioChromaProperties.isEnabled()).thenReturn(true);
 	}
 

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerTest.java
@@ -37,7 +37,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = DocumentPipelineController.class)
+@WebMvcTest(controllers = DocumentPipelineController.class, properties = {
+		"spring.ai.vectorstore.chroma.client.host=http://localhost",
+		"spring.ai.vectorstore.chroma.client.port=8100"
+})
 @Import({ SecurityConfig.class, MvcTestUserDetailsConfig.class, DocumentPipelineControllerAdvice.class })
 class DocumentPipelineControllerTest {
 
@@ -111,7 +114,8 @@ class DocumentPipelineControllerTest {
 
 		mockMvc.perform(get("/admin/tools/documents"))
 			.andExpect(status().isServiceUnavailable())
-			.andExpect(jsonPath("$.error").value("Connection refused"));
+			.andExpect(jsonPath("$.error").value(containsString("Connection refused")))
+			.andExpect(jsonPath("$.error").value(containsString("http://localhost:8100")));
 	}
 
 	@Test

--- a/backend/src/test/java/com/kevinmazali/portfolio/util/ChromaClientDiagnosticsTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/util/ChromaClientDiagnosticsTest.java
@@ -1,0 +1,32 @@
+package com.kevinmazali.portfolio.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChromaClientDiagnosticsTest {
+
+  @Test
+  void baseUrlJoinsHostAndPort() {
+    assertThat(ChromaClientDiagnostics.baseUrl("http://chroma.internal", 8000))
+        .isEqualTo("http://chroma.internal:8000");
+  }
+
+  @Test
+  void apiErrorBodyMessageReplacesIoErrorEndingWithNull() {
+    String raw = "I/O error on GET request for \"http://host:8000/api/v2/foo\": null";
+    var ex = new ResourceAccessException(raw);
+    String body = ChromaClientDiagnostics.apiErrorBodyMessage(ex, "http://host:8000");
+    assertThat(body)
+        .startsWith("Cannot reach Chroma at http://host:8000")
+        .contains("Hint:")
+        .doesNotEndWith(": null");
+  }
+
+  @Test
+  void healthFailureMessageKeepsRuntimeExceptionWithMessage() {
+    var ex = new RuntimeException("boom");
+    assertThat(ChromaClientDiagnostics.healthFailureMessage(ex, "http://x:1")).isEqualTo("boom");
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       timeout: 5s
       retries: 20
 
+  # Chroma listens on 8000 in-container; host maps 8100 for local dev.
+  # Railway private networking is often IPv6-only: if the backend cannot connect to Chroma over
+  # *.railway.internal, set CHROMA_HOST_ADDR=:: (or equivalent) on the Chroma service so uvicorn binds IPv6.
   chromadb:
     image: chromadb/chroma:1.0.13
     container_name: aboutme-chromadb


### PR DESCRIPTION
- Add ChromaClientDiagnostics for base URL and human-readable I/O messages
- ChromaHealthController, DocumentPipelineControllerAdvice, DocumentIngestionService use Environment for client URL (slice tests friendly)
- Wrap requireCollectionId RestClient failures with actionable hints
- Separate ResourceAccessException handler in document pipeline advice
- ConfigLogging logs resolved Chroma host:port
- docker-compose and .env.example: Railway IPv6 / CHROMA_ENABLED / CHROMA_HOST_ADDR
- Fix ChromaHealthControllerTest: @MockBean ChromaApi instead of mocking ObjectProvider