### PR TITLE
feat(chat): extend model catalog with tags and fast defaults

### DIFF
--- a/backend/src/main/java/com/kevinmazali/portfolio/model/ChatModelOption.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/ChatModelOption.java
@@ -1,7 +1,10 @@
 package com.kevinmazali.portfolio.model;
 
 import com.kevinmazali.portfolio.model.chat.ChatProvider;
+import com.kevinmazali.portfolio.model.chat.ModelTag;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Set;
 
 @Schema(description = "Selectable chat model for the RAG UI")
 public record ChatModelOption(
@@ -10,6 +13,8 @@ public record ChatModelOption(
     @Schema(description = "LLM vendor")
     ChatProvider provider,
     @Schema(description = "Human-readable label")
-    String label
+    String label,
+    @Schema(description = "Capability tags (e.g. FAST vs REASONING)")
+    Set<ModelTag> tags
 ) {
 }

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/chat/ModelTag.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/chat/ModelTag.java
@@ -1,0 +1,11 @@
+package com.kevinmazali.portfolio.model.chat;
+
+/**
+ * High-level capability / latency category for chat models exposed in the catalog.
+ */
+public enum ModelTag {
+  /** Lower-latency, cost-efficient models suitable as defaults. */
+  FAST,
+  /** Higher-capability models; may require authentication for anonymous public chat. */
+  REASONING
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/chat/SupportedChatModel.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/chat/SupportedChatModel.java
@@ -1,27 +1,35 @@
 package com.kevinmazali.portfolio.model.chat;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Allow-listed chat models exposed to clients. Unknown ids are rejected server-side.
  */
 public enum SupportedChatModel {
 
-  GPT_5_4_MINI("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini"),
-  GPT_5_4("gpt-5.4", ChatProvider.OPENAI, "GPT-5.4"),
+  GPT_5_4_NANO("gpt-5.4-nano", ChatProvider.OPENAI, "GPT-5.4 Nano", EnumSet.of(ModelTag.FAST)),
+  GPT_5_4_MINI("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini", EnumSet.of(ModelTag.FAST)),
+  GPT_5_4("gpt-5.4", ChatProvider.OPENAI, "GPT-5.4", EnumSet.of(ModelTag.REASONING)),
+  GPT_5_5("gpt-5.5", ChatProvider.OPENAI, "GPT-5.5", EnumSet.of(ModelTag.REASONING)),
 
-  CLAUDE_HAIKU_4_5("claude-haiku-4-5-20251001", ChatProvider.ANTHROPIC, "Claude Haiku 4.5"),
-  CLAUDE_SONNET_4_6("claude-sonnet-4-6", ChatProvider.ANTHROPIC, "Claude Sonnet 4.6");
+  CLAUDE_HAIKU_4_5("claude-haiku-4-5-20251001", ChatProvider.ANTHROPIC, "Claude Haiku 4.5", EnumSet.of(ModelTag.FAST)),
+  CLAUDE_SONNET_4_6("claude-sonnet-4-6", ChatProvider.ANTHROPIC, "Claude Sonnet 4.6", EnumSet.of(ModelTag.REASONING)),
+  CLAUDE_OPUS_4_7("claude-opus-4-7", ChatProvider.ANTHROPIC, "Claude Opus 4.7", EnumSet.of(ModelTag.REASONING));
 
   private final String modelId;
   private final ChatProvider provider;
   private final String label;
+  private final Set<ModelTag> tags;
 
-  SupportedChatModel(String modelId, ChatProvider provider, String label) {
+  SupportedChatModel(String modelId, ChatProvider provider, String label, Set<ModelTag> tags) {
     this.modelId = modelId;
     this.provider = provider;
     this.label = label;
+    this.tags = Collections.unmodifiableSet(tags);
   }
 
   public String modelId() {
@@ -36,6 +44,10 @@ public enum SupportedChatModel {
     return label;
   }
 
+  public Set<ModelTag> tags() {
+    return tags;
+  }
+
   public static Optional<SupportedChatModel> fromModelId(String id) {
     if (id == null || id.isBlank()) {
       return Optional.empty();
@@ -46,9 +58,9 @@ public enum SupportedChatModel {
   }
 
   /**
-   * Premium models that anonymous public {@code /ask} callers must not use (cheaper models stay public).
+   * Models that anonymous public {@code /ask} callers must not use (fast models stay public).
    */
   public boolean requiresAuthenticationForPublicChat() {
-    return this == GPT_5_4 || this == CLAUDE_SONNET_4_6;
+    return tags.contains(ModelTag.REASONING);
   }
 }

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/ChatModelCatalog.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/ChatModelCatalog.java
@@ -29,7 +29,7 @@ public class ChatModelCatalog {
     boolean anthropic = hasApiKey("spring.ai.anthropic.api-key");
     return Arrays.stream(SupportedChatModel.values())
         .filter(m -> m.provider() == ChatProvider.OPENAI ? openai : anthropic)
-        .map(m -> new ChatModelOption(m.modelId(), m.provider(), m.label()))
+        .map(m -> new ChatModelOption(m.modelId(), m.provider(), m.label(), m.tags()))
         .toList();
   }
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -38,7 +38,7 @@ spring:
       api-key: ${ANTHROPIC_API_KEY:}
       chat:
         options:
-          model: claude-sonnet-4-6
+          model: claude-haiku-4-5-20251001
           max-tokens: ${portfolio.ai.limits.chat-max-completion-tokens:400}
     chat:
       observations:
@@ -77,10 +77,16 @@ portfolio:
       spike-hourly-multiplier: 5.0
       anon-identity-salt: ${AI_BUDGET_ANON_SALT:portfolio-ai-budget}
       models:
+        gpt-5.4-nano:
+          input-per-million-usd: 0.05
+          output-per-million-usd: 0.20
         gpt-5.4-mini:
           input-per-million-usd: 0.15
           output-per-million-usd: 0.60
         gpt-5.4:
+          input-per-million-usd: 2.50
+          output-per-million-usd: 10.00
+        gpt-5.5:
           input-per-million-usd: 2.50
           output-per-million-usd: 10.00
         claude-haiku-4-5-20251001:
@@ -89,6 +95,9 @@ portfolio:
         claude-sonnet-4-6:
           input-per-million-usd: 3.00
           output-per-million-usd: 15.00
+        claude-opus-4-7:
+          input-per-million-usd: 5.00
+          output-per-million-usd: 25.00
     kill-switch:
       enabled: true
       monthly-limit-usd: 50.00

--- a/backend/src/test/java/com/kevinmazali/portfolio/MockConfig.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/MockConfig.java
@@ -3,6 +3,7 @@ package com.kevinmazali.portfolio;
 import com.kevinmazali.portfolio.config.AiLimitsProperties;
 import com.kevinmazali.portfolio.model.ChatModelOption;
 import com.kevinmazali.portfolio.model.chat.ChatProvider;
+import com.kevinmazali.portfolio.model.chat.ModelTag;
 import com.kevinmazali.portfolio.model.chat.SupportedChatModel;
 import com.kevinmazali.portfolio.service.ChatModelCatalog;
 import com.kevinmazali.portfolio.service.OpenAIService;
@@ -11,6 +12,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -39,7 +41,7 @@ public class MockConfig {
         ChatModelCatalog catalog = Mockito.mock(ChatModelCatalog.class);
         lenient().when(catalog.isModelConfigured(any(SupportedChatModel.class))).thenReturn(true);
         lenient().when(catalog.listAvailableModels()).thenReturn(List.of(
-            new ChatModelOption("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini")
+            new ChatModelOption("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini", EnumSet.of(ModelTag.FAST))
         ));
         return catalog;
     }

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/ChatModelsControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/ChatModelsControllerTest.java
@@ -8,6 +8,7 @@ import com.kevinmazali.portfolio.config.SecurityConfig;
 import com.kevinmazali.portfolio.config.WebConfig;
 import com.kevinmazali.portfolio.model.ChatModelOption;
 import com.kevinmazali.portfolio.model.chat.ChatProvider;
+import com.kevinmazali.portfolio.model.chat.ModelTag;
 import com.kevinmazali.portfolio.service.ChatModelCatalog;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -42,13 +44,16 @@ class ChatModelsControllerTest {
   @Test
   void listModelsReturnsJsonArray() throws Exception {
     when(chatModelCatalog.listAvailableModels()).thenReturn(List.of(
-        new ChatModelOption("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini")
+        new ChatModelOption("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini", EnumSet.of(ModelTag.FAST)),
+        new ChatModelOption("gpt-5.4", ChatProvider.OPENAI, "GPT-5.4", EnumSet.of(ModelTag.REASONING))
     ));
 
     mockMvc.perform(get("/chat/models"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].id").value("gpt-5.4-mini"))
         .andExpect(jsonPath("$[0].provider").value("OPENAI"))
-        .andExpect(jsonPath("$[0].label").value("GPT-5.4 mini"));
+        .andExpect(jsonPath("$[0].label").value("GPT-5.4 mini"))
+        .andExpect(jsonPath("$[0].tags[0]").value("FAST"))
+        .andExpect(jsonPath("$[1].tags[0]").value("REASONING"));
   }
 }

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/ExperimentControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/ExperimentControllerTest.java
@@ -10,6 +10,7 @@ import com.kevinmazali.portfolio.config.SecurityConfig;
 import com.kevinmazali.portfolio.config.WebConfig;
 import com.kevinmazali.portfolio.model.ChatModelOption;
 import com.kevinmazali.portfolio.model.chat.ChatProvider;
+import com.kevinmazali.portfolio.model.chat.ModelTag;
 import com.kevinmazali.portfolio.model.experiment.CreateEvalDatasetRequest;
 import com.kevinmazali.portfolio.model.experiment.DatasetGenerationStatus;
 import com.kevinmazali.portfolio.model.experiment.DatasetGenerationStatusResponse;
@@ -23,6 +24,7 @@ import com.kevinmazali.portfolio.service.ChatModelCatalog;
 import com.kevinmazali.portfolio.service.DatasetGenerationService;
 import com.kevinmazali.portfolio.service.ExperimentService;
 import java.time.OffsetDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,7 +141,7 @@ class ExperimentControllerTest {
   @WithMockUser(roles = "ADMIN")
   void modelsEndpointReturnsCatalogForAdmin() throws Exception {
     when(chatModelCatalog.listAvailableModels()).thenReturn(List.of(
-        new ChatModelOption("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini")));
+        new ChatModelOption("gpt-5.4-mini", ChatProvider.OPENAI, "GPT-5.4 mini", EnumSet.of(ModelTag.FAST))));
 
     mockMvc.perform(get("/admin/tools/experiments/models"))
         .andExpect(status().isOk())

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/QuestionControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/QuestionControllerTest.java
@@ -104,6 +104,20 @@ class QuestionControllerTest {
 	}
 
 	@Test
+	void askAcceptsAdditionalAllowListedModel() throws Exception {
+		when(openAIService.getAnswer(any(Question.class))).thenReturn(new Answer("ok"));
+
+		mockMvc.perform(post("/ask")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"question\":\"Ping\",\"model\":\"gpt-5.4-nano\"}"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.answer").value("ok"));
+
+		verify(openAIService).getAnswer(argThat(q ->
+			"Ping".equals(q.question()) && "gpt-5.4-nano".equals(q.model())));
+	}
+
+	@Test
 	void askRejectsUnknownModel() throws Exception {
 		mockMvc.perform(post("/ask")
 				.contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/kevinmazali/portfolio/model/chat/SupportedChatModelTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/model/chat/SupportedChatModelTest.java
@@ -1,0 +1,55 @@
+package com.kevinmazali.portfolio.model.chat;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SupportedChatModelTest {
+
+  @Test
+  void fromModelId_resolvesAllConfiguredIds() {
+    for (SupportedChatModel m : SupportedChatModel.values()) {
+      assertThat(SupportedChatModel.fromModelId(m.modelId())).contains(m);
+    }
+  }
+
+  @Test
+  void fromModelId_trimsWhitespace() {
+    assertThat(SupportedChatModel.fromModelId("  gpt-5.4-mini  ")).contains(SupportedChatModel.GPT_5_4_MINI);
+  }
+
+  @Test
+  void fromModelId_emptyOrUnknown() {
+    assertThat(SupportedChatModel.fromModelId(null)).isEmpty();
+    assertThat(SupportedChatModel.fromModelId("")).isEmpty();
+    assertThat(SupportedChatModel.fromModelId("gpt-4o")).isEmpty();
+  }
+
+  @Test
+  void fastModelsDoNotRequireAuthForPublicChat() {
+    assertThat(SupportedChatModel.GPT_5_4_NANO.tags()).isEqualTo(EnumSet.of(ModelTag.FAST));
+    assertThat(SupportedChatModel.GPT_5_4_MINI.tags()).isEqualTo(EnumSet.of(ModelTag.FAST));
+    assertThat(SupportedChatModel.CLAUDE_HAIKU_4_5.tags()).isEqualTo(EnumSet.of(ModelTag.FAST));
+
+    assertFalse(SupportedChatModel.GPT_5_4_NANO.requiresAuthenticationForPublicChat());
+    assertFalse(SupportedChatModel.GPT_5_4_MINI.requiresAuthenticationForPublicChat());
+    assertFalse(SupportedChatModel.CLAUDE_HAIKU_4_5.requiresAuthenticationForPublicChat());
+  }
+
+  @Test
+  void reasoningModelsRequireAuthForPublicChat() {
+    assertThat(SupportedChatModel.GPT_5_4.tags()).isEqualTo(EnumSet.of(ModelTag.REASONING));
+    assertThat(SupportedChatModel.GPT_5_5.tags()).isEqualTo(EnumSet.of(ModelTag.REASONING));
+    assertThat(SupportedChatModel.CLAUDE_SONNET_4_6.tags()).isEqualTo(EnumSet.of(ModelTag.REASONING));
+    assertThat(SupportedChatModel.CLAUDE_OPUS_4_7.tags()).isEqualTo(EnumSet.of(ModelTag.REASONING));
+
+    assertTrue(SupportedChatModel.GPT_5_4.requiresAuthenticationForPublicChat());
+    assertTrue(SupportedChatModel.GPT_5_5.requiresAuthenticationForPublicChat());
+    assertTrue(SupportedChatModel.CLAUDE_SONNET_4_6.requiresAuthenticationForPublicChat());
+    assertTrue(SupportedChatModel.CLAUDE_OPUS_4_7.requiresAuthenticationForPublicChat());
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/ChatModelCatalogTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/ChatModelCatalogTest.java
@@ -1,9 +1,13 @@
 package com.kevinmazali.portfolio.service;
 
+import com.kevinmazali.portfolio.model.ChatModelOption;
 import com.kevinmazali.portfolio.model.chat.ChatProvider;
+import com.kevinmazali.portfolio.model.chat.ModelTag;
 import com.kevinmazali.portfolio.model.chat.SupportedChatModel;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
+
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,7 +36,28 @@ class ChatModelCatalogTest {
         .withProperty("spring.ai.anthropic.api-key", "sk-ant-test");
     ChatModelCatalog catalog = new ChatModelCatalog(env);
 
-    assertThat(catalog.listAvailableModels()).hasSize(4);
+    assertThat(catalog.listAvailableModels()).hasSize(7);
+  }
+
+  @Test
+  void listAvailableModels_includesTagsOnEachOption() {
+    MockEnvironment env = new MockEnvironment()
+        .withProperty("spring.ai.openai.api-key", "sk-openai-test")
+        .withProperty("spring.ai.openai.chat.enabled", "true")
+        .withProperty("spring.ai.anthropic.api-key", "sk-ant-test");
+    ChatModelCatalog catalog = new ChatModelCatalog(env);
+
+    ChatModelOption nano = catalog.listAvailableModels().stream()
+        .filter(o -> "gpt-5.4-nano".equals(o.id()))
+        .findFirst()
+        .orElseThrow();
+    assertThat(nano.tags()).isEqualTo(EnumSet.of(ModelTag.FAST));
+
+    ChatModelOption opus = catalog.listAvailableModels().stream()
+        .filter(o -> "claude-opus-4-7".equals(o.id()))
+        .findFirst()
+        .orElseThrow();
+    assertThat(opus.tags()).isEqualTo(EnumSet.of(ModelTag.REASONING));
   }
 
   @Test

--- a/frontend/homepage/cypress/e2e/chat-models.cy.ts
+++ b/frontend/homepage/cypress/e2e/chat-models.cy.ts
@@ -1,0 +1,52 @@
+describe('Chat model catalog', () => {
+  it('loads models with tags, defaults to FAST, and switches provider subset', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({
+          statusCode: 200,
+          body: [
+            {
+              id: 'gpt-5.4',
+              provider: 'OPENAI',
+              label: 'GPT-5.4',
+              tags: ['REASONING'],
+            },
+            {
+              id: 'gpt-5.4-mini',
+              provider: 'OPENAI',
+              label: 'GPT-5.4 mini',
+              tags: ['FAST'],
+            },
+            {
+              id: 'claude-haiku-4-5-20251001',
+              provider: 'ANTHROPIC',
+              label: 'Claude Haiku 4.5',
+              tags: ['FAST'],
+            },
+            {
+              id: 'claude-sonnet-4-6',
+              provider: 'ANTHROPIC',
+              label: 'Claude Sonnet 4.6',
+              tags: ['REASONING'],
+            },
+          ],
+        })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+
+    cy.get('#chat-model-select').should('exist')
+    cy.get('#chat-model-select').find('option').should('have.length', 2)
+    cy.get('#chat-model-select').find('option').contains('Fast')
+    cy.get('#chat-model-select').find('option').contains('Reasoning')
+    cy.get('#chat-model-select').should('have.value', 'gpt-5.4-mini')
+
+    cy.contains('button', /^Anthropic$/i).click()
+    cy.get('#chat-model-select').find('option').should('have.length', 2)
+    cy.get('#chat-model-select').should('have.value', 'claude-haiku-4-5-20251001')
+    cy.get('#chat-model-select').find('option').contains('Haiku')
+  })
+})

--- a/frontend/homepage/openapi/openapi.json
+++ b/frontend/homepage/openapi/openapi.json
@@ -83,8 +83,16 @@
         "properties": {
           "id": { "type": "string" },
           "provider": { "$ref": "#/components/schemas/ChatModelOptionProvider" },
-          "label": { "type": "string" }
+          "label": { "type": "string" },
+          "tags": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ModelTag" }
+          }
         }
+      },
+      "ModelTag": {
+        "type": "string",
+        "enum": ["FAST", "REASONING"]
       },
       "ChatModelOptionProvider": {
         "type": "string",

--- a/frontend/homepage/src/api/generated/portfolio.ts
+++ b/frontend/homepage/src/api/generated/portfolio.ts
@@ -56,7 +56,17 @@ export interface ChatModelOption {
   id?: string;
   provider?: ChatModelOptionProvider;
   label?: string;
+  /** Capability tags (e.g. FAST vs REASONING) */
+  tags?: ChatModelTag[];
 }
+
+export type ChatModelTag = typeof ChatModelTag[keyof typeof ChatModelTag];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ChatModelTag = {
+  FAST: 'FAST',
+  REASONING: 'REASONING',
+} as const;
 
 export type ChatModelOptionProvider = typeof ChatModelOptionProvider[keyof typeof ChatModelOptionProvider];
 

--- a/frontend/homepage/src/stores/__tests__/model.spec.ts
+++ b/frontend/homepage/src/stores/__tests__/model.spec.ts
@@ -224,7 +224,7 @@ describe('useChatModelStore', () => {
       headers: new Headers(),
     })
     await Promise.all([a, b])
-    expect(store.models).toHaveLength(1)
+    expect(store.models).toHaveLength(2)
     expect(store.selectedModelId).toBe('x')
   })
 

--- a/frontend/homepage/src/stores/__tests__/model.spec.ts
+++ b/frontend/homepage/src/stores/__tests__/model.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import { listChatModels, ChatModelOptionProvider } from '@/api/generated/portfolio'
+import { listChatModels, ChatModelOptionProvider, ChatModelTag } from '@/api/generated/portfolio'
 import { isChatProvider, useChatModelStore } from '../model'
 
 vi.mock('@/api/generated/portfolio', async (importOriginal) => {
@@ -121,6 +121,28 @@ describe('useChatModelStore', () => {
     expect(store.selectedModelId).toBe('only')
   })
 
+  it('applyInitialSelection prefers FAST when multiple models and no storage', () => {
+    const store = useChatModelStore()
+    store.$patch({
+      models: [
+        {
+          id: 'r',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'R',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'f',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'F',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+    })
+    store.applyInitialSelection()
+    expect(store.selectedModelId).toBe('f')
+  })
+
   it('selectFirstForProvider sets first model id for provider', () => {
     const store = useChatModelStore()
     store.$patch({
@@ -131,6 +153,28 @@ describe('useChatModelStore', () => {
     })
     store.selectFirstForProvider(ChatModelOptionProvider.OPENAI)
     expect(store.selectedModelId).toBe('o2')
+  })
+
+  it('selectFirstForProvider prefers FAST when reasoning model is listed first', () => {
+    const store = useChatModelStore()
+    store.$patch({
+      models: [
+        {
+          id: 'slow',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'S',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'fast',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'F',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+    })
+    store.selectFirstForProvider(ChatModelOptionProvider.OPENAI)
+    expect(store.selectedModelId).toBe('fast')
   })
 
   it('selectFirstForProvider does nothing when list empty', () => {
@@ -163,7 +207,20 @@ describe('useChatModelStore', () => {
     expect(listChatModels).toHaveBeenCalledTimes(1)
     resolveFn!({
       status: 200,
-      data: [{ id: 'x', provider: ChatModelOptionProvider.OPENAI, label: 'X' }],
+      data: [
+        {
+          id: 'y',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'Y',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'x',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'X',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
       headers: new Headers(),
     })
     await Promise.all([a, b])

--- a/frontend/homepage/src/stores/model.ts
+++ b/frontend/homepage/src/stores/model.ts
@@ -3,6 +3,7 @@ import {
   listChatModels,
   type ChatModelOption,
   ChatModelOptionProvider,
+  ChatModelTag,
 } from '@/api/generated/portfolio'
 
 // Mirrors backend allow-list: only models returned by GET /chat/models are selectable in the UI.
@@ -60,11 +61,13 @@ export const useChatModelStore = defineStore('chatModel', {
       this.persistModelId()
     },
 
-    /** Switch UI to a provider and pick its first available model. */
+    /** Switch UI to a provider and pick the first FAST model when available, else first listed. */
     selectFirstForProvider(p: ChatProvider) {
       const list = this.modelsForProvider(p)
-      if (list.length > 0 && list[0].id) {
-        this.setSelectedModelId(list[0].id)
+      const fast = list.find((m) => m.tags?.includes(ChatModelTag.FAST))
+      const pick = fast ?? list[0]
+      if (pick?.id) {
+        this.setSelectedModelId(pick.id)
       }
     },
 
@@ -79,7 +82,8 @@ export const useChatModelStore = defineStore('chatModel', {
         // ignore
       }
       if (this.models.length > 0) {
-        const first = this.models[0]
+        const fast = this.models.find((m) => m.tags?.includes(ChatModelTag.FAST))
+        const first = fast ?? this.models[0]
         if (first.id) {
           this.selectedModelId = first.id
           this.persistModelId()

--- a/frontend/homepage/src/views/ChatView.vue
+++ b/frontend/homepage/src/views/ChatView.vue
@@ -15,7 +15,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import MessagesArea from '@/views/MessagesArea.vue'
-import { askQuestion, ChatModelOptionProvider } from '@/api/generated/portfolio'
+import {
+  askQuestion,
+  ChatModelOptionProvider,
+  ChatModelTag,
+  type ChatModelOption,
+} from '@/api/generated/portfolio'
 import {
   POSTHOG_CHAT_EVENTS,
   POSTHOG_FEATURE_FLAGS,
@@ -55,6 +60,19 @@ const modelsForActiveProvider = computed(() => {
   const p = chatModelStore.activeProvider
   if (!p) return chatModelStore.models
   return chatModelStore.modelsForProvider(p)
+})
+
+/** Human-readable tag suffix for the model dropdown (FAST / REASONING). */
+const formatModelTags = computed(() => (m: ChatModelOption) => {
+  const tags = m.tags ?? []
+  if (tags.length === 0) return ''
+  const no = language.value === 'no'
+  const parts = tags.map((t) => {
+    if (t === ChatModelTag.FAST) return no ? 'Rask' : 'Fast'
+    if (t === ChatModelTag.REASONING) return no ? 'Resonnering' : 'Reasoning'
+    return String(t)
+  })
+  return ` — ${parts.join(', ')}`
 })
 
 const selectedModelId = computed({
@@ -439,7 +457,7 @@ onMounted(async () => {
               class="w-full rounded-xl border border-blue-200/70 bg-white/90 px-3 py-2.5 text-sm text-slate-700 focus:border-blue-300/80 focus:outline-none disabled:opacity-50"
             >
               <option v-for="m in modelsForActiveProvider" :key="m.id" :value="m.id">
-                {{ m.label }} ({{ m.provider }})
+                {{ m.label }} ({{ m.provider }}){{ formatModelTags(m) }}
               </option>
             </select>
           </div>

--- a/frontend/homepage/src/views/__tests__/ChatView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/ChatView.spec.ts
@@ -3,7 +3,13 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import ChatView from '../ChatView.vue'
-import { askQuestion, listChatModels, type askQuestionResponse } from '@/api/generated/portfolio'
+import {
+  askQuestion,
+  listChatModels,
+  ChatModelOptionProvider,
+  ChatModelTag,
+  type askQuestionResponse,
+} from '@/api/generated/portfolio'
 import { useLangStore } from '@/stores/lang'
 import { useChatModelStore } from '@/stores/model'
 
@@ -79,6 +85,35 @@ describe('ChatView', () => {
     await flushPromises()
     return { wrapper, router, pinia }
   }
+
+  it('shows model FAST / Reasoning labels and defaults to a FAST model', async () => {
+    vi.mocked(listChatModels).mockResolvedValue({
+      status: 200,
+      data: [
+        {
+          id: 'gpt-5.4',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'GPT-5.4',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'gpt-5.4-mini',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'GPT-5.4 mini',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+      headers: new Headers(),
+    })
+    const { wrapper } = await mountChat({})
+    await flushPromises()
+    const sel = wrapper.find('#chat-model-select')
+    expect(sel.exists()).toBe(true)
+    const opts = sel.findAll('option')
+    expect(opts.some((o) => o.text().includes('Fast'))).toBe(true)
+    expect(opts.some((o) => o.text().includes('Reasoning'))).toBe(true)
+    expect((sel.element as HTMLSelectElement).value).toBe('gpt-5.4-mini')
+  })
 
   it('shows English error when prompt exceeds max length', async () => {
     const { wrapper } = await mountChat({})


### PR DESCRIPTION
- Add ModelTag (FAST, REASONING) and SupportedChatModel entries (nano, 5.5, opus)
- Expose tags on ChatModelOption; premium gate for all REASONING models
- Default Anthropic Spring AI model to Haiku; budget pricing for new ids
- Pinia: prefer FAST for initial selection and provider switch
- ChatView: localized tag suffix in model dropdown
- Tests: SupportedChatModelTest, catalog/controller updates, Vitest + Cypress