### PR TITLE
Fix CI: Mockito unnecessary stubbing in backend tests

### DIFF
--- a/backend/src/test/java/com/kevinmazali/portfolio/service/AiBudgetServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/AiBudgetServiceTest.java
@@ -45,7 +45,6 @@ class AiBudgetServiceTest {
     pricing.setInputPerMillionUsd(new BigDecimal("1"));
     pricing.setOutputPerMillionUsd(new BigDecimal("2"));
     properties.getModels().put("gpt-5.4-mini", pricing);
-    when(postHogLlmService.isEnabled()).thenReturn(false);
     service = new AiBudgetService(properties, usageRepository, new SimpleMeterRegistry(), null, postHogLlmService);
   }
 
@@ -63,6 +62,7 @@ class AiBudgetServiceTest {
 
   @Test
   void recordUsagePersistsRow() {
+    when(postHogLlmService.isEnabled()).thenReturn(false);
     service.recordUsage("user:a", "gpt-5.4-mini", 1000, 500, false);
     verify(usageRepository).save(any());
   }

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/ExperimentServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/ExperimentServiceTest.java
@@ -312,8 +312,6 @@ class ExperimentServiceTest {
   @Test
   void startRunRejectsSameProviderModels() {
     when(phoenixDatasetService.isEnabled()).thenReturn(true);
-    when(phoenixDatasetService.getExamples("ds-1")).thenReturn(
-        List.of(new PhoenixDatasetExample("What?", "Ref", null, null)));
     when(chatModelCatalog.isModelConfigured(SupportedChatModel.GPT_5_4_MINI)).thenReturn(true);
     when(chatModelCatalog.isModelConfigured(SupportedChatModel.GPT_5_4)).thenReturn(true);
 


### PR DESCRIPTION
Fixes failing GitHub Actions **Tests** workflow (backend \./mvnw verify\) after merge of PR #89.

**Failure:** [Tests run 24800335413](https://github.com/kdm-kev-NTNU/AboutMe/actions/runs/24800335413) — four \UnnecessaryStubbingException\ errors from Mockito strict stubbing.

**Changes (tests only):**
- \AiBudgetServiceTest\: moved \when(postHogLlmService.isEnabled()).thenReturn(false)\ from \@BeforeEach\ into \ecordUsagePersistsRow\ only, since \ssertWithinBudget*\ and \systemUserSkipsBudgetCheck\ never touch PostHog.
- \ExperimentServiceTest.startRunRejectsSameProviderModels\: removed unused \getExamples\ stub; \ExperimentService.startRun\ throws on same-provider before \getExamples\ is called.

Verified with \./mvnw -B verify\ in a JDK 21 container locally.