### PR TITLE
[codex] Add GitGuardian secret scanning gate

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,31 @@
+# Local environment (secrets / machine-specific)
+**/.env
+**/.env.*
+backend/.env
+frontend/homepage/.env
+
+# Local scratch payloads / agent artifacts
+scripts/_*
+
+# Local credentials / private key material
+**/credentials.json
+**/secrets.json
+**/*.key
+**/*.pem
+**/*.p12
+**/*.pfx
+**/id_rsa
+**/id_ed25519
+
+# Build and test outputs
+backend/target/
+frontend/homepage/dist/
+frontend/homepage/dist-ssr/
+frontend/homepage/coverage/
+frontend/homepage/test-results/
+frontend/homepage/cypress/videos/
+frontend/homepage/cypress/screenshots/
+
+# Logs
+logs/
+*.log

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -1,0 +1,49 @@
+# GitGuardian: secret scanning gate for pull requests and pushes.
+#
+# Requires GITGUARDIAN_API_KEY in GitHub Actions secrets. This workflow fails
+# hard when the token is missing so secret scanning remains a real merge gate.
+name: GitGuardian scan
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: '37 18 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: GitGuardian scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: GitGuardian preflight
+        shell: bash
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GITGUARDIAN_API_KEY:-}" ]; then
+            echo "::error title=GitGuardian token missing::Set GITGUARDIAN_API_KEY in repository Actions secrets."
+            exit 1
+          fi
+          echo "GitGuardian token detected."
+
+      - name: GitGuardian scan
+        uses: GitGuardian/ggshield/actions/secret@v1.49.0
+        env:
+          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
+          GITHUB_PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          # Enough history for normal PR commit ranges without full-repo checkout delays.
+          fetch-depth: 50
 
       - name: GitGuardian preflight
         shell: bash

--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -1,7 +1,7 @@
 # GitGuardian: secret scanning gate for pull requests and pushes.
 #
-# Requires GITGUARDIAN_API_KEY in GitHub Actions secrets. This workflow fails
-# hard when the token is missing so secret scanning remains a real merge gate.
+# Requires GITGUARDIAN_API_KEY as a repository Actions secret. This workflow
+# fails hard when the token is missing so secret scanning remains a real merge gate.
 name: GitGuardian scan
 
 on:
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GITGUARDIAN_API_KEY:-}" ]; then
-            echo "::error title=GitGuardian token missing::Set GITGUARDIAN_API_KEY in repository Actions secrets."
+            echo "::error title=GitGuardian token missing::Set GITGUARDIAN_API_KEY as a repository Actions secret, not only as an environment secret."
             exit 1
           fi
           echo "GitGuardian token detected."

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,19 @@ Thumbs.db
 # Local environment (secrets / machine-specific)
 .env
 .env.*
+**/.env
+**/.env.*
 !.env.example
+
+# Local credentials / private key material
+**/credentials.json
+**/secrets.json
+**/*.key
+**/*.pem
+**/*.p12
+**/*.pfx
+**/id_rsa
+**/id_ed25519
 
 # Local vector store exports (not used by runtime)
 backend/vectordatabase/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Core stack:
 | `scripts/dev.ps1` | Windows helper that starts Docker infrastructure and opens backend + Vite terminals |
 | `docker-compose.yml` | PostgreSQL/pgvector, backend, and Nginx-hosted frontend |
 | `.env.example` | Documented runtime configuration for backend secrets and optional integrations |
-| `.github/workflows/` | Maven/frontend tests, Semgrep, and Docker image publishing |
+| `.github/workflows/` | Maven/frontend tests, GitGuardian secret scanning, Semgrep, and Docker image publishing |
 
 Seed documents for the vector store go in `backend/data/docs/` (gitignored). The backend also ships a classpath seed document for a minimal local knowledge base.
 
@@ -138,6 +138,8 @@ Public AI endpoints are rate-limited with Bucket4j. Admin routes are protected b
 
 Treat database backups as sensitive. Conversations, documents, chunks, embeddings, prompts, feedback, and experiment datasets may contain personal or project-specific information.
 
+CI uses GitGuardian as the PR/push secret scanning gate and Semgrep for SAST. Add `GITGUARDIAN_API_KEY` to GitHub Actions secrets before enabling required checks; the GitGuardian workflow fails hard when the token is missing.
+
 ## Document Pipeline and RAG
 
 The knowledge base is curated through admin tooling:
@@ -187,7 +189,7 @@ Release notes should say "Live OpenAI Realtime E2E passed" only after the full l
 CI can build multi-platform backend and frontend images and publish them to Docker Hub when the required repository variables and secrets are configured:
 
 - Variables: `DOCKER_ACCOUNT`, `CLOUD_BUILDER_NAME`
-- Secrets: `DOCKER_ACCESS_TOKEN`, plus optional frontend `VITE_POSTHOG_*` build values
+- Secrets: `GITGUARDIAN_API_KEY` for PR/push secret scanning, `DOCKER_ACCESS_TOKEN` for image publishing, plus optional frontend `VITE_POSTHOG_*` build values
 
 Use prebuilt images by replacing the `build:` blocks in `docker-compose.yml` with:
 


### PR DESCRIPTION
## Summary
- Add a GitGuardian ggshield workflow that gates PRs and pushes on secret scanning.
- Add local ignore coverage for nested env files, MCP scratch payloads, and common credential/key files.
- Keep README updates minimal: document the GitGuardian required secret and existing Semgrep split.

## Validation
- git check-ignore -v backend/.env frontend/homepage/.env scripts/_full_mcp_args.json
- rg secret-pattern checks for ELEVENLABS_API_KEY and xi-api-key
- PyYAML parse of .github/workflows/gitguardian.yml
- cmd.exe /d /c mvnw.cmd -B -Dtest=ElevenLabsRealtimeTokenServiceTest test

## Follow-up
- Add GITGUARDIAN_API_KEY to GitHub Actions secrets so the gate can run.
- Rotate the existing ElevenLabs key outside this repository.