### PR TITLE
fix(realtime): relax /realtime/lookup rate limit for voice sessions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/backend/src/main/java/com/kevinmazali/portfolio/config/RealtimeLookupRateLimitProperties.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/RealtimeLookupRateLimitProperties.java
@@ -11,10 +11,10 @@ public class RealtimeLookupRateLimitProperties {
   private boolean enabled = true;
 
   /** Max POST /realtime/lookup calls per window per IP. */
-  private int capacity = 20;
+  private int capacity = 200;
 
   /** Refill window in seconds. */
-  private int windowSeconds = 180;
+  private int windowSeconds = 1800;
 
   public boolean isEnabled() {
     return enabled;

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -141,8 +141,8 @@ portfolio:
     window-seconds: 3600
   realtime-lookup-rate-limit:
     enabled: true
-    capacity: 20
-    window-seconds: 180
+    capacity: 200
+    window-seconds: 1800
   retrieval:
     # Optional ONNX rerank; Docker image sets paths under /app/rerank (see backend/Dockerfile).
     rerank-enabled: false


### PR DESCRIPTION
- Raise capacity 20 -> 200 and window 180s -> 1800s (defaults + YAML)

- Add root .gitattributes with * text=auto to reduce CRLF drift on Windows