### PR TITLE
privacy: add voice transcription disclosure to privacy policy

### DIFF
--- a/frontend/homepage/src/lib/posthog-consent.ts
+++ b/frontend/homepage/src/lib/posthog-consent.ts
@@ -1,7 +1,7 @@
 import posthog from 'posthog-js'
 import { initializePosthogSdk, isPosthogSdkInitialized } from './posthog-sdk'
 
-export const PRIVACY_POLICY_VERSION = '2026-05-06'
+export const PRIVACY_POLICY_VERSION = '2026-05-08'
 
 /** Legacy key (v1: single `analytics` boolean). Still read for migration. */
 export const CONSENT_RECORD_KEY_V1 = 'aboutme_cookie_consent_v1'

--- a/frontend/homepage/src/views/PrivacyPolicyView.vue
+++ b/frontend/homepage/src/views/PrivacyPolicyView.vue
@@ -35,12 +35,14 @@ const sections = computed(() => {
         ],
       },
       {
-        heading: '4. Chat-funksjonen og AI',
+        heading: '4. Chat-funksjonen, taleinndata og AI',
         paragraphs: [
           'Når du bruker chat-funksjonen, sendes meldingene dine til en tjeneste som bruker en språkmodell (for eksempel OpenAI) for å generere svar.',
-          'Unngå å sende sensitive personopplysninger, helseopplysninger, passord eller annet du ikke ønsker å dele med en ekstern leverandør.',
+          'Chat-siden og forsiden tilbyr også taleinndata. Når du aktiverer mikrofonen, tas lyden opp i nettleseren og sendes til vår server, som videresender den til en ekstern transkripsjonstjeneste (for tiden OpenAI Whisper). Lydfilen behandles kun for å produsere tekst og lagres ikke permanent verken hos oss eller hos leverandøren utover det som kreves for selve transkripsjonen. Den transkriberte teksten settes inn i chat-feltet på samme måte som om du hadde skrevet den selv.',
+          'Taleinndata krever at du gir nettleseren tilgang til mikrofonen. Ingen lydopptak starter uten at du aktivt trykker på mikrofonknappen.',
+          'Unngå å sende sensitive personopplysninger, helseopplysninger, passord eller annet du ikke ønsker å dele med en ekstern leverandør — dette gjelder både tekst og tale.',
           'Behandlingen skjer for å levere funksjonen du ber om. Oppbevaring og logger avhenger av hvordan backend er konfigurert; kontakt eier ved spørsmål.',
-          'Tekst og filer som inngår i kunnskapsbasen for AI-svar, lastes inn via eiers administrerte dokumentpipeline. Råfangst fra eventuelle fremtidige samtale- eller stemmeverktøy inngår ikke automatisk i den basen uten egen, kontrollert behandling og opplasting.',
+          'Tekst og filer som inngår i kunnskapsbasen for AI-svar, lastes inn via eiers administrerte dokumentpipeline. Lydopptak og transkripsjoner fra taleinndata inngår ikke automatisk i kunnskapsbasen uten egen, kontrollert behandling og opplasting.',
         ],
       },
       {
@@ -87,12 +89,14 @@ const sections = computed(() => {
       ],
     },
     {
-      heading: '4. Chat and AI',
+      heading: '4. Chat, voice input, and AI',
       paragraphs: [
         'When you use the chat feature, your messages are sent to a service that uses a language model (for example OpenAI) to generate replies.',
-        'Do not send sensitive personal data, health information, passwords, or anything you do not want shared with an external provider.',
+        'The chat page and the home page also offer voice input. When you activate the microphone, audio is recorded in your browser and sent to our server, which forwards it to an external transcription service (currently OpenAI Whisper). The audio file is processed only to produce text and is not permanently stored by us or the provider beyond what is needed for the transcription itself. The transcribed text is inserted into the chat field just as if you had typed it yourself.',
+        'Voice input requires you to grant the browser access to your microphone. No audio recording starts without you actively pressing the microphone button.',
+        'Do not send sensitive personal data, health information, passwords, or anything you do not want shared with an external provider — this applies to both text and voice.',
         'Processing is performed to deliver the functionality you request. Retention and logging depend on how the backend is configured; contact the owner if you have questions.',
-        'Text and files that power the AI knowledge base are ingested through the owner’s controlled document pipeline. Raw capture from any future conversational or voice tools is not automatically included in that base without separate, controlled processing and upload.',
+        'Text and files that power the AI knowledge base are ingested through the owner’s controlled document pipeline. Audio recordings and transcriptions from voice input are not automatically included in the knowledge base without separate, controlled processing and upload.',
       ],
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the privacy policy page to explicitly describe the voice input / microphone transcription feature that is already live on the chat page and home page.

### Changes

**`PrivacyPolicyView.vue`** — Section 4 updated in both Norwegian and English:
- Renamed heading from "Chat and AI" to "Chat, voice input, and AI"
- Added paragraph explaining that audio is captured in the browser, sent to the backend, and forwarded to OpenAI Whisper for transcription
- Clarified that audio is not permanently stored
- Added paragraph about microphone permission requirement (explicit user action)
- Extended the "do not share sensitive data" warning to cover both text and voice
- Replaced vague "future conversational or voice tools" language with accurate current-state description of how audio recordings and transcriptions are excluded from the knowledge base

**`posthog-consent.ts`** — Bumped `PRIVACY_POLICY_VERSION` from `2026-05-06` to `2026-05-08` to reflect the material policy change.

### Context

Checked PostHog MCP for tracked events (`$ai_generation`, `portfolio_chat_*`, `$exception`, `$pageview`, etc.), feature flags, and surveys to confirm what the site tracks. The privacy policy now accurately reflects the voice transcription data flow: browser microphone → backend `/transcribe` endpoint → OpenAI Whisper → text inserted into chat input.

### Testing

- All 272 existing unit tests pass across 41 test files (vitest)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18ce9cf5-cd94-4f39-b2f5-fb0799353014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18ce9cf5-cd94-4f39-b2f5-fb0799353014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

