### PR TITLE
fix(docker): cache Maven repo and retry to survive Central 429s

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,10 +44,18 @@ RUN set -eux; \
 # Build stage
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
+# Survive transient Maven Central 429s during concurrent multi-platform (amd64 + arm64)
+# Buildx runs by retrying transfers and reusing the HTTP connection pool.
+ENV MAVEN_OPTS="-Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Daether.connector.http.retryHandler.count=5"
 COPY pom.xml .
-RUN mvn dependency:go-offline -B
+# Cache /root/.m2/repository across builds and share it across concurrent multi-arch
+# builds (sharing=locked) so we don't re-download every dependency per platform and
+# stampede Maven Central into rate limiting.
+RUN --mount=type=cache,id=aboutme-m2,target=/root/.m2/repository,sharing=locked \
+    mvn -B --no-transfer-progress dependency:go-offline
 COPY src ./src
-RUN mvn clean package -DskipTests -Dmaven.test.skip=true -Dmaven.compiler.fork=true -Dmaven.compiler.maxmem=512m
+RUN --mount=type=cache,id=aboutme-m2,target=/root/.m2/repository,sharing=locked \
+    mvn -B --no-transfer-progress clean package -DskipTests -Dmaven.test.skip=true -Dmaven.compiler.fork=true -Dmaven.compiler.maxmem=512m
 
 # Production stage
 FROM eclipse-temurin:21-jre


### PR DESCRIPTION
## Summary
- Fixes Docker image publish failing on `main` (run 25513227393, sha 65e8900) where the multi-platform Buildx build (`linux/amd64` + `linux/arm64`) hit `mvn dependency:go-offline` cold on both architectures simultaneously and Maven Central responded with `HTTP 429 Too Many Requests`, aborting the build.
- Adds a shared BuildKit cache mount on `/root/.m2/repository` (`id=aboutme-m2`, `sharing=locked`) so both arch builds reuse downloaded artifacts instead of stampeding Central.
- Adds Wagon/Aether retry handlers via `MAVEN_OPTS` and `--no-transfer-progress` so any remaining transient 429s recover instead of failing the run.

## Why this works
The previous failure looked like:

```
[FATAL] Non-resolvable parent POM ... spring-boot-starter-parent:pom:4.0.6 ...
status code: 429, reason phrase: Too Many Requests
```

Both `linux/amd64` and `linux/arm64` were resolving the full Spring Boot dependency graph in parallel from a fresh `~/.m2`. With a shared cache mount the second platform now hits the local cache, and the retry handlers absorb any remaining throttling without aborting.

The `dependency:go-offline` / `clean package` split is preserved so source-only changes still hit the dependency layer cache.

## Test plan
- [x] `docker buildx build --platform linux/amd64 --target build ./backend` from a clean cache: `BUILD SUCCESS` end-to-end (no 429s).
- [x] Re-run of the same command: completes in seconds with all stages cached, confirming the Maven cache mount is reused.
- [ ] On merge: GitHub Actions multi-arch publish (`linux/amd64,linux/arm64`) completes without `429 Too Many Requests` from Maven Central.
