### PR TITLE
Improve frontend coverage quick wins

### DIFF
--- a/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
+++ b/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
 import CookieConsentBanner from '../CookieConsentBanner.vue'
 import { useLangStore } from '@/stores/lang'
 import posthog from 'posthog-js'
@@ -20,24 +21,26 @@ describe('CookieConsentBanner', () => {
     setActivePinia(createPinia())
   })
 
-  it('shows banner when explicit consent is pending', () => {
+  it('shows banner when explicit consent is pending', async () => {
     vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('pending')
 
     const wrapper = mount(CookieConsentBanner, {
       global: { plugins: [createPinia()] },
     })
+    await nextTick()
 
     expect(wrapper.text()).toContain('Cookies and analytics')
     expect(wrapper.text()).toContain('Accept')
     expect(wrapper.text()).toContain('Decline')
   })
 
-  it('hides banner when consent is not pending', () => {
+  it('hides banner when consent is not pending', async () => {
     vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('granted')
 
     const wrapper = mount(CookieConsentBanner, {
       global: { plugins: [createPinia()] },
     })
+    await nextTick()
 
     expect(wrapper.text()).toBe('')
   })
@@ -48,6 +51,7 @@ describe('CookieConsentBanner', () => {
     const wrapper = mount(CookieConsentBanner, {
       global: { plugins: [createPinia()] },
     })
+    await nextTick()
 
     await wrapper.get('button').trigger('click')
     expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1)
@@ -60,6 +64,7 @@ describe('CookieConsentBanner', () => {
     const wrapper = mount(CookieConsentBanner, {
       global: { plugins: [createPinia()] },
     })
+    await nextTick()
 
     await wrapper.findAll('button')[1].trigger('click')
     expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
@@ -83,7 +88,7 @@ describe('CookieConsentBanner', () => {
     expect(wrapper.text()).toContain('Cookies and analytics')
   })
 
-  it('renders norwegian text when language is no', () => {
+  it('renders norwegian text when language is no', async () => {
     vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('pending')
     const pinia = createPinia()
     setActivePinia(pinia)
@@ -92,6 +97,7 @@ describe('CookieConsentBanner', () => {
     const wrapper = mount(CookieConsentBanner, {
       global: { plugins: [pinia] },
     })
+    await nextTick()
 
     expect(wrapper.text()).toContain('Informasjonskapsler og analyse')
     expect(wrapper.text()).toContain('Godta')

--- a/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
+++ b/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CookieConsentBanner from '../CookieConsentBanner.vue'
+import { useLangStore } from '@/stores/lang'
+import posthog from 'posthog-js'
+
+vi.mock('posthog-js', () => ({
+  default: {
+    get_explicit_consent_status: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+    clear_opt_in_out_capturing: vi.fn(),
+  },
+}))
+
+describe('CookieConsentBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+
+  it('shows banner when explicit consent is pending', () => {
+    vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('pending')
+
+    const wrapper = mount(CookieConsentBanner, {
+      global: { plugins: [createPinia()] },
+    })
+
+    expect(wrapper.text()).toContain('Cookies and analytics')
+    expect(wrapper.text()).toContain('Accept')
+    expect(wrapper.text()).toContain('Decline')
+  })
+
+  it('hides banner when consent is not pending', () => {
+    vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('granted')
+
+    const wrapper = mount(CookieConsentBanner, {
+      global: { plugins: [createPinia()] },
+    })
+
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('accept button opts in capturing and hides banner', async () => {
+    vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('pending')
+
+    const wrapper = mount(CookieConsentBanner, {
+      global: { plugins: [createPinia()] },
+    })
+
+    await wrapper.get('button').trigger('click')
+    expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('decline button opts out capturing and hides banner', async () => {
+    vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('pending')
+
+    const wrapper = mount(CookieConsentBanner, {
+      global: { plugins: [createPinia()] },
+    })
+
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('openConsentSettings clears status and refreshes banner visibility', async () => {
+    vi.mocked(posthog.get_explicit_consent_status)
+      .mockReturnValueOnce('granted')
+      .mockReturnValueOnce('pending')
+
+    const wrapper = mount(CookieConsentBanner, {
+      global: { plugins: [createPinia()] },
+    })
+
+    expect(wrapper.text()).toBe('')
+    ;(wrapper.vm as { openConsentSettings: () => void }).openConsentSettings()
+    await wrapper.vm.$nextTick()
+
+    expect(posthog.clear_opt_in_out_capturing).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('Cookies and analytics')
+  })
+
+  it('renders norwegian text when language is no', () => {
+    vi.mocked(posthog.get_explicit_consent_status).mockReturnValue('pending')
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+
+    const wrapper = mount(CookieConsentBanner, {
+      global: { plugins: [pinia] },
+    })
+
+    expect(wrapper.text()).toContain('Informasjonskapsler og analyse')
+    expect(wrapper.text()).toContain('Godta')
+    expect(wrapper.text()).toContain('Avslå')
+  })
+})

--- a/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
+++ b/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
@@ -90,4 +90,10 @@ describe('application router (index)', () => {
 		await router.push('/admin/experiments')
 		expect(router.currentRoute.value.name).toBe('admin-experiments')
 	})
+
+	it('creates a router with default web-history option path', () => {
+		const router = createPortfolioRouter()
+		expect(router).toBeTruthy()
+		expect(router.currentRoute.value.path).toBe('/')
+	})
 })

--- a/frontend/homepage/src/utils/__tests__/cloudinary.spec.ts
+++ b/frontend/homepage/src/utils/__tests__/cloudinary.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('cloudinary helpers', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns empty string when cloud name is missing', async () => {
+    vi.stubEnv('VITE_CLOUDINARY_CLOUD_NAME', '')
+    const { buildCloudinaryImageUrl } = await import('../cloudinary')
+
+    expect(buildCloudinaryImageUrl('sample')).toBe('')
+  })
+
+  it('returns empty string when publicId is missing', async () => {
+    vi.stubEnv('VITE_CLOUDINARY_CLOUD_NAME', 'demo')
+    const { buildCloudinaryImageUrl } = await import('../cloudinary')
+
+    expect(buildCloudinaryImageUrl('')).toBe('')
+  })
+
+  it('uses default transforms for image url generation', async () => {
+    vi.stubEnv('VITE_CLOUDINARY_CLOUD_NAME', 'demo')
+    const { buildCloudinaryImageUrl } = await import('../cloudinary')
+
+    expect(buildCloudinaryImageUrl('portfolio/avatar')).toBe(
+      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto/portfolio/avatar',
+    )
+  })
+
+  it('returns empty srcset when widths list is empty', async () => {
+    vi.stubEnv('VITE_CLOUDINARY_CLOUD_NAME', 'demo')
+    const { buildCloudinarySrcSet } = await import('../cloudinary')
+
+    expect(buildCloudinarySrcSet('portfolio/avatar', [])).toBe('')
+  })
+
+  it('builds srcset entries with extra transforms and width tokens', async () => {
+    vi.stubEnv('VITE_CLOUDINARY_CLOUD_NAME', 'demo')
+    const { buildCloudinarySrcSet } = await import('../cloudinary')
+
+    expect(buildCloudinarySrcSet('portfolio/avatar', [320, 640], ['c_fill', 'g_auto'])).toBe(
+      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto,c_fill,g_auto,w_320/portfolio/avatar 320w, ' +
+        'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto,c_fill,g_auto,w_640/portfolio/avatar 640w',
+    )
+  })
+})

--- a/frontend/homepage/src/views/__tests__/ChatView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/ChatView.spec.ts
@@ -126,7 +126,7 @@ describe('ChatView', () => {
 
     const clearBtn = wrapper
       .findAll('button')
-      .find((b) => b.text().includes('Clear Chat'))
+      .find((b) => /clear chat/i.test(b.text()))
     expect(clearBtn).toBeDefined()
     await clearBtn!.trigger('click')
 

--- a/frontend/homepage/src/views/__tests__/MessagesArea.spec.ts
+++ b/frontend/homepage/src/views/__tests__/MessagesArea.spec.ts
@@ -9,6 +9,10 @@ describe('MessagesArea', () => {
       props: ['text'],
       template: '<span class="typewriter-stub">{{ text }}</span>',
     },
+    SafeMarkdown: {
+      props: ['source'],
+      template: '<div class="safe-markdown-stub">{{ source }}</div>',
+    },
     Brain: { template: '<span class="icon-brain" />' },
     UserRound: { template: '<span class="icon-user" />' },
     MessageSquare: { template: '<span class="icon-msq" />' },
@@ -71,6 +75,18 @@ describe('MessagesArea', () => {
     expect(wrapper.find('.typewriter-stub').text()).toBe('Typed')
   })
 
+  it('falls back to markdown renderer for new assistant message in read-only mode', () => {
+    const wrapper = mount(MessagesArea, {
+      props: {
+        messages: [{ role: 'assistant', text: 'Read only text', isNew: true }],
+        isReadOnly: true,
+      },
+      global: { stubs: globalStubs },
+    })
+    expect(wrapper.find('.typewriter-stub').exists()).toBe(false)
+    expect(wrapper.find('.safe-markdown-stub').text()).toBe('Read only text')
+  })
+
   it('applies read-only border class on message container', () => {
     const wrapper = mount(MessagesArea, {
       props: {
@@ -79,7 +95,7 @@ describe('MessagesArea', () => {
       },
       global: { stubs: globalStubs },
     })
-    const box = wrapper.find('.border-gray-200\\/20')
+    const box = wrapper.find('.border-gray-200\\/50')
     expect(box.exists()).toBe(true)
   })
 


### PR DESCRIPTION
## Summary
- add focused tests for Cloudinary URL helpers and cookie consent behavior
- tighten MessagesArea and router branch coverage with additional edge-case assertions
- include recent frontend polish changes already present on the branch

## Test plan
- [x] Run unit tests locally for touched suites
- [x] Run coverage suite and verify thresholds pass