### PR TITLE
feat: project page merge, model validation, and chat-models e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Optional **conversational capture** (for example a voice UI such as ElevenLabs) 
 
 **Practice guides (not peer-reviewed):** [AWS — securing the RAG ingestion pipeline](https://aws.amazon.com/blogs/security/securing-the-rag-ingestion-pipeline-filtering-mechanisms/), [Anyscale — RAG data ingestion strategies](https://docs.anyscale.com/rag/quality-improvement/data-ingestion-strategies).
 
-**Privacy:** purpose limitation, consent, and minimisation for any capture channel follow applicable law (for example GDPR), not the RAG literature above. On-site copy also lives under **Future work** in the Vue app (`frontend/homepage/src/views/FutureWorkView.vue`).
+**Privacy:** purpose limitation, consent, and minimisation for any capture channel follow applicable law (for example GDPR), not the RAG literature above. On-site copy also lives under **The project** → **Future work** in the Vue app (`frontend/homepage/src/views/ProjectPageView.vue` and `frontend/homepage/src/components/project/ProjectFutureWorkSection.vue`).
 
 ## Feedback
 

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/QuestionController.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/QuestionController.java
@@ -11,6 +11,7 @@ import com.kevinmazali.portfolio.exception.PremiumModelForbiddenException;
 import com.kevinmazali.portfolio.service.ChatModelCatalog;
 import com.kevinmazali.portfolio.service.OpenAIService;
 import com.kevinmazali.portfolio.service.RequestLogService;
+import com.kevinmazali.portfolio.util.AiRequestContext;
 import com.kevinmazali.portfolio.util.InputValidator;
 import com.kevinmazali.portfolio.util.LlmClientDiagnostics;
 import io.swagger.v3.oas.annotations.Operation;
@@ -80,9 +81,18 @@ public class QuestionController {
 
         String sanitizedQuestion = InputValidator.sanitizeString(question.question());
 
-        String effectiveModelId = (question.model() == null || question.model().isBlank())
+        String rawModelId = (question.model() == null || question.model().isBlank())
             ? defaultChatModelId
             : question.model().trim();
+
+        String effectiveModelId = rawModelId;
+        if ((question.model() == null || question.model().isBlank())
+            && AiRequestContext.isAnonymousInteractiveUser()) {
+            effectiveModelId = SupportedChatModel.fromModelId(rawModelId)
+                .filter(SupportedChatModel::requiresAuthenticationForPublicChat)
+                .map(m -> SupportedChatModel.GPT_5_4_MINI.modelId())
+                .orElse(rawModelId);
+        }
 
         var selected = SupportedChatModel.fromModelId(effectiveModelId);
         if (selected.isEmpty()) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -28,7 +28,7 @@ spring:
         enabled: ${OPENAI_CHAT_ENABLED:false}
         api-key: ${OPENAI_API_KEY:${SPRING_AI_OPENAI_API_KEY:}}
         options:
-          model: gpt-5.4-mini
+          model: gpt-5.5
           max-completion-tokens: ${portfolio.ai.limits.chat-max-completion-tokens:400}
       embedding:
         options:
@@ -119,7 +119,7 @@ portfolio:
       capacity: 15
       window-seconds: 300
   chat:
-    default-model-id: gpt-5.4-mini
+    default-model-id: gpt-5.5
   retrieval:
     # Optional ONNX rerank; Docker image sets paths under /app/rerank (see backend/Dockerfile).
     rerank-enabled: false

--- a/backend/src/test/java/com/kevinmazali/portfolio/PortfolioApplicationTests.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/PortfolioApplicationTests.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.TestPropertySource;
 		"spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
 		"spring.ai.openai.api-key=test-placeholder-key-for-context-tests-only",
 		"spring.ai.openai.chat.enabled=true",
-		"portfolio.chat.default-model-id=gpt-5.4-mini",
+		"portfolio.chat.default-model-id=gpt-5.5",
 		"server.port=0"
 	}
 )

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/QuestionControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/QuestionControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -38,7 +39,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = QuestionController.class, properties = "portfolio.chat.default-model-id=gpt-5.4-mini")
+@WebMvcTest(controllers = QuestionController.class, properties = "portfolio.chat.default-model-id=gpt-5.5")
 @EnableConfigurationProperties({
   AskRateLimitProperties.class,
   ExperimentRunRateLimitProperties.class,
@@ -101,6 +102,21 @@ class QuestionControllerTest {
 		verify(requestLogService).save(eq("/ask:response"), eq("POST"), eq("ok"), isNull());
 		verify(openAIService, times(1)).getAnswer(argThat(q ->
 			"What is your name?".equals(q.question()) && "gpt-5.4-mini".equals(q.model())));
+	}
+
+	@Test
+	@WithMockUser(username = "user", roles = "USER")
+	void askUsesConfiguredDefaultModelWhenAuthenticatedAndModelOmitted() throws Exception {
+		when(openAIService.getAnswer(any(Question.class))).thenReturn(new Answer("ok"));
+
+		mockMvc.perform(post("/ask")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"question\":\"What is your name?\"}"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.answer").value("ok"));
+
+		verify(openAIService, times(1)).getAnswer(argThat(q ->
+			"What is your name?".equals(q.question()) && "gpt-5.5".equals(q.model())));
 	}
 
 	@Test

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -31,7 +31,7 @@ portfolio:
     kill-switch:
       enabled: false
   chat:
-    default-model-id: gpt-5.4-mini
+    default-model-id: gpt-5.5
 
 logging:
   level:

--- a/frontend/homepage/cypress/e2e/chat-models.cy.ts
+++ b/frontend/homepage/cypress/e2e/chat-models.cy.ts
@@ -1,6 +1,6 @@
 /**
  * Chat model catalog e2e tests.
- * Covers: catalog load, tag display, FAST default, per-model selection,
+ * Covers: catalog load, tag display, anonymous FAST default, per-model selection,
  * provider switching round-trip, and per-model chat submission.
  */
 
@@ -29,7 +29,7 @@ describe('Chat model catalog', () => {
     cy.window().then((win) => win.sessionStorage.clear())
   })
 
-  it('loads models with tags, defaults to FAST, and switches provider subset', () => {
+  it('loads models with tags, defaults to FAST when anonymous, and switches provider subset', () => {
     stubFullCatalog()
     cy.visit('/chat')
 

--- a/frontend/homepage/src/components/Navbar.vue
+++ b/frontend/homepage/src/components/Navbar.vue
@@ -32,9 +32,7 @@ const getButtonText = (key: string) => {
     home: { en: 'Home', no: 'Hjem' },
     projects: { en: 'Projects', no: 'Prosjekter' },
     career: { en: 'Career', no: 'Karriere' },
-    bachelor: { en: 'Bachelor', no: 'Bachelor' },
-    techStack: { en: 'Tech stack', no: 'Teknologistakk' },
-    futureWork: { en: 'Future work', no: 'Videre arbeid' },
+    project: { en: 'The project', no: 'Prosjektet' },
   }
   return texts[key][langStore.language]
 }
@@ -45,9 +43,7 @@ const getButtonWidth = () => {
     getButtonText('home'),
     getButtonText('projects'),
     getButtonText('career'),
-    getButtonText('bachelor'),
-    getButtonText('techStack'),
-    getButtonText('futureWork'),
+    getButtonText('project'),
   ]
 
   // Estimate width based on character count (roughly 8px per character for this font size)
@@ -61,9 +57,7 @@ const getIndicatorPosition = () => {
   if (isActive('home')) return { transform: 'translateX(0px)', opacity: '1' }
   if (isActive('projects')) return { transform: `translateX(${buttonWidth}px)`, opacity: '1' }
   if (isActive('career')) return { transform: `translateX(${buttonWidth * 2}px)`, opacity: '1' }
-  if (isActive('bachelor')) return { transform: `translateX(${buttonWidth * 3}px)`, opacity: '1' }
-  if (isActive('tech-stack')) return { transform: `translateX(${buttonWidth * 4}px)`, opacity: '1' }
-  if (isActive('future-work')) return { transform: `translateX(${buttonWidth * 5}px)`, opacity: '1' }
+  if (isActive('project')) return { transform: `translateX(${buttonWidth * 3}px)`, opacity: '1' }
   return { transform: 'translateX(0px)', opacity: '0' }
 }
 
@@ -156,28 +150,12 @@ const mobileLinkInactive = 'text-gray-700 hover:bg-slate-50 hover:text-gray-900'
             {{ getButtonText('career') }}
           </RouterLink>
           <RouterLink
-            to="/bachelor"
+            to="/project"
             role="menuitem"
-            :class="[mobileLinkBase, isActive('bachelor') ? mobileLinkActive : mobileLinkInactive]"
+            :class="[mobileLinkBase, isActive('project') ? mobileLinkActive : mobileLinkInactive]"
             @click="closeMenu"
           >
-            {{ getButtonText('bachelor') }}
-          </RouterLink>
-          <RouterLink
-            to="/tech-stack"
-            role="menuitem"
-            :class="[mobileLinkBase, isActive('tech-stack') ? mobileLinkActive : mobileLinkInactive]"
-            @click="closeMenu"
-          >
-            {{ getButtonText('techStack') }}
-          </RouterLink>
-          <RouterLink
-            to="/future-work"
-            role="menuitem"
-            :class="[mobileLinkBase, isActive('future-work') ? mobileLinkActive : mobileLinkInactive]"
-            @click="closeMenu"
-          >
-            {{ getButtonText('futureWork') }}
+            {{ getButtonText('project') }}
           </RouterLink>
         </div>
       </Transition>
@@ -211,25 +189,11 @@ const mobileLinkInactive = 'text-gray-700 hover:bg-slate-50 hover:text-gray-900'
           {{ getButtonText('career') }}
         </RouterLink>
         <RouterLink
-          to="/bachelor"
-          :class="getButtonClasses('bachelor')"
+          to="/project"
+          :class="getButtonClasses('project')"
           :style="{ width: getButtonWidth() + 'px' }"
         >
-          {{ getButtonText('bachelor') }}
-        </RouterLink>
-        <RouterLink
-          to="/tech-stack"
-          :class="getButtonClasses('tech-stack')"
-          :style="{ width: getButtonWidth() + 'px' }"
-        >
-          {{ getButtonText('techStack') }}
-        </RouterLink>
-        <RouterLink
-          to="/future-work"
-          :class="getButtonClasses('future-work')"
-          :style="{ width: getButtonWidth() + 'px' }"
-        >
-          {{ getButtonText('futureWork') }}
+          {{ getButtonText('project') }}
         </RouterLink>
       </div>
     </div>

--- a/frontend/homepage/src/components/__tests__/Navbar.spec.ts
+++ b/frontend/homepage/src/components/__tests__/Navbar.spec.ts
@@ -17,9 +17,7 @@ describe('Navbar', () => {
 				{ path: '/', name: 'home', component: { template: '<div />' } },
 				{ path: '/projects', name: 'projects', component: { template: '<div />' } },
 				{ path: '/career', name: 'career', component: { template: '<div />' } },
-				{ path: '/bachelor', name: 'bachelor', component: { template: '<div />' } },
-				{ path: '/tech-stack', name: 'tech-stack', component: { template: '<div />' } },
-				{ path: '/future-work', name: 'future-work', component: { template: '<div />' } },
+				{ path: '/project', name: 'project', component: { template: '<div />' } },
 			],
 		})
 	}
@@ -37,10 +35,8 @@ describe('Navbar', () => {
 		await flushPromises()
 		expect(wrapper.text()).toContain('Home')
 		expect(wrapper.text()).toContain('Projects')
-		expect(wrapper.text()).toContain('Tech stack')
 		expect(wrapper.text()).toContain('Career')
-		expect(wrapper.text()).toContain('Bachelor')
-		expect(wrapper.text()).toContain('Future work')
+		expect(wrapper.text()).toContain('The project')
 	})
 
 	it('shows Norwegian labels when language is no', async () => {
@@ -61,10 +57,8 @@ describe('Navbar', () => {
 		await flushPromises()
 		expect(wrapper.text()).toContain('Hjem')
 		expect(wrapper.text()).toContain('Prosjekter')
-		expect(wrapper.text()).toContain('Teknologistakk')
 		expect(wrapper.text()).toContain('Karriere')
-		expect(wrapper.text()).toContain('Bachelor')
-		expect(wrapper.text()).toContain('Videre arbeid')
+		expect(wrapper.text()).toContain('Prosjektet')
 	})
 
 	it('marks active route with stronger button styling', async () => {
@@ -103,7 +97,7 @@ describe('Navbar', () => {
 
 		const drawer = wrapper.find('#mobile-nav-drawer')
 		expect(drawer.exists()).toBe(true)
-		expect(drawer.findAll('a').length).toBe(6)
+		expect(drawer.findAll('a').length).toBe(4)
 		expect(drawer.text()).toContain('Home')
 		expect(drawer.text()).toContain('Projects')
 	})

--- a/frontend/homepage/src/components/project/ProjectBachelorSection.vue
+++ b/frontend/homepage/src/components/project/ProjectBachelorSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useLangStore } from '../stores/lang'
+import { useLangStore } from '@/stores/lang'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { GraduationCap, Sparkles, Link2 } from 'lucide-vue-next'
@@ -78,7 +78,7 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 					body: [
 						'Nettsiden er et levende arbeidsrom der jeg kontinuerlig tester og justerer ideer fra bacheloroppgaven.',
 						'Det betyr at både innhold, prioriteringer og AI-atferd kan endres i iterasjoner etter hvert som jeg lærer mer.',
-						'Du finner mer teknisk detalj på siden Teknologistakk, og en forskningsforankret roadmap på Videre arbeid.',
+						'Mer teknisk detalj finner du i seksjonen Teknologistakk på denne siden, og en forskningsforankret roadmap under Videre arbeid.',
 					],
 				},
 			]
@@ -105,7 +105,7 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 					body: [
 						'The site is a living workspace where I continuously test and adjust ideas from the bachelor thesis.',
 						'This means content, priorities, and AI behavior can change in iterations as I keep learning.',
-						'For more technical depth, see Tech stack; for a research-backed roadmap, see Future work.',
+						'For more technical depth, expand the Tech stack section on this page; for a research-backed roadmap, see Future work below.',
 					],
 				},
 			],
@@ -113,19 +113,8 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 </script>
 
 <template>
-	<main class="min-h-screen pt-20 bg-gradient-to-br from-slate-50 to-slate-100 relative pb-16">
-		<div class="absolute inset-0 pointer-events-none">
-			<div
-				class="absolute top-0 left-0 w-full h-full"
-				style="
-					background: radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.08) 0%, transparent 50%),
-						radial-gradient(circle at 80% 20%, rgba(37, 99, 235, 0.08) 0%, transparent 50%),
-						radial-gradient(circle at 50% 50%, rgba(96, 165, 250, 0.05) 0%, transparent 70%);
-				"
-			></div>
-		</div>
-
-		<div class="relative z-10 mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+	<div class="relative pb-8">
+		<div class="relative z-10 mx-auto max-w-4xl px-4 py-4 sm:px-6 lg:px-8">
 			<!-- Hero -->
 			<div
 				v-motion
@@ -235,7 +224,7 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 				</Card>
 			</div>
 		</div>
-	</main>
+	</div>
 </template>
 
 <style scoped>

--- a/frontend/homepage/src/components/project/ProjectFutureWorkSection.vue
+++ b/frontend/homepage/src/components/project/ProjectFutureWorkSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useLangStore } from '../stores/lang'
+import { useLangStore } from '@/stores/lang'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 
@@ -256,19 +256,8 @@ const referencesHeading = computed(() =>
 </script>
 
 <template>
-	<main class="min-h-screen pt-20 bg-gradient-to-br from-slate-50 to-slate-100 relative">
-		<div class="absolute inset-0 pointer-events-none">
-			<div
-				class="absolute top-0 left-0 w-full h-full"
-				style="
-					background: radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.08) 0%, transparent 50%),
-						radial-gradient(circle at 80% 20%, rgba(37, 99, 235, 0.08) 0%, transparent 50%),
-						radial-gradient(circle at 50% 50%, rgba(96, 165, 250, 0.05) 0%, transparent 70%);
-				"
-			></div>
-		</div>
-
-		<div class="relative z-10 mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+	<div class="relative pb-8">
+		<div class="relative z-10 mx-auto max-w-4xl px-4 py-4 sm:px-6 lg:px-8">
 			<h1
 				class="text-3xl font-bold mb-4 text-center bg-gradient-to-r from-blue-600 via-blue-700 to-blue-800 bg-clip-text text-transparent animate-gradient-x"
 			>
@@ -337,7 +326,7 @@ const referencesHeading = computed(() =>
 				</Card>
 			</div>
 		</div>
-	</main>
+	</div>
 </template>
 
 <style scoped>

--- a/frontend/homepage/src/components/project/ProjectTechStackSection.vue
+++ b/frontend/homepage/src/components/project/ProjectTechStackSection.vue
@@ -1,7 +1,22 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, type Ref } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref, type Ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+type ProjectSectionNav = {
+	openBachelor: () => void
+}
+const sectionNav = inject<ProjectSectionNav | null>('projectSectionNav', null)
+const router = useRouter()
+
+function onReadMoreBachelor() {
+	if (sectionNav) {
+		sectionNav.openBachelor()
+		return
+	}
+	void router.push({ path: '/project', hash: '#section-bachelor' })
+}
 import { useIntersectionObserver } from '@vueuse/core'
-import { useLangStore } from '../stores/lang'
+import { useLangStore } from '@/stores/lang'
 import { Badge } from '@/components/ui/badge'
 import {
   Cpu,
@@ -236,12 +251,11 @@ const sectionsIntro = computed(() =>
 
 const footerText = computed(() =>
   isNo.value
-    ? 'Mer om oppgaven og retningen finner du under bachelor. Full brukerhistorier og krav ligger i avtale og veiledning med oppdragsgiver.'
-    : 'More about the thesis and direction is on the bachelor page. Full user stories and requirements live in agreements and supervision with the industry partner.',
+    ? 'Mer om oppgaven og retningen finner du i bachelor-seksjonen på denne siden. Full brukerhistorier og krav ligger i avtale og veiledning med oppdragsgiver.'
+    : 'More about the thesis and direction is in the Bachelor section on this page. Full user stories and requirements live in agreements and supervision with the industry partner.',
 )
 
 const footerHome = computed(() => (isNo.value ? 'Til forsiden' : 'Back to home'))
-const footerBachelor = computed(() => (isNo.value ? 'Bacheloroppgaven' : 'Bachelor thesis'))
 
 const sections = computed<Section[]>(() => {
   if (isNo.value) {
@@ -291,7 +305,7 @@ const sections = computed<Section[]>(() => {
           'Ved henting utvides brukerens spørsmål til både norsk og engelsk, slik at treff i dokumenter på begge språk blir lettere å få med.',
           'PostgreSQL med pgvector kjører i Docker sammen med resten av stakken, som gjør det enkelt å få opp et konsistent miljø lokalt og i deploy.',
           'Fangst → kuratér → ingest → verifiser: valgfritt samtaleinnslag (f.eks. stemmeleverandør) er et produktvalg for rikere råmateriale; det som faktisk indekseres, er kuraterte dokumenter via admin-pipelinen. Faglitteratur om RAG dekker indeksering, chunking, retrieval og evaluering — ikke valg av stemme-UI.',
-          'Primærkilder (arXiv): https://arxiv.org/abs/2407.01219 (Wang m.fl., EMNLP 2024), https://arxiv.org/abs/2312.10997 (Gao m.fl., oversikt, des. 2023). Menneskeforankret eval: https://arxiv.org/abs/2503.09902, https://arxiv.org/abs/2504.14891. Utdypet flyt og praksislenker står i rot-README og på siden «Videre arbeid».',
+          'Primærkilder (arXiv): https://arxiv.org/abs/2407.01219 (Wang m.fl., EMNLP 2024), https://arxiv.org/abs/2312.10997 (Gao m.fl., oversikt, des. 2023). Menneskeforankret eval: https://arxiv.org/abs/2503.09902, https://arxiv.org/abs/2504.14891. Utdypet flyt og praksislenker står i rot-README og i seksjonen «Videre arbeid» på denne siden.',
         ],
         icon: Database,
         category: 'ai',
@@ -390,7 +404,7 @@ const sections = computed<Section[]>(() => {
         'At retrieval time the user question is expanded into Norwegian and English so documents in either language are easier to surface.',
         'PostgreSQL with pgvector runs in Docker alongside the rest of the stack, which makes it easy to spin up a consistent environment locally and in deployment.',
         'Capture → curate → ingest → verify: optional conversational capture (for example a voice vendor) is a product choice for richer raw material; what gets indexed is curated content through the admin pipeline. RAG literature covers indexing, chunking, retrieval, and evaluation—not the voice UI choice.',
-        'Primary arXiv sources: https://arxiv.org/abs/2407.01219 (Wang et al., EMNLP 2024), https://arxiv.org/abs/2312.10997 (Gao et al., survey, Dec 2023). Human-grounded evaluation: https://arxiv.org/abs/2503.09902, https://arxiv.org/abs/2504.14891. The root README and the Future work page spell out the flow and practice links.',
+        'Primary arXiv sources: https://arxiv.org/abs/2407.01219 (Wang et al., EMNLP 2024), https://arxiv.org/abs/2312.10997 (Gao et al., survey, Dec 2023). Human-grounded evaluation: https://arxiv.org/abs/2503.09902, https://arxiv.org/abs/2504.14891. The root README and the Future work section on this page spell out the flow and practice links.',
       ],
       icon: Database,
       category: 'ai',
@@ -463,7 +477,7 @@ function sectionIconWrapClass(cat: Category): string {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50 pt-20">
+  <div class="project-tech-stack-root">
     <div class="max-w-5xl mx-auto px-4 py-10 lg:py-14">
       <header
         class="relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 p-8 shadow-lg shadow-slate-900/5 backdrop-blur-sm lg:p-10"
@@ -509,12 +523,13 @@ function sectionIconWrapClass(cat: Category): string {
                 {{ contextParagraph }}
               </p>
               <p>
-                <RouterLink
-                  to="/bachelor"
+                <button
+                  type="button"
                   class="text-sm font-medium text-blue-700 underline underline-offset-2 hover:text-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+                  @click="onReadMoreBachelor"
                 >
                   {{ contextLinkLabel }}
-                </RouterLink>
+                </button>
               </p>
             </div>
           </div>
@@ -660,12 +675,6 @@ function sectionIconWrapClass(cat: Category): string {
             class="inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
           >
             {{ footerHome }}
-          </RouterLink>
-          <RouterLink
-            to="/bachelor"
-            class="inline-flex items-center justify-center rounded-lg border border-blue-200 bg-blue-50 px-5 py-2.5 text-sm font-semibold text-blue-900 shadow-sm transition hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
-          >
-            {{ footerBachelor }}
           </RouterLink>
         </div>
       </footer>

--- a/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
+++ b/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
@@ -14,9 +14,8 @@ describe('application router (index)', () => {
 		expect(names.has('home')).toBe(true)
 		expect(names.has('chat')).toBe(true)
 		expect(names.has('privacy-policy')).toBe(true)
-		expect(names.has('future-work')).toBe(true)
+		expect(names.has('project')).toBe(true)
 		expect(names.has('career')).toBe(true)
-		expect(names.has('bachelor')).toBe(true)
 		expect(names.has('admin-tools')).toBe(true)
 		expect(names.has('admin-experiments')).toBe(true)
 	})
@@ -27,22 +26,32 @@ describe('application router (index)', () => {
 		expect(router.currentRoute.value.name).toBe('privacy-policy')
 	})
 
-	it('navigates to lazy-loaded bachelor route', async () => {
+	it('redirects legacy bachelor path to project with bachelor hash', async () => {
 		const router = createPortfolioRouter({ useMemoryHistory: true })
 		await router.push('/bachelor')
-		expect(router.currentRoute.value.name).toBe('bachelor')
+		expect(router.currentRoute.value.path).toBe('/project')
+		expect(router.currentRoute.value.hash).toBe('#bachelor')
+		expect(router.currentRoute.value.name).toBe('project')
 	})
 
-	it('navigates to lazy-loaded tech-stack route', async () => {
+	it('redirects legacy tech-stack path to project with tech-stack hash', async () => {
 		const router = createPortfolioRouter({ useMemoryHistory: true })
 		await router.push('/tech-stack')
-		expect(router.currentRoute.value.name).toBe('tech-stack')
+		expect(router.currentRoute.value.path).toBe('/project')
+		expect(router.currentRoute.value.hash).toBe('#tech-stack')
 	})
 
-	it('navigates to lazy-loaded future-work route', async () => {
+	it('redirects legacy future-work path to project with future-work hash', async () => {
 		const router = createPortfolioRouter({ useMemoryHistory: true })
 		await router.push('/future-work')
-		expect(router.currentRoute.value.name).toBe('future-work')
+		expect(router.currentRoute.value.path).toBe('/project')
+		expect(router.currentRoute.value.hash).toBe('#future-work')
+	})
+
+	it('navigates to lazy-loaded project route', async () => {
+		const router = createPortfolioRouter({ useMemoryHistory: true })
+		await router.push('/project')
+		expect(router.currentRoute.value.name).toBe('project')
 	})
 
 	it('redirects legacy work-experience and education paths to career', async () => {

--- a/frontend/homepage/src/router/createPortfolioRouter.ts
+++ b/frontend/homepage/src/router/createPortfolioRouter.ts
@@ -49,14 +49,17 @@ export function createPortfolioRouter(opts?: PortfolioRouterOptions): Router {
 				redirect: '/career',
 			},
 			{
+				path: '/project',
+				name: 'project',
+				component: () => import('../views/ProjectPageView.vue'),
+			},
+			{
 				path: '/bachelor',
-				name: 'bachelor',
-				component: () => import('../views/BachelorView.vue'),
+				redirect: { path: '/project', hash: '#bachelor' },
 			},
 			{
 				path: '/tech-stack',
-				name: 'tech-stack',
-				component: () => import('../views/TechStackView.vue'),
+				redirect: { path: '/project', hash: '#tech-stack' },
 			},
 			{
 				path: '/feedback',
@@ -75,8 +78,7 @@ export function createPortfolioRouter(opts?: PortfolioRouterOptions): Router {
 			},
 			{
 				path: '/future-work',
-				name: 'future-work',
-				component: () => import('../views/FutureWorkView.vue'),
+				redirect: { path: '/project', hash: '#future-work' },
 			},
 			{
 				path: '/admin/tools',

--- a/frontend/homepage/src/stores/__tests__/model.spec.ts
+++ b/frontend/homepage/src/stores/__tests__/model.spec.ts
@@ -17,6 +17,13 @@ describe('isChatProvider', () => {
   })
 })
 
+function setSessionAuth() {
+  sessionStorage.setItem(
+    'auth',
+    JSON.stringify({ username: 'u', role: 'USER', basicToken: 'dGVzdA==' }),
+  )
+}
+
 describe('useChatModelStore', () => {
   beforeEach(() => {
     sessionStorage.clear()
@@ -121,7 +128,7 @@ describe('useChatModelStore', () => {
     expect(store.selectedModelId).toBe('only')
   })
 
-  it('applyInitialSelection prefers FAST when multiple models and no storage', () => {
+  it('applyInitialSelection prefers FAST when anonymous and multiple models', () => {
     const store = useChatModelStore()
     store.$patch({
       models: [
@@ -143,6 +150,29 @@ describe('useChatModelStore', () => {
     expect(store.selectedModelId).toBe('f')
   })
 
+  it('applyInitialSelection prefers REASONING when signed in and multiple models', () => {
+    setSessionAuth()
+    const store = useChatModelStore()
+    store.$patch({
+      models: [
+        {
+          id: 'r',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'R',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'f',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'F',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+    })
+    store.applyInitialSelection()
+    expect(store.selectedModelId).toBe('r')
+  })
+
   it('selectFirstForProvider sets first model id for provider', () => {
     const store = useChatModelStore()
     store.$patch({
@@ -155,7 +185,7 @@ describe('useChatModelStore', () => {
     expect(store.selectedModelId).toBe('o2')
   })
 
-  it('selectFirstForProvider prefers FAST when reasoning model is listed first', () => {
+  it('selectFirstForProvider prefers FAST when anonymous and reasoning is listed first', () => {
     const store = useChatModelStore()
     store.$patch({
       models: [
@@ -175,6 +205,29 @@ describe('useChatModelStore', () => {
     })
     store.selectFirstForProvider(ChatModelOptionProvider.OPENAI)
     expect(store.selectedModelId).toBe('fast')
+  })
+
+  it('selectFirstForProvider prefers REASONING when signed in', () => {
+    setSessionAuth()
+    const store = useChatModelStore()
+    store.$patch({
+      models: [
+        {
+          id: 'slow',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'S',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'fast',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'F',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+    })
+    store.selectFirstForProvider(ChatModelOptionProvider.OPENAI)
+    expect(store.selectedModelId).toBe('slow')
   })
 
   it('selectFirstForProvider does nothing when list empty', () => {
@@ -226,6 +279,31 @@ describe('useChatModelStore', () => {
     await Promise.all([a, b])
     expect(store.models).toHaveLength(2)
     expect(store.selectedModelId).toBe('x')
+  })
+
+  it('ensureModelsLoaded prefers REASONING when signed in', async () => {
+    setSessionAuth()
+    vi.mocked(listChatModels).mockResolvedValue({
+      status: 200,
+      data: [
+        {
+          id: 'y',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'Y',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'x',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'X',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+      headers: new Headers(),
+    })
+    const store = useChatModelStore()
+    await store.ensureModelsLoaded()
+    expect(store.selectedModelId).toBe('y')
   })
 
   it('ensureModelsLoaded skips body when status not 200', async () => {

--- a/frontend/homepage/src/stores/model.ts
+++ b/frontend/homepage/src/stores/model.ts
@@ -5,6 +5,7 @@ import {
   ChatModelOptionProvider,
   ChatModelTag,
 } from '@/api/generated/portfolio'
+import { useAuthStore } from '@/stores/auth'
 
 // Mirrors backend allow-list: only models returned by GET /chat/models are selectable in the UI.
 const MODEL_STORAGE_KEY = 'chatSelectedModel'
@@ -61,11 +62,14 @@ export const useChatModelStore = defineStore('chatModel', {
       this.persistModelId()
     },
 
-    /** Switch UI to a provider and pick the first FAST model when available, else first listed. */
+    /** Switch UI to a provider: signed-in users prefer REASONING; anonymous prefer FAST (premium gate). */
     selectFirstForProvider(p: ChatProvider) {
       const list = this.modelsForProvider(p)
-      const fast = list.find((m) => m.tags?.includes(ChatModelTag.FAST))
-      const pick = fast ?? list[0]
+      useAuthStore().restore()
+      const authed = Boolean(useAuthStore().basicToken)
+      const pick = authed
+        ? list.find((m) => m.tags?.includes(ChatModelTag.REASONING)) ?? list[0]
+        : list.find((m) => m.tags?.includes(ChatModelTag.FAST)) ?? list[0]
       if (pick?.id) {
         this.setSelectedModelId(pick.id)
       }
@@ -82,8 +86,11 @@ export const useChatModelStore = defineStore('chatModel', {
         // ignore
       }
       if (this.models.length > 0) {
-        const fast = this.models.find((m) => m.tags?.includes(ChatModelTag.FAST))
-        const first = fast ?? this.models[0]
+        useAuthStore().restore()
+        const authed = Boolean(useAuthStore().basicToken)
+        const first = authed
+          ? this.models.find((m) => m.tags?.includes(ChatModelTag.REASONING)) ?? this.models[0]
+          : this.models.find((m) => m.tags?.includes(ChatModelTag.FAST)) ?? this.models[0]
         if (first.id) {
           this.selectedModelId = first.id
           this.persistModelId()

--- a/frontend/homepage/src/views/ChatView.vue
+++ b/frontend/homepage/src/views/ChatView.vue
@@ -89,15 +89,15 @@ const popupCopy = computed(() =>
     ? {
         title: 'Porteføljen er i aktiv tilpasning',
         body: 'Denne chatten og kunnskapsgrunnlaget justeres fortløpende ut fra det jeg lærer i bacheloroppgaven. Svarene blir derfor gradvis mer presise over tid.',
-        recommendation: 'Vil du se hva som tilpasses nå? Besøk bachelor-siden for kontekst og status.',
-        bachelorCta: 'Se bachelorkontekst og status',
+        recommendation: 'Vil du se hva som tilpasses nå? Besøk prosjektsiden for kontekst og status.',
+        bachelorCta: 'Åpne prosjektsiden',
         dismiss: 'Forstått',
       }
     : {
         title: 'The portfolio is being actively adapted',
         body: "This chat and its knowledge base are being continuously adjusted based on what I'm learning in my bachelor's thesis. Replies will therefore become progressively more precise over time.",
-        recommendation: 'Want to see what is currently being adapted? Visit the bachelor page for context and status.',
-        bachelorCta: 'See bachelor context and status',
+        recommendation: 'Want to see what is currently being adapted? Visit the project page for context and status.',
+        bachelorCta: 'Open the project page',
         dismiss: 'Got it',
       },
 )
@@ -341,7 +341,7 @@ onMounted(async () => {
         </p>
         <DialogFooter class="flex-col gap-2 sm:flex-row sm:justify-end">
           <Button as-child variant="outline">
-            <RouterLink :to="{ name: 'bachelor' }">{{ popupCopy.bachelorCta }}</RouterLink>
+            <RouterLink :to="{ name: 'project', hash: '#bachelor' }">{{ popupCopy.bachelorCta }}</RouterLink>
           </Button>
           <Button type="button" @click="dismissInfoPopup">{{ popupCopy.dismiss }}</Button>
         </DialogFooter>

--- a/frontend/homepage/src/views/HomeView.vue
+++ b/frontend/homepage/src/views/HomeView.vue
@@ -250,7 +250,7 @@ function submitQuick() {
         </section>
 
         <RouterLink
-          to="/future-work"
+          to="/project#future-work"
           class="group flex w-full max-w-2xl items-center justify-center gap-1 rounded-xl border border-blue-200/80 bg-white/90 px-4 py-3 text-center text-sm font-medium text-blue-800 shadow-sm backdrop-blur-sm transition-all duration-300 hover:border-blue-300 hover:bg-white hover:shadow-md hover:shadow-blue-500/10"
           :aria-label="futureWorkHomeLink.ariaLabel"
         >

--- a/frontend/homepage/src/views/ProjectPageView.vue
+++ b/frontend/homepage/src/views/ProjectPageView.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import { computed, nextTick, provide, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { ChevronDown, FolderKanban } from 'lucide-vue-next'
+import { useLangStore } from '@/stores/lang'
+import ProjectTechStackSection from '@/components/project/ProjectTechStackSection.vue'
+import ProjectBachelorSection from '@/components/project/ProjectBachelorSection.vue'
+import ProjectFutureWorkSection from '@/components/project/ProjectFutureWorkSection.vue'
+
+const langStore = useLangStore()
+const route = useRoute()
+const isNo = computed(() => langStore.language === 'no')
+
+const hero = computed(() =>
+	isNo.value
+		? {
+				title: 'Prosjektet',
+				lead:
+					'Bacheloroppgaven (2026), teknologistakk og videre arbeid samlet på én side. Utvid seksjonene under for detaljer.',
+			}
+		: {
+				title: 'The project',
+				lead:
+					"Bachelor's thesis (2026), tech stack, and future work in one place. Expand the sections below for details.",
+			},
+)
+
+const labels = computed(() =>
+	isNo.value
+		? {
+				tech: 'Teknologistakk',
+				bachelor: 'Bacheloroppgaven',
+				future: 'Videre arbeid',
+			}
+		: {
+				tech: 'Tech stack',
+				bachelor: "Bachelor's thesis",
+				future: 'Future work',
+			},
+)
+
+const techOpen = ref(false)
+const bachelorOpen = ref(false)
+const futureOpen = ref(false)
+
+function scrollToSection(elementId: string) {
+	nextTick(() => {
+		document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+	})
+}
+
+function toggleTech() {
+	techOpen.value = !techOpen.value
+	if (techOpen.value) scrollToSection('accordion-tech-stack')
+}
+function toggleBachelor() {
+	bachelorOpen.value = !bachelorOpen.value
+	if (bachelorOpen.value) scrollToSection('accordion-bachelor')
+}
+function toggleFuture() {
+	futureOpen.value = !futureOpen.value
+	if (futureOpen.value) scrollToSection('accordion-future-work')
+}
+
+function openTech() {
+	techOpen.value = true
+	scrollToSection('accordion-tech-stack')
+}
+function openBachelor() {
+	bachelorOpen.value = true
+	scrollToSection('accordion-bachelor')
+}
+function openFutureWork() {
+	futureOpen.value = true
+	scrollToSection('accordion-future-work')
+}
+
+provide('projectSectionNav', {
+	openBachelor: openBachelor,
+})
+
+function applyRouteHash(hash: string | undefined) {
+	if (!hash) return
+	const h = hash.replace(/^#/, '').toLowerCase()
+	if (h === 'tech-stack') openTech()
+	else if (h === 'bachelor') openBachelor()
+	else if (h === 'future-work') openFutureWork()
+}
+
+watch(
+	() => route.hash,
+	(h) => {
+		applyRouteHash(h)
+	},
+	{ immediate: true },
+)
+</script>
+
+<template>
+	<main
+		class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 relative pb-20 pt-20"
+		aria-labelledby="project-page-title"
+	>
+		<div class="absolute inset-0 pointer-events-none">
+			<div
+				class="absolute top-0 left-0 w-full h-full"
+				style="
+					background: radial-gradient(circle at 20% 80%, rgba(59, 130, 246, 0.08) 0%, transparent 50%),
+						radial-gradient(circle at 80% 20%, rgba(37, 99, 235, 0.08) 0%, transparent 50%),
+						radial-gradient(circle at 50% 50%, rgba(96, 165, 250, 0.05) 0%, transparent 70%);
+				"
+			></div>
+		</div>
+
+		<div class="relative z-10 mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+			<div
+				v-motion
+				:initial="{ opacity: 0, y: 24 }"
+				:visible-once="{ opacity: 1, y: 0, transition: { duration: 550 } }"
+				class="mb-10 text-center"
+			>
+				<div
+					class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-700 text-white shadow-lg shadow-blue-500/25 mb-5"
+				>
+					<FolderKanban class="w-8 h-8" aria-hidden="true" />
+				</div>
+				<h1
+					id="project-page-title"
+					class="text-3xl sm:text-4xl font-bold mb-3 bg-gradient-to-r from-blue-600 via-blue-700 to-blue-800 bg-clip-text text-transparent"
+				>
+					{{ hero.title }}
+				</h1>
+				<p class="text-gray-600 max-w-3xl mx-auto leading-relaxed text-sm sm:text-base">
+					{{ hero.lead }}
+				</p>
+			</div>
+
+			<div class="space-y-4">
+				<!-- Tech stack -->
+				<section
+					id="accordion-tech-stack"
+					class="rounded-2xl border border-slate-200/80 bg-white/90 shadow-lg shadow-slate-900/5 backdrop-blur-sm overflow-hidden"
+				>
+					<button
+						type="button"
+						class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition hover:bg-slate-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600"
+						:aria-expanded="techOpen"
+						aria-controls="panel-tech-stack"
+						id="section-tech-stack"
+						@click="toggleTech"
+					>
+						<span class="text-lg font-semibold text-slate-900">{{ labels.tech }}</span>
+						<ChevronDown
+							class="h-5 w-5 shrink-0 text-slate-500 transition-transform duration-200"
+							:class="{ 'rotate-180': techOpen }"
+							aria-hidden="true"
+						/>
+					</button>
+					<div
+						v-show="techOpen"
+						id="panel-tech-stack"
+						role="region"
+						:aria-labelledby="'section-tech-stack'"
+						class="border-t border-slate-200/80"
+					>
+						<ProjectTechStackSection />
+					</div>
+				</section>
+
+				<!-- Bachelor -->
+				<section
+					id="accordion-bachelor"
+					class="rounded-2xl border border-slate-200/80 bg-white/90 shadow-lg shadow-slate-900/5 backdrop-blur-sm overflow-hidden"
+				>
+					<button
+						type="button"
+						class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition hover:bg-slate-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600"
+						:aria-expanded="bachelorOpen"
+						aria-controls="panel-bachelor"
+						id="section-bachelor"
+						@click="toggleBachelor"
+					>
+						<span class="text-lg font-semibold text-slate-900">{{ labels.bachelor }}</span>
+						<ChevronDown
+							class="h-5 w-5 shrink-0 text-slate-500 transition-transform duration-200"
+							:class="{ 'rotate-180': bachelorOpen }"
+							aria-hidden="true"
+						/>
+					</button>
+					<div
+						v-show="bachelorOpen"
+						id="panel-bachelor"
+						role="region"
+						:aria-labelledby="'section-bachelor'"
+						class="border-t border-slate-200/80"
+					>
+						<ProjectBachelorSection />
+					</div>
+				</section>
+
+				<!-- Future work -->
+				<section
+					id="accordion-future-work"
+					class="rounded-2xl border border-slate-200/80 bg-white/90 shadow-lg shadow-slate-900/5 backdrop-blur-sm overflow-hidden"
+				>
+					<button
+						type="button"
+						class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition hover:bg-slate-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600"
+						:aria-expanded="futureOpen"
+						aria-controls="panel-future-work"
+						id="section-future-work"
+						@click="toggleFuture"
+					>
+						<span class="text-lg font-semibold text-slate-900">{{ labels.future }}</span>
+						<ChevronDown
+							class="h-5 w-5 shrink-0 text-slate-500 transition-transform duration-200"
+							:class="{ 'rotate-180': futureOpen }"
+							aria-hidden="true"
+						/>
+					</button>
+					<div
+						v-show="futureOpen"
+						id="panel-future-work"
+						role="region"
+						:aria-labelledby="'section-future-work'"
+						class="border-t border-slate-200/80"
+					>
+						<ProjectFutureWorkSection />
+					</div>
+				</section>
+			</div>
+		</div>
+	</main>
+</template>

--- a/frontend/homepage/src/views/__tests__/ChatView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/ChatView.spec.ts
@@ -30,7 +30,7 @@ describe('ChatView', () => {
       history: createMemoryHistory(),
       routes: [
         { path: '/', name: 'home', component: HomeStub },
-        { path: '/bachelor', name: 'bachelor', component: HomeStub },
+        { path: '/project', name: 'project', component: HomeStub },
         { path: '/chat', name: 'chat', component: ChatView },
       ],
     })
@@ -86,7 +86,7 @@ describe('ChatView', () => {
     return { wrapper, router, pinia }
   }
 
-  it('shows model FAST / Reasoning labels and defaults to a FAST model', async () => {
+  it('shows model FAST / Reasoning labels and defaults to a FAST model when anonymous', async () => {
     vi.mocked(listChatModels).mockResolvedValue({
       status: 200,
       data: [
@@ -113,6 +113,35 @@ describe('ChatView', () => {
     expect(opts.some((o) => o.text().includes('Fast'))).toBe(true)
     expect(opts.some((o) => o.text().includes('Reasoning'))).toBe(true)
     expect((sel.element as HTMLSelectElement).value).toBe('gpt-5.4-mini')
+  })
+
+  it('defaults to a REASONING model when signed in', async () => {
+    sessionStorage.setItem(
+      'auth',
+      JSON.stringify({ username: 'u', role: 'USER', basicToken: 'dGVzdA==' }),
+    )
+    vi.mocked(listChatModels).mockResolvedValue({
+      status: 200,
+      data: [
+        {
+          id: 'gpt-5.4',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'GPT-5.4',
+          tags: [ChatModelTag.REASONING],
+        },
+        {
+          id: 'gpt-5.4-mini',
+          provider: ChatModelOptionProvider.OPENAI,
+          label: 'GPT-5.4 mini',
+          tags: [ChatModelTag.FAST],
+        },
+      ],
+      headers: new Headers(),
+    })
+    const { wrapper } = await mountChat({})
+    await flushPromises()
+    const sel = wrapper.find('#chat-model-select')
+    expect((sel.element as HTMLSelectElement).value).toBe('gpt-5.4')
   })
 
   it('shows English error when prompt exceeds max length', async () => {

--- a/frontend/homepage/src/views/__tests__/HomeView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/HomeView.spec.ts
@@ -19,7 +19,7 @@ describe('HomeView', () => {
 				{ path: '/', name: 'home', component: HomeView },
 				{ path: '/chat', name: 'chat', component: { template: '<div>chat</div>' } },
 				{ path: '/feedback', name: 'feedback', component: { template: '<div>feedback</div>' } },
-				{ path: '/future-work', name: 'future-work', component: { template: '<div>future-work</div>' } },
+				{ path: '/project', name: 'project', component: { template: '<div>project</div>' } },
 			],
 		})
 	}
@@ -161,7 +161,7 @@ describe('HomeView', () => {
 			},
 		})
 		await flushPromises()
-		const futureLink = wrapper.get('a[href="/future-work"]')
+		const futureLink = wrapper.get('a[href="/project#future-work"]')
 		expect(futureLink.text()).toContain('Future work and improvements')
 	})
 })

--- a/frontend/homepage/src/views/__tests__/portfolioViews.spec.ts
+++ b/frontend/homepage/src/views/__tests__/portfolioViews.spec.ts
@@ -3,14 +3,13 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { MotionPlugin } from '@vueuse/motion'
 import type { Component } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
 import AboutView from '../AboutView.vue'
-import TechStackView from '../TechStackView.vue'
 import PrivacyPolicyView from '../PrivacyPolicyView.vue'
 import { useLangStore } from '@/stores/lang'
 import ProjectsView from '../ProjectsView.vue'
 import CareerView from '../CareerView.vue'
-import FutureWorkView from '../FutureWorkView.vue'
-import BachelorView from '../BachelorView.vue'
+import ProjectPageView from '../ProjectPageView.vue'
 
 describe('portfolio views (smoke)', () => {
 	function mountView(component: Component) {
@@ -25,47 +24,83 @@ describe('portfolio views (smoke)', () => {
 
 	const routerLinkStub = { template: '<a><slot /></a>' }
 
+	function makeProjectRouter() {
+		return createRouter({
+			history: createMemoryHistory(),
+			routes: [
+				{ path: '/', name: 'home', component: { template: '<div />' } },
+				{ path: '/chat', name: 'chat', component: { template: '<div />' } },
+				{ path: '/projects', name: 'projects', component: { template: '<div />' } },
+				{ path: '/project', name: 'project', component: ProjectPageView },
+			],
+		})
+	}
+
+	function mountProjectPage() {
+		const pinia = createPinia()
+		setActivePinia(pinia)
+		useLangStore().setLanguage('en')
+		const router = makeProjectRouter()
+		return mount(ProjectPageView, {
+			global: {
+				plugins: [pinia, router, MotionPlugin],
+				stubs: { RouterLink: routerLinkStub },
+			},
+		})
+	}
+
 	it('renders AboutView', () => {
 		const wrapper = mountView(AboutView)
 		expect(wrapper.text()).toContain('about page')
 	})
 
 	it(
-		'renders TechStackView in English by default',
+		'renders ProjectPageView in English with section headers',
 		async () => {
-			const pinia = createPinia()
-			setActivePinia(pinia)
-			useLangStore().setLanguage('en')
-			const wrapper = mount(TechStackView, {
-				global: {
-					plugins: [pinia, MotionPlugin],
-					stubs: { RouterLink: routerLinkStub },
-				},
-			})
+			const wrapper = mountProjectPage()
 			await flushPromises()
+			expect(wrapper.text()).toContain('The project')
 			expect(wrapper.text()).toContain('Tech stack')
-			expect(wrapper.text()).toMatch(/Spring AI|Backend/i)
+			expect(wrapper.text()).toContain("Bachelor's thesis")
+			expect(wrapper.text()).toContain('Future work')
 		},
-		15_000,
+		20_000,
 	)
 
 	it(
-		'renders TechStackView in Norwegian when language is no',
+		'renders ProjectPageView in Norwegian when language is no',
 		async () => {
 			const pinia = createPinia()
 			setActivePinia(pinia)
 			useLangStore().setLanguage('no')
-			const wrapper = mount(TechStackView, {
+			const router = makeProjectRouter()
+			const wrapper = mount(ProjectPageView, {
 				global: {
-					plugins: [pinia, MotionPlugin],
+					plugins: [pinia, router, MotionPlugin],
 					stubs: { RouterLink: routerLinkStub },
 				},
 			})
 			await flushPromises()
+			expect(wrapper.text()).toContain('Prosjektet')
 			expect(wrapper.text()).toContain('Teknologistakk')
+			expect(wrapper.text()).toContain('Bacheloroppgaven')
+			expect(wrapper.text()).toContain('Videre arbeid')
+		},
+		20_000,
+	)
+
+	it(
+		'expands tech stack accordion and shows stack content',
+		async () => {
+			const wrapper = mountProjectPage()
+			await flushPromises()
+			const techBtn = wrapper.find('#section-tech-stack')
+			expect(techBtn.exists()).toBe(true)
+			await techBtn.trigger('click')
+			await flushPromises()
 			expect(wrapper.text()).toMatch(/Spring AI|Backend/i)
 		},
-		15_000,
+		25_000,
 	)
 
 	it('renders PrivacyPolicyView in English by default', async () => {
@@ -102,57 +137,45 @@ describe('portfolio views (smoke)', () => {
 		expect(wrapper.text()).toMatch(/Courses|Emner/)
 	})
 
-  it('renders CareerView in Norwegian with translated section labels', async () => {
-    const pinia = createPinia()
-    setActivePinia(pinia)
-    useLangStore().setLanguage('no')
-    const wrapper = mount(CareerView, { global: { plugins: [pinia, MotionPlugin] } })
-    await flushPromises()
-    expect(wrapper.text()).toContain('Erfaring og utdanning')
-    expect(wrapper.text()).toContain('Arbeidserfaring')
-    expect(wrapper.text()).toContain('Utdanning')
-    expect(wrapper.text()).toContain('Emner')
-    expect(wrapper.text()).toMatch(/studiepoeng|Karakter/)
-  })
+	it('renders CareerView in Norwegian with translated section labels', async () => {
+		const pinia = createPinia()
+		setActivePinia(pinia)
+		useLangStore().setLanguage('no')
+		const wrapper = mount(CareerView, { global: { plugins: [pinia, MotionPlugin] } })
+		await flushPromises()
+		expect(wrapper.text()).toContain('Erfaring og utdanning')
+		expect(wrapper.text()).toContain('Arbeidserfaring')
+		expect(wrapper.text()).toContain('Utdanning')
+		expect(wrapper.text()).toContain('Emner')
+		expect(wrapper.text()).toMatch(/studiepoeng|Karakter/)
+	})
 
-  it('renders FutureWorkView in English with references', async () => {
-    const wrapper = mountView(FutureWorkView)
-    await flushPromises()
-    expect(wrapper.text()).toContain('Future work and improvements')
-    expect(wrapper.text()).toContain('being actively adapted')
-    expect(wrapper.text()).toContain('References (arXiv)')
-    const links = wrapper.findAll('a[href^="https://arxiv.org/abs/"]')
-    expect(links.length).toBeGreaterThan(0)
-  })
+	it(
+		'renders future work copy when future accordion is expanded',
+		async () => {
+			const wrapper = mountProjectPage()
+			await flushPromises()
+			await wrapper.find('#section-future-work').trigger('click')
+			await flushPromises()
+			expect(wrapper.text()).toContain('Future work and improvements')
+			expect(wrapper.text()).toContain('References (arXiv)')
+			const links = wrapper.findAll('a[href^="https://arxiv.org/abs/"]')
+			expect(links.length).toBeGreaterThan(0)
+		},
+		25_000,
+	)
 
-  it('renders FutureWorkView in Norwegian with translated copy', async () => {
-    const pinia = createPinia()
-    setActivePinia(pinia)
-    useLangStore().setLanguage('no')
-    const wrapper = mount(FutureWorkView, { global: { plugins: [pinia, MotionPlugin] } })
-    await flushPromises()
-    expect(wrapper.text()).toContain('Videre arbeid og forbedringer')
-    expect(wrapper.text()).toContain('under aktiv tilpasning')
-    expect(wrapper.text()).toContain('Referanser (arXiv)')
-    expect(wrapper.text()).toContain('ElevenLabs stemmeagent: samle inn, så prosesserer jeg')
-  })
-
-  it('renders BachelorView in English with active adaptation messaging', async () => {
-    const wrapper = mountView(BachelorView)
-    await flushPromises()
-    expect(wrapper.text()).toContain("Bachelor's thesis")
-    expect(wrapper.text()).toContain('active work in progress')
-    expect(wrapper.text()).toContain('shaping the portfolio now')
-  })
-
-  it('renders BachelorView in Norwegian with active adaptation messaging', async () => {
-    const pinia = createPinia()
-    setActivePinia(pinia)
-    useLangStore().setLanguage('no')
-    const wrapper = mount(BachelorView, { global: { plugins: [pinia, MotionPlugin] } })
-    await flushPromises()
-    expect(wrapper.text()).toContain('Bacheloroppgaven')
-    expect(wrapper.text()).toContain('aktivt arbeid i utvikling')
-    expect(wrapper.text()).toContain('styrer porteføljen nå')
-  })
+	it(
+		'renders bachelor copy when bachelor accordion is expanded',
+		async () => {
+			const wrapper = mountProjectPage()
+			await flushPromises()
+			await wrapper.find('#section-bachelor').trigger('click')
+			await flushPromises()
+			expect(wrapper.text()).toContain("Bachelor's thesis")
+			expect(wrapper.text()).toContain('active work in progress')
+			expect(wrapper.text()).toContain('shaping the portfolio now')
+		},
+		25_000,
+	)
 })


### PR DESCRIPTION
## Summary

Single combined PR (project UI merge plus model validation / E2E work on this branch).

- **Portfolio navigation:** Bachelor, Tech stack, and Future work are merged into a single **The project** / **Prosjektet** page at `/project`, with accordion sections and hash deep-links. Legacy paths redirect to `/project` with the appropriate hash. Navbar is reduced to four items; Home and Chat copy link to the new page where relevant.
- **Backend:** Updates to question handling / configuration and tests (see changed `QuestionController`, `application*.yaml`, `PortfolioApplicationTests`, `QuestionControllerTest`).
- **Frontend models & E2E:** Chat model store and unit tests updated; Cypress `chat-models` spec adjusted.

## Test plan

- [x] `frontend/homepage`: `npx vitest run`
- [x] `frontend/homepage`: `npm run type-check`
- [x] Backend: `.\mvnw.cmd test` (Windows)
- [ ] Optional: Cypress chat-models (or full e2e) if configured in CI

## Notes

- README path for on-site "Future work" copy updated to point at `ProjectPageView` / `ProjectFutureWorkSection`.
