### PR TITLE
feat(analytics): PostHog session recording + consent copy

### DIFF
--- a/frontend/homepage/src/components/CookieConsentBanner.vue
+++ b/frontend/homepage/src/components/CookieConsentBanner.vue
@@ -20,8 +20,8 @@ const bannerTitle = computed(() =>
 )
 const bannerBody = computed(() =>
   isNo.value
-    ? 'Jeg bruker PostHog for å forstå hvordan nettsiden brukes. Du kan velge nødvendige, akseptere alle eller avvise valgfri analyse.'
-    : 'I use PostHog to understand how the site is used. You can allow necessary only, accept all, or reject optional analytics.',
+    ? 'Jeg bruker PostHog for å forstå hvordan nettsiden brukes, inkludert anonymisert opptak av sesjoner. Du kan velge nødvendige, akseptere alle eller avvise valgfri analyse.'
+    : 'I use PostHog to understand how the site is used, including anonymized session recordings. You can allow necessary only, accept all, or reject optional analytics.',
 )
 const acceptAllLabel = computed(() => (isNo.value ? 'Godta alle' : 'Accept all'))
 const necessaryOnlyLabel = computed(() =>

--- a/frontend/homepage/src/components/CookieConsentSettingsModal.vue
+++ b/frontend/homepage/src/components/CookieConsentSettingsModal.vue
@@ -42,8 +42,8 @@ const analyticsLabel = computed(() =>
 )
 const analyticsHelp = computed(() =>
   langStore.language === 'no'
-    ? `Hjelper oss å forstå bruk av siden (aggregert). Behandles etter personvernerklæringen (versjon ${PRIVACY_POLICY_VERSION}).`
-    : `Helps us understand site usage in aggregate. Governed by the privacy policy (version ${PRIVACY_POLICY_VERSION}).`,
+    ? `Hjelper oss å forstå bruk av siden (aggregert), inkludert anonymiserte sesjonsopptak. Alle skjemafelt maskeres automatisk. Behandles etter personvernerklæringen (versjon ${PRIVACY_POLICY_VERSION}).`
+    : `Helps us understand site usage in aggregate, including anonymized session recordings. All form inputs are automatically masked. Governed by the privacy policy (version ${PRIVACY_POLICY_VERSION}).`,
 )
 const saveLabel = computed(() => (langStore.language === 'no' ? 'Lagre valg' : 'Save choices'))
 const cancelLabel = computed(() => (langStore.language === 'no' ? 'Avbryt' : 'Cancel'))

--- a/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
+++ b/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
+import { useLangStore } from '@/stores/lang'
 import CookieConsentBanner from '../CookieConsentBanner.vue'
 import {
   grantAllCookies,
@@ -51,6 +52,13 @@ describe('CookieConsentBanner', () => {
     const wrapper = mountBanner()
     await nextTick()
     expect(wrapper.find('[role="region"]').exists()).toBe(true)
+  })
+
+  it('mentions session recordings in English banner copy', async () => {
+    useLangStore().setLanguage('en')
+    const wrapper = mountBanner()
+    await nextTick()
+    expect(wrapper.text()).toContain('anonymized session recordings')
   })
 
   it('does not render when consent was previously recorded', async () => {

--- a/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
+++ b/frontend/homepage/src/components/__tests__/CookieConsentBanner.spec.ts
@@ -61,6 +61,13 @@ describe('CookieConsentBanner', () => {
     expect(wrapper.text()).toContain('anonymized session recordings')
   })
 
+  it('mentions session recordings in Norwegian banner copy', async () => {
+    useLangStore().setLanguage('no')
+    const wrapper = mountBanner()
+    await nextTick()
+    expect(wrapper.text()).toContain('anonymisert opptak av sesjoner')
+  })
+
   it('does not render when consent was previously recorded', async () => {
     vi.mocked(isCookieBannerDismissed).mockReturnValue(true)
     const wrapper = mountBanner()

--- a/frontend/homepage/src/lib/__tests__/posthog-consent.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/posthog-consent.spec.ts
@@ -7,6 +7,8 @@ vi.mock('posthog-js', () => ({
     opt_in_capturing: vi.fn(),
     opt_out_capturing: vi.fn(),
     reset: vi.fn(),
+    startSessionRecording: vi.fn(),
+    stopSessionRecording: vi.fn(),
     get_explicit_consent_status: vi.fn(() => undefined),
   },
 }))
@@ -79,6 +81,7 @@ describe('posthog-consent', () => {
 
     expect(initializePosthogSdk).toHaveBeenCalled()
     expect(posthog.opt_in_capturing).toHaveBeenCalled()
+    expect(posthog.startSessionRecording).toHaveBeenCalled()
     expect(handler).toHaveBeenCalled()
   })
 
@@ -97,6 +100,7 @@ describe('posthog-consent', () => {
 
     applyStoredTrackingConsent()
 
+    expect(posthog.stopSessionRecording).toHaveBeenCalled()
     expect(posthog.opt_out_capturing).toHaveBeenCalled()
     expect(posthog.reset).toHaveBeenCalled()
   })
@@ -111,6 +115,7 @@ describe('posthog-consent', () => {
     expect(record.source).toBe('banner_accept_all')
     expect(record.policyVersion).toBe(PRIVACY_POLICY_VERSION)
     expect(posthog.opt_in_capturing).toHaveBeenCalled()
+    expect(posthog.startSessionRecording).toHaveBeenCalled()
   })
 
   it('persists denied analytics on grantNecessaryCookiesOnly', () => {
@@ -127,6 +132,7 @@ describe('posthog-consent', () => {
     const record = JSON.parse(localStorageMock[COOKIE_CONSENT_RECORD_KEY])
     expect(record.analytics).toBe(false)
     expect(record.source).toBe('banner_reject')
+    expect(posthog.stopSessionRecording).toHaveBeenCalledTimes(1)
     expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
     expect(posthog.reset).toHaveBeenCalledTimes(1)
   })
@@ -139,6 +145,7 @@ describe('posthog-consent', () => {
     expect(hasAnalyticsConsent()).toBe(true)
     expect(isCookieBannerDismissed()).toBe(true)
     expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1)
+    expect(posthog.startSessionRecording).toHaveBeenCalledTimes(1)
     expect(handler).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/homepage/src/lib/__tests__/posthog-sdk.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/posthog-sdk.spec.ts
@@ -45,7 +45,11 @@ describe('posthog-sdk', () => {
       capture_pageview: false,
       autocapture: false,
       persistence: 'localStorage',
-      disable_session_recording: true,
+      disable_session_recording: false,
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: '[data-ph-mask]',
+      },
     })
     expect(isPosthogSdkInitialized()).toBe(true)
   })

--- a/frontend/homepage/src/lib/posthog-consent.ts
+++ b/frontend/homepage/src/lib/posthog-consent.ts
@@ -114,12 +114,22 @@ function activatePosthogAnalytics(): void {
   if (!env.enabled) return
   if (!initializePosthogSdk({ key: env.key, host: env.host })) return
   posthog.opt_in_capturing()
+  try {
+    posthog.startSessionRecording?.()
+  } catch {
+    // ignore if recorder unavailable
+  }
   activationHandler?.()
 }
 
 function deactivatePosthogAnalytics(): void {
   if (!isPosthogEnabled()) return
   if (!isPosthogSdkInitialized()) return
+  try {
+    posthog.stopSessionRecording?.()
+  } catch {
+    // ignore if recorder unavailable
+  }
   posthog.opt_out_capturing()
   posthog.reset()
 }

--- a/frontend/homepage/src/lib/posthog-sdk.ts
+++ b/frontend/homepage/src/lib/posthog-sdk.ts
@@ -46,7 +46,11 @@ export function initializePosthogSdk(config?: Partial<PosthogConfig>): boolean {
     capture_pageview: false,
     autocapture: false,
     persistence: 'localStorage',
-    disable_session_recording: true,
+    disable_session_recording: false,
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: '[data-ph-mask]',
+    },
   })
 
   sdkInitialized = true


### PR DESCRIPTION
Aktiverer session recording i posthog-js (maskering av inputs), start/stopp ved samtykke, og oppdatert cookie-tekst for GDPR-transparens.

**Endringer**
- \posthog-sdk.ts\: \disable_session_recording: false\, \session_recording\ med \maskAllInputs\ / \maskTextSelector\
- \posthog-consent.ts\: \startSessionRecording\ / \stopSessionRecording\ ved opt-in/out
- \posthog-sdk.spec.ts\: forventet init-config oppdatert
- \CookieConsentBanner.vue\ / \CookieConsentSettingsModal.vue\: tekst om sesjonsopptak
- \CookieConsentBanner.spec.ts\ + \posthog-consent.spec.ts\: tester oppdatert

PostHog-prosjekt: session replay er på; sample rate satt til 1.00 der det er relevant.