### PR TITLE
chore(ci): combine Dependabot backend parent + tokenizers bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
     directory: "/backend"
     schedule:
       interval: "weekly"
+    groups:
+      # Keep parent BOM + native tokenizer bumps in one PR (fewer merge/rebase churn).
+      backend-platform-and-ml:
+        patterns:
+          - "org.springframework.boot:spring-boot-starter-parent"
+          - "ai.djl.huggingface:tokenizers"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

- **Dependabot**: groups `org.springframework.boot:spring-boot-starter-parent` and `ai.djl.huggingface:tokenizers` for `/backend` so future bumps land in **one** weekly PR instead of two parallel ones.

## Context (replaces Dependabot PR #113 + #114)

Those two PRs targeted the same `backend/pom.xml` changes that are **already on `main`** from the Spring Boot 4 migration (**PR #121**): Spring Boot **4.0.6** and DJL Hugging Face tokenizers **0.36.0**. Merging #113 or #114 now would **downgrade** the repo (e.g. Boot 3.5.x / tokenizers 0.31.1 and older Spring AI / springdoc pins from the Dependabot branches).

**Please close #113 and #114** in favor of this PR (or merge this and close them as superseded).

## Verification

- `./mvnw test` in `backend/` passed on the pre-push `main` revision (same `pom.xml` as this branch touches only Dependabot config).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7f8251-8167-4905-9e15-72da9bbffd92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7f8251-8167-4905-9e15-72da9bbffd92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

