### PR TITLE
Improve frontend coverage above minimum gates

### DIFF
--- a/frontend/homepage/cypress/e2e/example.cy.ts
+++ b/frontend/homepage/cypress/e2e/example.cy.ts
@@ -1,10 +1,28 @@
 // https://on.cypress.io/api
 
-describe('Home page', () => {
-  it('loads without blocking tutorial modal', () => {
+describe('Core frontend flows', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/**', {
+      statusCode: 200,
+      body: [],
+    }).as('apiGet')
+  })
+
+  it('loads the home page and shows hero content', () => {
     cy.visit('/')
     cy.get('h1').should('contain.text', 'Kevin')
-    cy.get('[data-slot="dialog-content"]').should('not.exist')
-    cy.get('[role="alert"]').should('exist')
+    cy.contains('button, a', /chat with Kevin|go to chat/i).should('exist')
+  })
+
+  it('opens and uses chat flow entry points', () => {
+    cy.visit('/chat')
+    cy.get('h1').should('contain.text', 'Chat with Kevin')
+    cy.get('textarea, input').first().should('exist')
+  })
+
+  it('redirects unauthenticated user away from admin area', () => {
+    cy.visit('/admin', { failOnStatusCode: false })
+    cy.url().should('include', '/chat')
+    cy.contains(/admin|internal tools/i).should('not.exist')
   })
 })

--- a/frontend/homepage/src/composables/__tests__/useConsent.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useConsent.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useConsent } from '../useConsent'
+
+describe('useConsent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  function mountHarness() {
+    return mount(
+      defineComponent({
+        setup() {
+          const state = useConsent()
+          return () => h('div', JSON.stringify(state.consent.value))
+        },
+      }),
+    )
+  }
+
+  it('uses safe default consent before any storage value exists', async () => {
+    const wrapper = mountHarness()
+    await nextTick()
+    expect(wrapper.text()).toContain('"analytics":false')
+    expect(wrapper.text()).toContain('"marketing":false')
+    expect(wrapper.text()).toContain('"necessary":true')
+  })
+
+  it('reads consent from localStorage on mount', async () => {
+    localStorage.setItem('csfy_consent', JSON.stringify({ analytics: true, marketing: true }))
+    const wrapper = mountHarness()
+    await nextTick()
+    expect(wrapper.text()).toContain('"analytics":true')
+    expect(wrapper.text()).toContain('"marketing":true')
+    expect(wrapper.text()).toContain('"necessary":true')
+  })
+
+  it('coerces non-boolean values to booleans when reading storage', async () => {
+    localStorage.setItem('csfy_consent', JSON.stringify({ analytics: 'yes', marketing: 0 }))
+    const wrapper = mountHarness()
+    await nextTick()
+    expect(wrapper.text()).toContain('"analytics":true')
+    expect(wrapper.text()).toContain('"marketing":false')
+  })
+
+  it('keeps defaults when storage payload is invalid JSON', async () => {
+    localStorage.setItem('csfy_consent', '{bad json')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mountHarness()
+    await nextTick()
+    expect(wrapper.text()).toContain('"analytics":false')
+    expect(wrapper.text()).toContain('"marketing":false')
+    expect(wrapper.text()).toContain('"necessary":true')
+    consoleSpy.mockRestore()
+  })
+})

--- a/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
+++ b/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
@@ -55,4 +55,39 @@ describe('application router (index)', () => {
 		expect(router.currentRoute.value.path).toBe('/career')
 		expect(router.currentRoute.value.name).toBe('career')
 	})
+
+	it('navigates to additional lazy-loaded public routes', async () => {
+		const router = createPortfolioRouter({ useMemoryHistory: true })
+		await router.push('/projects')
+		expect(router.currentRoute.value.name).toBe('projects')
+
+		await router.push('/career')
+		expect(router.currentRoute.value.name).toBe('career')
+
+		await router.push('/feedback')
+		expect(router.currentRoute.value.name).toBe('feedback')
+	})
+
+	it('allows admin routes when ADMIN session is restored', async () => {
+		sessionStorage.setItem(
+			'auth',
+			JSON.stringify({ username: 'admin', role: 'ADMIN', basicToken: 'dGVzdDp0ZXN0' }),
+		)
+		const router = createPortfolioRouter({ useMemoryHistory: true })
+
+		await router.push('/admin/tools')
+		expect(router.currentRoute.value.name).toBe('admin-tools')
+
+		await router.push('/admin/pipeline')
+		expect(router.currentRoute.value.name).toBe('admin-pipeline')
+
+		await router.push('/admin/chunks')
+		expect(router.currentRoute.value.name).toBe('admin-chunks')
+
+		await router.push('/admin/prompts')
+		expect(router.currentRoute.value.name).toBe('admin-prompts')
+
+		await router.push('/admin/experiments')
+		expect(router.currentRoute.value.name).toBe('admin-experiments')
+	})
 })

--- a/frontend/homepage/src/views/__tests__/ChatView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/ChatView.spec.ts
@@ -24,6 +24,7 @@ describe('ChatView', () => {
       history: createMemoryHistory(),
       routes: [
         { path: '/', name: 'home', component: HomeStub },
+        { path: '/bachelor', name: 'bachelor', component: HomeStub },
         { path: '/chat', name: 'chat', component: ChatView },
       ],
     })

--- a/frontend/homepage/src/views/__tests__/portfolioViews.spec.ts
+++ b/frontend/homepage/src/views/__tests__/portfolioViews.spec.ts
@@ -9,6 +9,7 @@ import PrivacyPolicyView from '../PrivacyPolicyView.vue'
 import { useLangStore } from '@/stores/lang'
 import ProjectsView from '../ProjectsView.vue'
 import CareerView from '../CareerView.vue'
+import FutureWorkView from '../FutureWorkView.vue'
 
 describe('portfolio views (smoke)', () => {
 	function mountView(component: Component) {
@@ -76,4 +77,37 @@ describe('portfolio views (smoke)', () => {
 		expect(wrapper.text()).toContain('Education')
 		expect(wrapper.text()).toMatch(/Courses|Emner/)
 	})
+
+  it('renders CareerView in Norwegian with translated section labels', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+    const wrapper = mount(CareerView, { global: { plugins: [pinia, MotionPlugin] } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Erfaring og utdanning')
+    expect(wrapper.text()).toContain('Arbeidserfaring')
+    expect(wrapper.text()).toContain('Utdanning')
+    expect(wrapper.text()).toContain('Emner')
+    expect(wrapper.text()).toMatch(/studiepoeng|Karakter/)
+  })
+
+  it('renders FutureWorkView in English with references', async () => {
+    const wrapper = mountView(FutureWorkView)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Future work and improvements')
+    expect(wrapper.text()).toContain('References (arXiv)')
+    const links = wrapper.findAll('a[href^="https://arxiv.org/abs/"]')
+    expect(links.length).toBeGreaterThan(0)
+  })
+
+  it('renders FutureWorkView in Norwegian with translated copy', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+    const wrapper = mount(FutureWorkView, { global: { plugins: [pinia, MotionPlugin] } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Videre arbeid og forbedringer')
+    expect(wrapper.text()).toContain('Referanser (arXiv)')
+    expect(wrapper.text()).toContain('Lokal modell og Obsidian-journal')
+  })
 })

--- a/frontend/homepage/vitest.config.ts
+++ b/frontend/homepage/vitest.config.ts
@@ -37,10 +37,10 @@ export default mergeConfig(
         ],
         // Line/function gates match product code; global branch % stays lower on template-heavy Vue (many ternaries).
         thresholds: {
-          lines: 80,
-          statements: 80,
-          branches: 73,
-          functions: 80,
+          lines: 85,
+          statements: 85,
+          branches: 76,
+          functions: 84,
         },
       },
     },


### PR DESCRIPTION
## Summary
- add new Vitest coverage for router/view branches and useConsent localStorage parsing behavior
- replace Cypress example with targeted core-flow checks (home, chat entry, admin redirect)
- raise frontend Vitest coverage thresholds to enforce a stronger CI safety margin

## Test plan
- [x] npm run type-check
- [x] npm run lint:ci
- [x] npm run test:unit:coverage
- [ ] npm run test:e2e (fails in this environment due to missing powershell.exe/wmic.exe for Cypress runtime)