### PR TITLE
test: model validation, budget consistency, and Cypress chat e2e

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,16 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_model_validation:
+        description: 'Run live model validation against real APIs'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Weekly Sunday 06:00 UTC — validate model IDs are still accepted by providers.
+    - cron: '0 6 * * 0'
 
 permissions:
   contents: read
@@ -78,4 +88,34 @@ jobs:
           path: |
             frontend/homepage/test-results
             frontend/homepage/coverage
+          if-no-files-found: ignore
+
+  model-validation:
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_model_validation)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+          cache-dependency-path: backend/pom.xml
+      - name: Live model validation (OpenAI + Anthropic)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: ./mvnw -B test -Dgroups=live -Dtest=LiveModelValidationIT
+      - name: Upload validation results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: model-validation-reports
+          path: backend/target/surefire-reports
           if-no-files-found: ignore

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -155,6 +155,13 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludedGroups>live</excludedGroups>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<annotationProcessorPaths>

--- a/backend/src/test/java/com/kevinmazali/portfolio/config/BudgetModelConsistencyTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/config/BudgetModelConsistencyTest.java
@@ -1,0 +1,110 @@
+package com.kevinmazali.portfolio.config;
+
+import com.kevinmazali.portfolio.model.chat.SupportedChatModel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ensures {@link SupportedChatModel} and the {@code portfolio.ai.budget.models}
+ * YAML block stay in sync. Pure unit test — no Spring context, runs in the fast CI gate.
+ */
+class BudgetModelConsistencyTest {
+
+  private static Set<String> budgetModelKeys;
+
+  @BeforeAll
+  static void loadBudgetKeysFromYaml() throws Exception {
+    YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+    var sources = loader.load("application", new ClassPathResource("application.yaml"));
+    assertThat(sources).isNotEmpty();
+
+    PropertySource<?> ps = sources.get(0);
+
+    budgetModelKeys = Arrays.stream(SupportedChatModel.values())
+        .map(SupportedChatModel::modelId)
+        .filter(id -> ps.getProperty("portfolio.ai.budget.models." + id + ".input-per-million-usd") != null)
+        .collect(Collectors.toSet());
+
+    Set<String> allEnumIds = Arrays.stream(SupportedChatModel.values())
+        .map(SupportedChatModel::modelId)
+        .collect(Collectors.toSet());
+
+    Set<String> yamlBudgetKeys = allEnumIds.stream()
+        .filter(id -> ps.getProperty("portfolio.ai.budget.models." + id + ".input-per-million-usd") != null)
+        .collect(Collectors.toSet());
+
+    budgetModelKeys = yamlBudgetKeys;
+  }
+
+  @Test
+  void everyEnumModelHasBudgetPricing() {
+    for (SupportedChatModel model : SupportedChatModel.values()) {
+      assertThat(budgetModelKeys)
+          .as("Budget pricing missing for model '%s' in application.yaml", model.modelId())
+          .contains(model.modelId());
+    }
+  }
+
+  @Test
+  void enumCoversAllBudgetEntries() {
+    Set<String> enumIds = Arrays.stream(SupportedChatModel.values())
+        .map(SupportedChatModel::modelId)
+        .collect(Collectors.toSet());
+
+    for (String budgetKey : budgetModelKeys) {
+      assertThat(enumIds)
+          .as("Budget entry '%s' has no matching SupportedChatModel enum value", budgetKey)
+          .contains(budgetKey);
+    }
+  }
+
+  @Test
+  void defaultModelIdIsInEnum() throws Exception {
+    YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+    var sources = loader.load("application", new ClassPathResource("application.yaml"));
+    PropertySource<?> ps = sources.get(0);
+
+    Object defaultId = ps.getProperty("portfolio.chat.default-model-id");
+    assertThat(defaultId).as("portfolio.chat.default-model-id must be set").isNotNull();
+
+    assertThat(SupportedChatModel.fromModelId(defaultId.toString()))
+        .as("default-model-id '%s' must be a valid SupportedChatModel", defaultId)
+        .isPresent();
+  }
+
+  @Test
+  void openAiDefaultModelIsInEnum() throws Exception {
+    YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+    var sources = loader.load("application", new ClassPathResource("application.yaml"));
+    PropertySource<?> ps = sources.get(0);
+
+    Object openaiDefault = ps.getProperty("spring.ai.openai.chat.options.model");
+    assertThat(openaiDefault).as("spring.ai.openai.chat.options.model must be set").isNotNull();
+    assertThat(SupportedChatModel.fromModelId(openaiDefault.toString()))
+        .as("OpenAI default model '%s' must be a valid SupportedChatModel", openaiDefault)
+        .isPresent();
+  }
+
+  @Test
+  void anthropicDefaultModelIsInEnum() throws Exception {
+    YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+    var sources = loader.load("application", new ClassPathResource("application.yaml"));
+    PropertySource<?> ps = sources.get(0);
+
+    Object anthropicDefault = ps.getProperty("spring.ai.anthropic.chat.options.model");
+    assertThat(anthropicDefault).as("spring.ai.anthropic.chat.options.model must be set").isNotNull();
+    assertThat(SupportedChatModel.fromModelId(anthropicDefault.toString()))
+        .as("Anthropic default model '%s' must be a valid SupportedChatModel", anthropicDefault)
+        .isPresent();
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/model/chat/LiveModelValidationIT.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/model/chat/LiveModelValidationIT.java
@@ -1,0 +1,103 @@
+package com.kevinmazali.portfolio.model.chat;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Live integration test that calls the real OpenAI / Anthropic APIs to verify
+ * every {@link SupportedChatModel} ID is accepted by the provider.
+ *
+ * <p>Excluded from the normal CI gate — run manually or via the
+ * {@code model-validation} GitHub Actions workflow:
+ * <pre>mvn test -Dgroups=live</pre>
+ *
+ * <p>Requires {@code OPENAI_API_KEY} and/or {@code ANTHROPIC_API_KEY} env vars.
+ */
+@Tag("live")
+class LiveModelValidationIT {
+
+  private static final HttpClient HTTP = HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(15))
+      .build();
+
+  @ParameterizedTest(name = "OpenAI model {0} is callable")
+  @EnumSource(value = SupportedChatModel.class, mode = EnumSource.Mode.MATCH_ANY,
+      names = {"GPT_.*"})
+  @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+  void openAiModelAccepted(SupportedChatModel model) throws Exception {
+    String apiKey = System.getenv("OPENAI_API_KEY");
+    assertNotNull(apiKey, "OPENAI_API_KEY must be set");
+
+    String body = """
+        {"model":"%s","messages":[{"role":"user","content":"Say hi"}],"max_completion_tokens":5}
+        """.formatted(model.modelId()).strip();
+
+    HttpRequest req = HttpRequest.newBuilder()
+        .uri(URI.create("https://api.openai.com/v1/chat/completions"))
+        .header("Authorization", "Bearer " + apiKey)
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body))
+        .timeout(Duration.ofSeconds(30))
+        .build();
+
+    HttpResponse<String> res = HTTP.send(req, HttpResponse.BodyHandlers.ofString());
+
+    if (res.statusCode() == 404 || res.body().contains("model_not_found")) {
+      fail("Model ID '" + model.modelId() + "' is not recognized by OpenAI. "
+          + "HTTP " + res.statusCode() + ": " + res.body());
+    }
+    assertEquals(200, res.statusCode(),
+        "Model '" + model.modelId() + "' returned HTTP " + res.statusCode()
+            + ": " + truncate(res.body(), 500));
+  }
+
+  @ParameterizedTest(name = "Anthropic model {0} is callable")
+  @EnumSource(value = SupportedChatModel.class, mode = EnumSource.Mode.MATCH_ANY,
+      names = {"CLAUDE_.*"})
+  @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+  void anthropicModelAccepted(SupportedChatModel model) throws Exception {
+    String apiKey = System.getenv("ANTHROPIC_API_KEY");
+    assertNotNull(apiKey, "ANTHROPIC_API_KEY must be set");
+
+    String body = """
+        {"model":"%s","messages":[{"role":"user","content":"Say hi"}],"max_tokens":5}
+        """.formatted(model.modelId()).strip();
+
+    HttpRequest req = HttpRequest.newBuilder()
+        .uri(URI.create("https://api.anthropic.com/v1/messages"))
+        .header("x-api-key", apiKey)
+        .header("anthropic-version", "2023-06-01")
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body))
+        .timeout(Duration.ofSeconds(30))
+        .build();
+
+    HttpResponse<String> res = HTTP.send(req, HttpResponse.BodyHandlers.ofString());
+
+    if (res.statusCode() == 404 || res.body().contains("model_not_found")
+        || res.body().contains("not_found_error")) {
+      fail("Model ID '" + model.modelId() + "' is not recognized by Anthropic. "
+          + "HTTP " + res.statusCode() + ": " + res.body());
+    }
+    assertEquals(200, res.statusCode(),
+        "Model '" + model.modelId() + "' returned HTTP " + res.statusCode()
+            + ": " + truncate(res.body(), 500));
+  }
+
+  private static String truncate(String s, int max) {
+    if (s == null) return "";
+    return s.length() <= max ? s : s.substring(0, max) + "…";
+  }
+}

--- a/frontend/homepage/cypress/e2e/chat-e2e.cy.ts
+++ b/frontend/homepage/cypress/e2e/chat-e2e.cy.ts
@@ -1,0 +1,151 @@
+/**
+ * Full chat flow e2e tests with stubbed backend.
+ * Covers: send/receive, markdown rendering, error states (429/503/400),
+ * conversation ID header, sessionStorage model persistence, and clear chat.
+ */
+
+const ALL_MODELS = [
+  { id: 'gpt-5.4-mini', provider: 'OPENAI', label: 'GPT-5.4 mini', tags: ['FAST'] },
+  { id: 'gpt-5.4', provider: 'OPENAI', label: 'GPT-5.4', tags: ['REASONING'] },
+  { id: 'claude-haiku-4-5-20251001', provider: 'ANTHROPIC', label: 'Claude Haiku 4.5', tags: ['FAST'] },
+]
+
+function stubCatalogAndAsk(askStatus: number, askBody: object) {
+  cy.intercept('GET', '/api/**', (req) => {
+    if (req.url.includes('/chat/models')) {
+      req.reply({ statusCode: 200, body: ALL_MODELS })
+    } else {
+      req.reply({ statusCode: 200, body: [] })
+    }
+  }).as('apiGet')
+
+  cy.intercept('POST', '**/ask', {
+    statusCode: askStatus,
+    body: askBody,
+  }).as('askPost')
+}
+
+describe('Chat e2e flow', () => {
+  beforeEach(() => {
+    cy.window().then((win) => win.sessionStorage.clear())
+  })
+
+  it('sends a question and receives a rendered answer', () => {
+    stubCatalogAndAsk(200, { answer: 'Hello! I am **Kevin\'s AI**.' })
+    cy.visit('/chat')
+
+    cy.get('input[type="text"]').type('Who are you?')
+    cy.contains('button', /send/i).click()
+
+    cy.wait('@askPost').its('request.headers').should('have.property', 'x-conversation-id')
+
+    cy.contains('Who are you?').should('exist')
+    cy.contains("Kevin's AI").should('exist')
+  })
+
+  it('shows error on 429 rate limit', () => {
+    stubCatalogAndAsk(429, { error: 'Rate limit exceeded' })
+    cy.visit('/chat')
+
+    cy.get('input[type="text"]').type('Hello')
+    cy.contains('button', /send/i).click()
+
+    cy.wait('@askPost')
+    cy.contains(/for mange|rate limit/i).should('be.visible')
+  })
+
+  it('shows error on 503 service unavailable', () => {
+    stubCatalogAndAsk(503, { error: 'AI service temporarily unavailable' })
+    cy.visit('/chat')
+
+    cy.get('input[type="text"]').type('Hello')
+    cy.contains('button', /send/i).click()
+
+    cy.wait('@askPost')
+    cy.contains(/gikk galt|unavailable|prøv igjen/i).should('be.visible')
+  })
+
+  it('shows error on 400 bad request', () => {
+    stubCatalogAndAsk(400, { error: 'Unknown chat model.' })
+    cy.visit('/chat')
+
+    cy.get('input[type="text"]').type('Hello')
+    cy.contains('button', /send/i).click()
+
+    cy.wait('@askPost')
+    cy.contains(/unknown|gikk galt/i).should('be.visible')
+  })
+
+  it('persists selected model in sessionStorage across navigation', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({ statusCode: 200, body: ALL_MODELS })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').should('exist')
+
+    cy.get('#chat-model-select').select('gpt-5.4')
+    cy.window().then((win) => {
+      expect(win.sessionStorage.getItem('chatSelectedModel')).to.eq('gpt-5.4')
+    })
+
+    cy.visit('/')
+    cy.visit('/chat')
+
+    cy.window().then((win) => {
+      expect(win.sessionStorage.getItem('chatSelectedModel')).to.eq('gpt-5.4')
+    })
+    cy.get('#chat-model-select').should('have.value', 'gpt-5.4')
+  })
+
+  it('clear chat removes messages and resets state', () => {
+    stubCatalogAndAsk(200, { answer: 'Reply one' })
+    cy.visit('/chat')
+
+    cy.get('input[type="text"]').type('First message')
+    cy.contains('button', /send/i).click()
+    cy.wait('@askPost')
+    cy.contains('Reply one').should('exist')
+
+    cy.contains('button', /clear chat/i).click()
+
+    cy.contains('First message').should('not.exist')
+    cy.contains('Reply one').should('not.exist')
+  })
+
+  it('disables send button while loading', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({ statusCode: 200, body: ALL_MODELS })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.intercept('POST', '**/ask', (req) => {
+      req.reply({ statusCode: 200, body: { answer: 'Delayed reply' }, delay: 1000 })
+    }).as('askPost')
+
+    cy.visit('/chat')
+    cy.get('input[type="text"]').type('Hello')
+    cy.contains('button', /send/i).click()
+
+    cy.contains('button', /sending/i).should('be.disabled')
+  })
+
+  it('rejects prompt exceeding max length client-side', () => {
+    stubCatalogAndAsk(200, { answer: 'Should not appear' })
+    cy.visit('/chat')
+
+    const longText = 'a'.repeat(3001)
+    cy.get('input[type="text"]').invoke('val', longText).trigger('input')
+    cy.contains('button', /send/i).click()
+
+    cy.contains(/for lang|too long/i).should('be.visible')
+    cy.get('@askPost.all').should('have.length', 0)
+  })
+})

--- a/frontend/homepage/cypress/e2e/chat-models.cy.ts
+++ b/frontend/homepage/cypress/e2e/chat-models.cy.ts
@@ -1,52 +1,134 @@
-describe('Chat model catalog', () => {
-  it('loads models with tags, defaults to FAST, and switches provider subset', () => {
-    cy.intercept('GET', '/api/**', (req) => {
-      if (req.url.includes('/chat/models')) {
-        req.reply({
-          statusCode: 200,
-          body: [
-            {
-              id: 'gpt-5.4',
-              provider: 'OPENAI',
-              label: 'GPT-5.4',
-              tags: ['REASONING'],
-            },
-            {
-              id: 'gpt-5.4-mini',
-              provider: 'OPENAI',
-              label: 'GPT-5.4 mini',
-              tags: ['FAST'],
-            },
-            {
-              id: 'claude-haiku-4-5-20251001',
-              provider: 'ANTHROPIC',
-              label: 'Claude Haiku 4.5',
-              tags: ['FAST'],
-            },
-            {
-              id: 'claude-sonnet-4-6',
-              provider: 'ANTHROPIC',
-              label: 'Claude Sonnet 4.6',
-              tags: ['REASONING'],
-            },
-          ],
-        })
-      } else {
-        req.reply({ statusCode: 200, body: [] })
-      }
-    }).as('apiGet')
+/**
+ * Chat model catalog e2e tests.
+ * Covers: catalog load, tag display, FAST default, per-model selection,
+ * provider switching round-trip, and per-model chat submission.
+ */
 
+const FULL_CATALOG = [
+  { id: 'gpt-5.4-nano', provider: 'OPENAI', label: 'GPT-5.4 Nano', tags: ['FAST'] },
+  { id: 'gpt-5.4-mini', provider: 'OPENAI', label: 'GPT-5.4 mini', tags: ['FAST'] },
+  { id: 'gpt-5.4', provider: 'OPENAI', label: 'GPT-5.4', tags: ['REASONING'] },
+  { id: 'gpt-5.5', provider: 'OPENAI', label: 'GPT-5.5', tags: ['REASONING'] },
+  { id: 'claude-haiku-4-5-20251001', provider: 'ANTHROPIC', label: 'Claude Haiku 4.5', tags: ['FAST'] },
+  { id: 'claude-sonnet-4-6', provider: 'ANTHROPIC', label: 'Claude Sonnet 4.6', tags: ['REASONING'] },
+  { id: 'claude-opus-4-7', provider: 'ANTHROPIC', label: 'Claude Opus 4.7', tags: ['REASONING'] },
+]
+
+function stubFullCatalog() {
+  cy.intercept('GET', '/api/**', (req) => {
+    if (req.url.includes('/chat/models')) {
+      req.reply({ statusCode: 200, body: FULL_CATALOG })
+    } else {
+      req.reply({ statusCode: 200, body: [] })
+    }
+  }).as('apiGet')
+}
+
+describe('Chat model catalog', () => {
+  beforeEach(() => {
+    cy.window().then((win) => win.sessionStorage.clear())
+  })
+
+  it('loads models with tags, defaults to FAST, and switches provider subset', () => {
+    stubFullCatalog()
     cy.visit('/chat')
 
     cy.get('#chat-model-select').should('exist')
-    cy.get('#chat-model-select').find('option').should('have.length', 2)
+    cy.get('#chat-model-select').find('option').should('have.length.at.least', 2)
     cy.get('#chat-model-select').find('option').contains('Fast')
     cy.get('#chat-model-select').find('option').contains('Reasoning')
-    cy.get('#chat-model-select').should('have.value', 'gpt-5.4-mini')
+    cy.get('#chat-model-select').should('have.value', 'gpt-5.4-nano')
 
     cy.contains('button', /^Anthropic$/i).click()
-    cy.get('#chat-model-select').find('option').should('have.length', 2)
+    cy.get('#chat-model-select').find('option').should('have.length.at.least', 2)
     cy.get('#chat-model-select').should('have.value', 'claude-haiku-4-5-20251001')
     cy.get('#chat-model-select').find('option').contains('Haiku')
+  })
+
+  it('can select every OpenAI model individually', () => {
+    stubFullCatalog()
+    cy.visit('/chat')
+
+    const openaiModels = FULL_CATALOG.filter((m) => m.provider === 'OPENAI')
+    openaiModels.forEach((model) => {
+      cy.get('#chat-model-select').select(model.id)
+      cy.get('#chat-model-select').should('have.value', model.id)
+    })
+  })
+
+  it('can select every Anthropic model individually', () => {
+    stubFullCatalog()
+    cy.visit('/chat')
+
+    cy.contains('button', /^Anthropic$/i).click()
+
+    const anthropicModels = FULL_CATALOG.filter((m) => m.provider === 'ANTHROPIC')
+    anthropicModels.forEach((model) => {
+      cy.get('#chat-model-select').select(model.id)
+      cy.get('#chat-model-select').should('have.value', model.id)
+    })
+  })
+
+  it('provider toggle switches between OpenAI and Anthropic models', () => {
+    stubFullCatalog()
+    cy.visit('/chat')
+
+    cy.get('#chat-model-select').should('have.value', 'gpt-5.4-nano')
+
+    cy.contains('button', /^Anthropic$/i).click()
+    cy.get('#chat-model-select').should('have.value', 'claude-haiku-4-5-20251001')
+    cy.get('#chat-model-select').find('option').each(($opt) => {
+      expect($opt.text()).to.match(/claude|anthropic/i)
+    })
+
+    cy.contains('button', /^OpenAI$/i).click()
+    cy.get('#chat-model-select').should('have.value', 'gpt-5.4-nano')
+    cy.get('#chat-model-select').find('option').each(($opt) => {
+      expect($opt.text()).to.match(/gpt|openai/i)
+    })
+  })
+
+  it('sends the selected model in the /ask request body', () => {
+    stubFullCatalog()
+    cy.intercept('POST', '**/ask', { statusCode: 200, body: { answer: 'ok' } }).as('askPost')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').select('gpt-5.4')
+    cy.get('input[type="text"]').type('Test question')
+    cy.contains('button', /send/i).click()
+
+    cy.wait('@askPost').its('request.body').should('have.property', 'model', 'gpt-5.4')
+  })
+
+  it('sends the selected Anthropic model in the /ask request body', () => {
+    stubFullCatalog()
+    cy.intercept('POST', '**/ask', { statusCode: 200, body: { answer: 'ok' } }).as('askPost')
+
+    cy.visit('/chat')
+    cy.contains('button', /^Anthropic$/i).click()
+    cy.get('#chat-model-select').select('claude-sonnet-4-6')
+    cy.get('input[type="text"]').type('Test question')
+    cy.contains('button', /send/i).click()
+
+    cy.wait('@askPost').its('request.body').should('have.property', 'model', 'claude-sonnet-4-6')
+  })
+
+  it('round-trip: switch providers, select model, send, switch back', () => {
+    stubFullCatalog()
+    cy.intercept('POST', '**/ask', { statusCode: 200, body: { answer: 'reply' } }).as('askPost')
+
+    cy.visit('/chat')
+
+    cy.contains('button', /^Anthropic$/i).click()
+    cy.get('#chat-model-select').select('claude-opus-4-7')
+    cy.get('input[type="text"]').type('Q1')
+    cy.contains('button', /send/i).click()
+    cy.wait('@askPost').its('request.body').should('have.property', 'model', 'claude-opus-4-7')
+
+    cy.contains('button', /^OpenAI$/i).click()
+    cy.get('#chat-model-select').select('gpt-5.5')
+    cy.get('input[type="text"]').type('Q2')
+    cy.contains('button', /send/i).click()
+    cy.wait('@askPost').its('request.body').should('have.property', 'model', 'gpt-5.5')
   })
 })

--- a/frontend/homepage/cypress/e2e/model-guard.cy.ts
+++ b/frontend/homepage/cypress/e2e/model-guard.cy.ts
@@ -1,0 +1,135 @@
+/**
+ * Model catalog edge-case tests.
+ * Covers: empty catalog, OpenAI-only, Anthropic-only scenarios.
+ */
+
+describe('Model catalog guard rails', () => {
+  it('gracefully handles empty model catalog', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({ statusCode: 200, body: [] })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').should('not.exist')
+    cy.get('input[type="text"]').should('exist')
+  })
+
+  it('hides provider toggle when only OpenAI models are available', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({
+          statusCode: 200,
+          body: [
+            { id: 'gpt-5.4-mini', provider: 'OPENAI', label: 'GPT-5.4 mini', tags: ['FAST'] },
+            { id: 'gpt-5.4', provider: 'OPENAI', label: 'GPT-5.4', tags: ['REASONING'] },
+          ],
+        })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').should('exist')
+    cy.get('#chat-model-select').find('option').should('have.length', 2)
+
+    cy.contains('button', /^OpenAI$/i).should('not.exist')
+    cy.contains('button', /^Anthropic$/i).should('not.exist')
+  })
+
+  it('hides provider toggle when only Anthropic models are available', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({
+          statusCode: 200,
+          body: [
+            {
+              id: 'claude-haiku-4-5-20251001',
+              provider: 'ANTHROPIC',
+              label: 'Claude Haiku 4.5',
+              tags: ['FAST'],
+            },
+            {
+              id: 'claude-sonnet-4-6',
+              provider: 'ANTHROPIC',
+              label: 'Claude Sonnet 4.6',
+              tags: ['REASONING'],
+            },
+          ],
+        })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').should('exist')
+    cy.get('#chat-model-select').find('option').should('have.length', 2)
+
+    cy.contains('button', /^OpenAI$/i).should('not.exist')
+    cy.contains('button', /^Anthropic$/i).should('not.exist')
+  })
+
+  it('shows provider toggle only when both providers have models', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({
+          statusCode: 200,
+          body: [
+            { id: 'gpt-5.4-mini', provider: 'OPENAI', label: 'GPT-5.4 mini', tags: ['FAST'] },
+            {
+              id: 'claude-haiku-4-5-20251001',
+              provider: 'ANTHROPIC',
+              label: 'Claude Haiku 4.5',
+              tags: ['FAST'],
+            },
+          ],
+        })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+
+    cy.contains('button', /^OpenAI$/i).should('exist')
+    cy.contains('button', /^Anthropic$/i).should('exist')
+  })
+
+  it('handles /chat/models endpoint failure gracefully', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({ statusCode: 500, body: { error: 'Internal server error' } })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').should('not.exist')
+    cy.get('input[type="text"]').should('exist')
+  })
+
+  it('defaults to FAST model when catalog loads', () => {
+    cy.intercept('GET', '/api/**', (req) => {
+      if (req.url.includes('/chat/models')) {
+        req.reply({
+          statusCode: 200,
+          body: [
+            { id: 'gpt-5.4', provider: 'OPENAI', label: 'GPT-5.4', tags: ['REASONING'] },
+            { id: 'gpt-5.4-mini', provider: 'OPENAI', label: 'GPT-5.4 mini', tags: ['FAST'] },
+          ],
+        })
+      } else {
+        req.reply({ statusCode: 200, body: [] })
+      }
+    }).as('apiGet')
+
+    cy.visit('/chat')
+    cy.get('#chat-model-select').should('have.value', 'gpt-5.4-mini')
+  })
+})

--- a/frontend/homepage/cypress/tsconfig.json
+++ b/frontend/homepage/cypress/tsconfig.json
@@ -4,6 +4,8 @@
   "exclude": ["./support/component.*"],
   "compilerOptions": {
     "isolatedModules": false,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
     "types": ["cypress"]
   }
 }

--- a/scripts/validate-models.ps1
+++ b/scripts/validate-models.ps1
@@ -1,0 +1,90 @@
+<#
+.SYNOPSIS
+  Quick-check that every SupportedChatModel ID is accepted by its provider API.
+
+.DESCRIPTION
+  Sends a minimal completion request (max 5 tokens) per model.
+  Exit code 0 = all models valid; non-zero = at least one rejected.
+
+.EXAMPLE
+  $env:OPENAI_API_KEY = "sk-..."
+  $env:ANTHROPIC_API_KEY = "sk-ant-..."
+  .\scripts\validate-models.ps1
+#>
+param(
+  [string] $OpenAiKey    = $env:OPENAI_API_KEY,
+  [string] $AnthropicKey = $env:ANTHROPIC_API_KEY
+)
+
+$ErrorActionPreference = 'Stop'
+$failed = @()
+
+$openaiModels = @('gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5')
+$anthropicModels = @('claude-haiku-4-5-20251001', 'claude-sonnet-4-6', 'claude-opus-4-7')
+
+if ($OpenAiKey) {
+  foreach ($m in $openaiModels) {
+    Write-Host -NoNewline "  OpenAI  $m ... "
+    $body = @{
+      model = $m
+      messages = @(@{ role = 'user'; content = 'Say hi' })
+      max_completion_tokens = 5
+    } | ConvertTo-Json -Depth 3
+
+    try {
+      $r = Invoke-WebRequest -Uri 'https://api.openai.com/v1/chat/completions' `
+        -Method POST `
+        -Headers @{ Authorization = "Bearer $OpenAiKey"; 'Content-Type' = 'application/json' } `
+        -Body $body `
+        -TimeoutSec 30 `
+        -ErrorAction Stop
+      Write-Host "OK ($($r.StatusCode))" -ForegroundColor Green
+    } catch {
+      $status = $_.Exception.Response.StatusCode.value__
+      Write-Host "FAIL (HTTP $status)" -ForegroundColor Red
+      $failed += $m
+    }
+  }
+} else {
+  Write-Host '  Skipping OpenAI models (OPENAI_API_KEY not set)' -ForegroundColor Yellow
+}
+
+if ($AnthropicKey) {
+  foreach ($m in $anthropicModels) {
+    Write-Host -NoNewline "  Anthropic  $m ... "
+    $body = @{
+      model = $m
+      messages = @(@{ role = 'user'; content = 'Say hi' })
+      max_tokens = 5
+    } | ConvertTo-Json -Depth 3
+
+    try {
+      $r = Invoke-WebRequest -Uri 'https://api.anthropic.com/v1/messages' `
+        -Method POST `
+        -Headers @{
+          'x-api-key' = $AnthropicKey
+          'anthropic-version' = '2023-06-01'
+          'Content-Type' = 'application/json'
+        } `
+        -Body $body `
+        -TimeoutSec 30 `
+        -ErrorAction Stop
+      Write-Host "OK ($($r.StatusCode))" -ForegroundColor Green
+    } catch {
+      $status = $_.Exception.Response.StatusCode.value__
+      Write-Host "FAIL (HTTP $status)" -ForegroundColor Red
+      $failed += $m
+    }
+  }
+} else {
+  Write-Host '  Skipping Anthropic models (ANTHROPIC_API_KEY not set)' -ForegroundColor Yellow
+}
+
+Write-Host ''
+if ($failed.Count -gt 0) {
+  Write-Host "BROKEN models: $($failed -join ', ')" -ForegroundColor Red
+  exit 1
+} else {
+  Write-Host 'All tested models are valid.' -ForegroundColor Green
+  exit 0
+}


### PR DESCRIPTION
## Summary

This PR implements the model validation and e2e coverage plan: live API checks for allow-listed chat models, fast CI checks that keep `SupportedChatModel` and budget YAML in sync, richer Cypress coverage for chat and catalog edge cases, and an optional GitHub Actions job for weekly or manual validation.

## Merge readiness

- **Backend:** `./mvnw verify` passes (Surefire excludes `@Tag("live")` by default; `BudgetModelConsistencyTest` runs in the normal gate).
- **Frontend:** Vitest suite unchanged in scope; new Cypress specs lint clean; run `npm run test:e2e` locally for full browser checks.
- **CI:** Default `Tests` workflow unchanged for PRs. `model-validation` runs only on `workflow_dispatch` with **Run live model validation** checked, or on the weekly schedule. Add repo secrets `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` for that job.

## What changed

- `LiveModelValidationIT`: minimal completion per model via provider REST APIs; gated by env vars.
- `BudgetModelConsistencyTest`: enum ↔ `portfolio.ai.budget.models` ↔ default model IDs in `application.yaml`.
- `scripts/validate-models.ps1`: optional PowerShell smoke test.
- Cypress: `chat-e2e.cy.ts`, `model-guard.cy.ts`, expanded `chat-models.cy.ts`; `cypress/tsconfig.json` `lib` for modern string APIs.
- `maven-surefire-plugin`: `excludedGroups=live`.
- `.github/workflows/tests.yml`: `model-validation` job + triggers.

## Notes

- No model IDs were removed: live validation was not run in this environment without API keys. After merge, run the manual workflow or `./mvnw test -Dgroups=live -Dtest=LiveModelValidationIT` with keys to confirm providers still accept every ID.
