### PR TITLE
test: coverage strategy (backend IT, Vitest, Cypress, CI)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 # Green means: backend ./mvnw verify (tests + JaCoCo check); frontend npm ci,
 #   type-check, lint:ci (eslint, no autofix), unit tests with coverage thresholds.
 # Semgrep runs in a separate workflow (.github/workflows/semgrep.yml).
-# Cypress e2e is intentionally not in this gate (run locally or add a manual/nightly workflow).
+# Cypress e2e is not in the PR gate; it runs weekly (Sunday 07:00 UTC) and on manual dispatch.
 name: Tests
 
 on:
@@ -18,9 +18,16 @@ on:
         required: false
         type: boolean
         default: false
+      run_frontend_e2e:
+        description: 'Run Cypress E2E (preview build + headless browser)'
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Weekly Sunday 06:00 UTC — validate model IDs are still accepted by providers.
     - cron: '0 6 * * 0'
+    # Weekly Sunday 07:00 UTC — Cypress E2E against production bundle (no backend required for stubbed specs).
+    - cron: '0 7 * * 0'
 
 permissions:
   contents: read
@@ -90,9 +97,41 @@ jobs:
             frontend/homepage/coverage
           if-no-files-found: ignore
 
+  frontend-e2e:
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '0 7 * * 0') ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_frontend_e2e)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: frontend/homepage
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/homepage/package-lock.json
+      - name: Install dependencies (includes Cypress binary)
+        run: npm ci
+      - name: Build production bundle
+        run: npm run build-only
+      - name: Cypress E2E
+        run: npm run test:e2e
+      - name: Upload Cypress videos on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-artifacts
+          path: |
+            frontend/homepage/cypress/videos
+            frontend/homepage/cypress/screenshots
+          if-no-files-found: ignore
+
   model-validation:
     if: >-
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 6 * * 0') ||
       (github.event_name == 'workflow_dispatch' && inputs.run_model_validation)
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -229,7 +229,12 @@
 										<limit>
 											<counter>LINE</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.80</minimum>
+											<minimum>0.82</minimum>
+										</limit>
+										<limit>
+											<counter>BRANCH</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.62</minimum>
 										</limit>
 									</limits>
 								</rule>

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerAdviceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerAdviceTest.java
@@ -1,0 +1,68 @@
+package com.kevinmazali.portfolio.controller;
+
+import com.kevinmazali.portfolio.MvcTestUserDetailsConfig;
+import com.kevinmazali.portfolio.config.SecurityConfig;
+import com.kevinmazali.portfolio.service.DocumentIngestionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@link WebMvcTest} slice for {@link DocumentPipelineControllerAdvice} mappings on
+ * {@link DocumentPipelineController} (503 + {@code ApiError} for ingestion I/O failures).
+ */
+@WebMvcTest(controllers = DocumentPipelineController.class)
+@Import({ SecurityConfig.class, MvcTestUserDetailsConfig.class, DocumentPipelineControllerAdvice.class })
+class DocumentPipelineControllerAdviceTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private DocumentIngestionService documentIngestionService;
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void illegalState_mapsTo503() throws Exception {
+    when(documentIngestionService.listDocuments())
+        .thenThrow(new IllegalStateException("Cannot access vector table public.vector_store: boom"));
+
+    mockMvc.perform(get("/admin/tools/documents"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.error").value(containsString("Cannot access vector table")));
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void resourceAccess_mapsTo503() throws Exception {
+    when(documentIngestionService.listDocuments())
+        .thenThrow(new ResourceAccessException("Connection refused"));
+
+    mockMvc.perform(get("/admin/tools/documents"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.error").value(containsString("Connection refused")));
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void restClientException_mapsTo503() throws Exception {
+    when(documentIngestionService.listDocuments())
+        .thenThrow(new RestClientException("Bad gateway from upstream"));
+
+    mockMvc.perform(get("/admin/tools/documents"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.error").value(containsString("Bad gateway from upstream")));
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/DocumentPipelineControllerTest.java
@@ -14,9 +14,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestClientException;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -91,39 +88,6 @@ class DocumentPipelineControllerTest {
 		mockMvc.perform(get("/admin/tools/documents"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$[0].documentId").value("id1"));
-	}
-
-	@Test
-	@WithMockUser(username = "admin", roles = "ADMIN")
-	void listReturns503WhenVectorTableInaccessible() throws Exception {
-		when(documentIngestionService.listDocuments())
-			.thenThrow(new IllegalStateException("Cannot access vector table public.vector_store: boom"));
-
-		mockMvc.perform(get("/admin/tools/documents"))
-			.andExpect(status().isServiceUnavailable())
-			.andExpect(jsonPath("$.error").value(containsString("Cannot access vector table")));
-	}
-
-	@Test
-	@WithMockUser(username = "admin", roles = "ADMIN")
-	void listReturns503OnRestClientFailure() throws Exception {
-		when(documentIngestionService.listDocuments())
-			.thenThrow(new ResourceAccessException("Connection refused"));
-
-		mockMvc.perform(get("/admin/tools/documents"))
-			.andExpect(status().isServiceUnavailable())
-			.andExpect(jsonPath("$.error").value(containsString("Connection refused")));
-	}
-
-	@Test
-	@WithMockUser(username = "admin", roles = "ADMIN")
-	void listReturns503OnGenericRestClientException() throws Exception {
-		when(documentIngestionService.listDocuments())
-			.thenThrow(new RestClientException("Bad gateway from upstream"));
-
-		mockMvc.perform(get("/admin/tools/documents"))
-			.andExpect(status().isServiceUnavailable())
-			.andExpect(jsonPath("$.error").value(containsString("Bad gateway from upstream")));
 	}
 
 	@Test

--- a/backend/src/test/java/com/kevinmazali/portfolio/exception/AiCircuitOpenExceptionTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/exception/AiCircuitOpenExceptionTest.java
@@ -1,0 +1,14 @@
+package com.kevinmazali.portfolio.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AiCircuitOpenExceptionTest {
+
+  @Test
+  void messageIsPreserved() {
+    AiCircuitOpenException ex = new AiCircuitOpenException("circuit open");
+    assertEquals("circuit open", ex.getMessage());
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/exception/BudgetExceededExceptionTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/exception/BudgetExceededExceptionTest.java
@@ -1,0 +1,14 @@
+package com.kevinmazali.portfolio.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BudgetExceededExceptionTest {
+
+  @Test
+  void messageIsPreserved() {
+    BudgetExceededException ex = new BudgetExceededException("daily cap reached");
+    assertEquals("daily cap reached", ex.getMessage());
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/repository/AiUsageRepositoryTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/repository/AiUsageRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.kevinmazali.portfolio.repository;
+
+import com.kevinmazali.portfolio.model.AiUsageRecord;
+import com.kevinmazali.portfolio.testsupport.VectorStoreTestConfiguration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@Import(VectorStoreTestConfiguration.class)
+@TestPropertySource(
+    properties = {
+        "spring.autoconfigure.exclude=org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreAutoConfiguration",
+        "spring.datasource.url=jdbc:h2:mem:aiusagerepo;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.ai.openai.api-key=test-placeholder-key-for-context-tests-only",
+        "spring.ai.openai.chat.enabled=true",
+        "spring.ai.anthropic.api-key=sk-ant-api03-test-placeholder-for-spring-context-only",
+        "portfolio.chat.default-model-id=gpt-5.5",
+        "server.port=0",
+    })
+class AiUsageRepositoryTest {
+
+  @Autowired
+  private AiUsageRepository repository;
+
+  @Test
+  void sumCostSince_filtersByUserAndTime() {
+    Instant base = Instant.parse("2026-01-15T12:00:00Z");
+    repository.save(row("alice", "gpt-1", base.minus(1, ChronoUnit.DAYS), "0.01"));
+    repository.save(row("alice", "gpt-1", base.minus(1, ChronoUnit.HOURS), "0.02"));
+    repository.save(row("bob", "gpt-1", base.minus(1, ChronoUnit.HOURS), "9.99"));
+
+    BigDecimal alice = repository.sumCostSince("alice", base.minus(2, ChronoUnit.DAYS));
+    assertThat(alice).isEqualByComparingTo("0.03");
+
+    BigDecimal global = repository.sumGlobalCostSince(base.minus(2, ChronoUnit.DAYS));
+    assertThat(global).isEqualByComparingTo("10.02");
+  }
+
+  @Test
+  void sumCostBetween_respectsWindow() {
+    Instant from = Instant.parse("2026-02-01T00:00:00Z");
+    Instant to = Instant.parse("2026-02-02T00:00:00Z");
+    repository.save(row("u", "gpt-1", from.plus(1, ChronoUnit.HOURS), "1.00"));
+    repository.save(row("u", "gpt-1", to.minus(1, ChronoUnit.SECONDS), "2.00"));
+    repository.save(row("u", "gpt-1", to, "99.00"));
+
+    BigDecimal sum = repository.sumCostBetween("u", from, to);
+    assertThat(sum).isEqualByComparingTo("3.00");
+  }
+
+  @Test
+  void aggregateByDayAndModel_groupsRows() {
+    Instant day = Instant.parse("2026-03-10T10:00:00Z");
+    repository.save(row("u", "m1", day, "0.5"));
+    repository.save(row("u", "m1", day.plus(1, ChronoUnit.HOURS), "0.5"));
+    repository.save(row("u", "m2", day.plus(2, ChronoUnit.HOURS), "1.0"));
+
+    List<Object[]> rows = repository.aggregateByDayAndModel(day.minus(1, ChronoUnit.DAYS));
+    assertThat(rows).isNotEmpty();
+    BigDecimal m1Total =
+        rows.stream()
+            .filter(r -> "m1".equals(r[1]))
+            .map(r -> (BigDecimal) r[2])
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    assertThat(m1Total).isEqualByComparingTo("1.0");
+  }
+
+  private static AiUsageRecord row(String user, String model, Instant created, String costUsd) {
+    AiUsageRecord r = new AiUsageRecord();
+    r.setUserIdentifier(user);
+    r.setModel(model);
+    r.setPromptTokens(1);
+    r.setCompletionTokens(1);
+    r.setEstimatedCostUsd(new BigDecimal(costUsd));
+    r.setCreatedAt(created);
+    return r;
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/security/SecurityConfigIT.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/security/SecurityConfigIT.java
@@ -1,0 +1,84 @@
+package com.kevinmazali.portfolio.security;
+
+import com.kevinmazali.portfolio.testsupport.VectorStoreTestConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(VectorStoreTestConfiguration.class)
+@TestPropertySource(
+    properties = {
+        "spring.autoconfigure.exclude=org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreAutoConfiguration",
+        "spring.datasource.url=jdbc:h2:mem:securityit;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.ai.openai.api-key=test-placeholder-key-for-context-tests-only",
+        "spring.ai.openai.chat.enabled=true",
+        "spring.ai.anthropic.api-key=sk-ant-api03-test-placeholder-for-spring-context-only",
+        "portfolio.chat.default-model-id=gpt-5.5",
+        "server.port=0",
+    })
+class SecurityConfigIT {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+  }
+
+  @Test
+  void openapiDocsPermitAll() throws Exception {
+    mockMvc.perform(get("/v3/api-docs")).andExpect(status().isOk());
+  }
+
+  @Test
+  void adminDocumentsRequiresAuthentication() throws Exception {
+    mockMvc.perform(get("/admin/tools/documents")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void feedbackPostPermitAllWithoutCsrf() throws Exception {
+    mockMvc
+        .perform(
+            post("/feedback")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"Great portfolio site\"}"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void corsPreflightAllowsConfiguredOrigin() throws Exception {
+    mockMvc
+        .perform(
+            options("/feedback")
+                .header(HttpHeaders.ORIGIN, "http://localhost:5173")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "Content-Type"))
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5173"));
+  }
+}

--- a/frontend/homepage/cypress/e2e/cookie-consent.cy.ts
+++ b/frontend/homepage/cypress/e2e/cookie-consent.cy.ts
@@ -1,0 +1,41 @@
+/**
+ * Cookie settings modal via footer (works without PostHog banner).
+ */
+
+describe('Cookie consent settings', () => {
+  beforeEach(() => {
+    cy.clearAllLocalStorage()
+    cy.intercept('GET', '**/api/chat/models', {
+      statusCode: 200,
+      body: [
+        {
+          id: 'gpt-5.4-mini',
+          provider: 'OPENAI',
+          label: 'GPT-5.4 mini',
+          tags: ['FAST'],
+        },
+      ],
+    }).as('chatModels')
+  })
+
+  it('opens cookie settings from footer, cancels, then saves analytics choice', () => {
+    cy.visit('/')
+    cy.wait('@chatModels')
+
+    cy.contains('button', 'Cookie Settings').click()
+    cy.get('[role="dialog"]').should('be.visible').and('contain.text', 'Cookies and analytics')
+
+    cy.contains('button', 'Cancel').click()
+    cy.get('[role="dialog"]').should('not.exist')
+
+    cy.contains('button', 'Cookie Settings').click()
+    cy.get('[role="dialog"]').within(() => {
+      cy.get('input[type="checkbox"]:not([disabled])').check({ force: true })
+    })
+    cy.contains('button', 'Save choices').click()
+
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('aboutme_cookie_consent_v1')).to.be.a('string')
+    })
+  })
+})

--- a/frontend/homepage/cypress/e2e/portfolio-browse.cy.ts
+++ b/frontend/homepage/cypress/e2e/portfolio-browse.cy.ts
@@ -1,0 +1,34 @@
+/**
+ * Smoke navigation across public portfolio routes (no backend required).
+ */
+
+describe('Portfolio browsing', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/chat/models', {
+      statusCode: 200,
+      body: [
+        {
+          id: 'gpt-5.4-mini',
+          provider: 'OPENAI',
+          label: 'GPT-5.4 mini',
+          tags: ['FAST'],
+        },
+      ],
+    }).as('chatModels')
+  })
+
+  it('loads home, projects, project page, and career', () => {
+    cy.visit('/')
+    cy.wait('@chatModels')
+    cy.contains("Kevin's").should('be.visible')
+
+    cy.visit('/projects')
+    cy.contains('Projects', { timeout: 30000 }).should('be.visible')
+
+    cy.visit('/project')
+    cy.contains(/Tech stack|Teknologistakk/).should('be.visible')
+
+    cy.visit('/career')
+    cy.contains(/Experience & education|Erfaring og utdanning/).should('be.visible')
+  })
+})

--- a/frontend/homepage/src/components/__tests__/CookieConsentSettingsModal.spec.ts
+++ b/frontend/homepage/src/components/__tests__/CookieConsentSettingsModal.spec.ts
@@ -1,0 +1,93 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import CookieConsentSettingsModal from '../CookieConsentSettingsModal.vue'
+import { cookieSettingsOpen } from '@/lib/cookie-settings-state'
+import { useLangStore } from '@/stores/lang'
+import * as posthogConsent from '@/lib/posthog-consent'
+
+vi.mock('@/lib/posthog-consent', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/posthog-consent')>('@/lib/posthog-consent')
+  return {
+    ...actual,
+    saveAnalyticsConsent: vi.fn(),
+    hasAnalyticsConsent: vi.fn(() => false),
+  }
+})
+
+describe('CookieConsentSettingsModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    useLangStore().setLanguage('en')
+    cookieSettingsOpen.value = false
+    vi.clearAllMocks()
+    vi.mocked(posthogConsent.hasAnalyticsConsent).mockReturnValue(false)
+  })
+
+  function mountModal() {
+    return mount(CookieConsentSettingsModal, {
+      global: { stubs: { transition: false } },
+    })
+  }
+
+  it('does not render when settings are closed', async () => {
+    const wrapper = mountModal()
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+  })
+
+  it('renders dialog when opened and shows English copy', async () => {
+    const wrapper = mountModal()
+    cookieSettingsOpen.value = true
+    await nextTick()
+    await flushPromises()
+
+    const dialog = wrapper.find('[role="dialog"]')
+    expect(dialog.exists()).toBe(true)
+    expect(dialog.text()).toContain('Cookies and analytics')
+    expect(dialog.text()).toContain('Necessary')
+  })
+
+  it('save calls saveAnalyticsConsent and closes', async () => {
+    const wrapper = mountModal()
+    cookieSettingsOpen.value = true
+    await nextTick()
+    await flushPromises()
+
+    const analytics = wrapper.find('input[type="checkbox"]:not([disabled])')
+    await analytics.setValue(true)
+
+    const saveBtn = wrapper.findAll('button').find((b) => b.text().includes('Save choices'))
+    expect(saveBtn).toBeDefined()
+    await saveBtn!.trigger('click')
+    await nextTick()
+
+    expect(posthogConsent.saveAnalyticsConsent).toHaveBeenCalledWith(true, 'settings')
+    expect(cookieSettingsOpen.value).toBe(false)
+  })
+
+  it('cancel closes the modal', async () => {
+    const wrapper = mountModal()
+    cookieSettingsOpen.value = true
+    await nextTick()
+    await flushPromises()
+
+    const cancelBtn = wrapper.findAll('button').find((b) => b.text().includes('Cancel'))
+    expect(cancelBtn).toBeDefined()
+    await cancelBtn!.trigger('click')
+    await nextTick()
+    expect(cookieSettingsOpen.value).toBe(false)
+  })
+
+  it('renders Norwegian copy when language is no', async () => {
+    useLangStore().setLanguage('no')
+    const wrapper = mountModal()
+    cookieSettingsOpen.value = true
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.find('[role="dialog"]').text()).toContain('Informasjonskapsler')
+    expect(wrapper.find('[role="dialog"]').text()).toContain('Lagre valg')
+  })
+})

--- a/frontend/homepage/src/components/project/__tests__/ProjectBachelorSection.spec.ts
+++ b/frontend/homepage/src/components/project/__tests__/ProjectBachelorSection.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { MotionPlugin } from '@vueuse/motion'
+import ProjectBachelorSection from '../ProjectBachelorSection.vue'
+import { useLangStore } from '@/stores/lang'
+
+describe('ProjectBachelorSection', () => {
+  it('renders English bachelor hero', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('en')
+    const wrapper = mount(ProjectBachelorSection, {
+      global: { plugins: [pinia, MotionPlugin] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain("Bachelor's thesis")
+    expect(wrapper.text()).toMatch(/Piscada|Trondheim/i)
+  })
+
+  it('renders Norwegian bachelor hero', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+    const wrapper = mount(ProjectBachelorSection, {
+      global: { plugins: [pinia, MotionPlugin] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Bacheloroppgaven')
+  })
+})

--- a/frontend/homepage/src/components/project/__tests__/ProjectFutureWorkSection.spec.ts
+++ b/frontend/homepage/src/components/project/__tests__/ProjectFutureWorkSection.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ProjectFutureWorkSection from '../ProjectFutureWorkSection.vue'
+import { useLangStore } from '@/stores/lang'
+
+describe('ProjectFutureWorkSection', () => {
+  it('renders English roadmap title and first section', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('en')
+    const wrapper = mount(ProjectFutureWorkSection, {
+      global: { plugins: [pinia] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Future work and improvements')
+    expect(wrapper.text()).toMatch(/ElevenLabs|retrieval/i)
+  })
+
+  it('renders Norwegian roadmap title', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+    const wrapper = mount(ProjectFutureWorkSection, {
+      global: { plugins: [pinia] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Videre arbeid og forbedringer')
+  })
+})

--- a/frontend/homepage/src/components/project/__tests__/ProjectTechStackSection.spec.ts
+++ b/frontend/homepage/src/components/project/__tests__/ProjectTechStackSection.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { MotionPlugin } from '@vueuse/motion'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import ProjectTechStackSection from '../ProjectTechStackSection.vue'
+import { useLangStore } from '@/stores/lang'
+
+const routerLinkStub = { template: '<a><slot /></a>' }
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/chat', component: { template: '<div />' } },
+      { path: '/projects', component: { template: '<div />' } },
+      { path: '/project', component: { template: '<div />' } },
+    ],
+  })
+}
+
+describe('ProjectTechStackSection', () => {
+  it('renders tech stack title and pillar links in English', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('en')
+    const router = makeRouter()
+    const wrapper = mount(ProjectTechStackSection, {
+      global: {
+        plugins: [pinia, router, MotionPlugin],
+        stubs: { RouterLink: routerLinkStub },
+      },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Tech stack')
+    expect(wrapper.text()).toMatch(/AI & RAG|Open chat/i)
+  })
+
+  it('renders Norwegian title', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+    const router = makeRouter()
+    const wrapper = mount(ProjectTechStackSection, {
+      global: {
+        plugins: [pinia, router, MotionPlugin],
+        stubs: { RouterLink: routerLinkStub },
+      },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Teknologistakk')
+  })
+})

--- a/frontend/homepage/src/lib/__tests__/chat-telemetry.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/chat-telemetry.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOrCreateChatConversationId, resetChatConversationId } from '../chat-telemetry'
+
+const KEY = 'portfolio.chat.conversationId.v1'
+
+describe('chat-telemetry', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal('crypto', { randomUUID: () => 'aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('creates and persists a conversation id when missing', () => {
+    const id = getOrCreateChatConversationId()
+    expect(id).toBe('aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee')
+    expect(localStorage.getItem(KEY)).toBe(id)
+  })
+
+  it('returns existing id from localStorage', () => {
+    localStorage.setItem(KEY, '  existing-id  ')
+    expect(getOrCreateChatConversationId()).toBe('existing-id')
+  })
+
+  it('regenerates id on reset and updates storage', () => {
+    localStorage.setItem(KEY, 'old')
+    const next = resetChatConversationId()
+    expect(next).toBe('aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee')
+    expect(localStorage.getItem(KEY)).toBe(next)
+  })
+
+  it('falls back when localStorage getItem throws', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    const id = getOrCreateChatConversationId()
+    expect(id.length).toBeGreaterThan(0)
+    spy.mockRestore()
+  })
+})

--- a/frontend/homepage/src/lib/chat-telemetry.ts
+++ b/frontend/homepage/src/lib/chat-telemetry.ts
@@ -12,7 +12,8 @@ function safeUuidV4(): string {
 export function getOrCreateChatConversationId(): string {
   try {
     const existing = localStorage.getItem(CHAT_CONVERSATION_ID_KEY)
-    if (existing && existing.trim()) return existing
+    const trimmed = existing?.trim()
+    if (trimmed) return trimmed
     const created = safeUuidV4()
     localStorage.setItem(CHAT_CONVERSATION_ID_KEY, created)
     return created

--- a/frontend/homepage/vitest.config.ts
+++ b/frontend/homepage/vitest.config.ts
@@ -40,7 +40,7 @@ export default mergeConfig(
         thresholds: {
           lines: 84,
           statements: 82,
-          branches: 68,
+          branches: 70,
           functions: 75,
         },
       },


### PR DESCRIPTION
## Summary
Implements the test coverage strategy plan: stronger gates, missing unit/integration tests, Cypress smoke flows, and a scheduled/manual E2E job.

## Backend
- Unit tests for \BudgetExceededException\ and \AiCircuitOpenException\.
- Dedicated \@WebMvcTest\ slice for \DocumentPipelineControllerAdvice\; duplicate 503 cases removed from \DocumentPipelineControllerTest\.
- \SecurityConfigIT\: public OpenAPI, admin 401 without auth, \POST /feedback\ without CSRF, CORS preflight.
- \AiUsageRepositoryTest\ (\@SpringBootTest\ + \@Transactional\) for custom JPQL/native aggregations.
- JaCoCo: line minimum **82%**, new branch minimum **62%**.

## Frontend
- \chat-telemetry\ tests + trim persisted conversation IDs.
- \CookieConsentSettingsModal\ tests; project section component smoke tests.
- Vitest branch threshold **70%** (bundle ~70.1%).

## Cypress & CI
- \portfolio-browse.cy.ts\ and \cookie-consent.cy.ts\ (stub \GET **/api/chat/models\).
- Workflow: second weekly cron (Sun 07:00 UTC) + \workflow_dispatch\ input \un_frontend_e2e\; model validation tied to Sun 06:00 cron only.

## How to verify
- \./mvnw verify\ in \ackend/\
- \
pm run test:unit:coverage\ in \rontend/homepage/\
- Optionally \
pm run test:e2e\ locally after \
pm run build-only\.