### PR TITLE
fix: isolate dompurify chunk to prevent production crash (TypeError: e is not a function)

### DIFF
--- a/frontend/homepage/vite.config.ts
+++ b/frontend/homepage/vite.config.ts
@@ -15,6 +15,17 @@ export default defineConfig({
     // DevTools breaks Vitest server bootstrap (configureServer rpc); keep for `vite dev` only.
     ...(process.env.VITEST ? [] : [vueDevTools()]),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules/dompurify')) {
+            return 'dompurify'
+          }
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The production build crashes on load with a blank white page:

```
pinia-omeZmEF3.js:3 Uncaught TypeError: e is not a function
```

## Root Cause

Vite 8's bundler (Rolldown) concatenates `@vueuse/motion`'s re-export helper and DOMPurify into the same chunk. During minification, both modules use the same variable name (`ke`):

1. `@vueuse/motion` assigns `ke` as a **function** (module namespace re-export helper)
2. DOMPurify later reassigns `ke` to a **frozen attribute set** (`ALLOWED_ATTR`)

The chunk's export statement maps `ke` to the symbol `S`. The Vue runtime chunk imports `S` expecting a callable function, but gets the frozen set instead — causing the crash.

## Fix

Added `manualChunks` in `vite.config.ts` to isolate DOMPurify into its own chunk, eliminating the variable name collision.

## About `share-modal.js` error

The second reported error (`Cannot read properties of null (reading 'addEventListener')` from `share-modal.js`) is **not from this codebase** — no share-modal code exists in the repo. This is from a browser extension.

## Testing

[hotfix_pinia_error_resolved.mp4](https://cursor.com/agents/bc-0504d044-afef-44c0-adcb-d2fae405e262/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhotfix_pinia_error_resolved.mp4)
App loads and navigates correctly after the fix — previously showed a blank white page.

[App rendering correctly after fix](https://cursor.com/agents/bc-0504d044-afef-44c0-adcb-d2fae405e262/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_working_after_fix.webp)
[Console showing zero JS errors](https://cursor.com/agents/bc-0504d044-afef-44c0-adcb-d2fae405e262/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_no_errors.webp)

- All 174 unit tests pass
- Type check passes
- ESLint passes
- Manual browser testing confirms no console errors

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0504d044-afef-44c0-adcb-d2fae405e262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0504d044-afef-44c0-adcb-d2fae405e262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

