### PR TITLE
feat(voice): add standard turn-based voice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Seed documents for the vector store go in `backend/data/docs/` (gitignored). The
 
 ### Full Stack in Docker
 
-Copy `.env.example` to `backend/.env`, set at least `OPENAI_API_KEY` and `OPENAI_CHAT_ENABLED=true`, then run:
+Copy `.env.example` to `backend/.env`, set at least `OPENAI_API_KEY` and `OPENAI_CHAT_ENABLED=true`. For Docker Compose database credentials, copy `.env.docker.example` to `.env.docker` at the repo root, then run:
 
 ```bash
+cp .env.docker.example .env.docker   # first time only (Windows: copy .env.docker.example .env.docker)
 docker compose up -d --build
 ```
 
@@ -62,6 +63,7 @@ The backend container mounts `./backend/data` read-only, so `file:./data/docs/` 
 Run only the database in Docker, then start backend and frontend on the host with auto-reload:
 
 ```bash
+cp .env.docker.example .env.docker   # first time only
 docker compose up -d db
 ```
 
@@ -90,6 +92,7 @@ Typical URLs: same as full stack — app [http://localhost:5173](http://localhos
 For auto-reload without a local JDK or Node install:
 
 ```bash
+cp .env.docker.example .env.docker   # first time only
 docker compose -f docker-compose.dev.yml up
 ```
 
@@ -115,7 +118,7 @@ Use this before deploy to confirm the production Dockerfile still builds and run
 
 ## Configuration
 
-Configuration defaults live in `backend/src/main/resources/application.yaml`. Copy `.env.example` to `backend/.env` for local secrets. Frontend build-time `VITE_*` values belong in `frontend/homepage/.env`.
+Configuration defaults live in `backend/src/main/resources/application.yaml`. Copy `.env.example` to `backend/.env` for local secrets. Copy `.env.docker.example` to `.env.docker` for Docker Compose Postgres credentials. Frontend build-time `VITE_*` values belong in `frontend/homepage/.env`. For Cursor ElevenLabs MCP, copy `.cursor/mcp.json.example` to `.cursor/mcp.json` and set your API key locally (rotate the key in ElevenLabs if it was previously committed).
 
 Common backend settings:
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,17 @@ Public AI endpoints are rate-limited with Bucket4j. Admin routes are protected b
 
 Treat database backups as sensitive. Conversations, documents, chunks, embeddings, prompts, feedback, and experiment datasets may contain personal or project-specific information.
 
-CI uses GitGuardian as the PR/push secret scanning gate and Semgrep for SAST. Add `GITGUARDIAN_API_KEY` to GitHub Actions secrets before enabling required checks; the GitGuardian workflow fails hard when the token is missing.
+CI uses two GitGuardian surfaces plus Semgrep for SAST:
+
+- **GitGuardian scan** (GitHub Actions, `ggshield` in [`.github/workflows/gitguardian.yml`](.github/workflows/gitguardian.yml)) scans commit ranges on PRs and pushes. It reads [`.gitguardian.yml`](.gitguardian.yml) for local-dev allowlists.
+- **GitGuardian Security Checks** (GitHub App) is a separate required check on the GitGuardian dashboard. Open incidents there must be resolved after rotation or remediation, even when the Actions workflow is green.
+
+Add `GITGUARDIAN_API_KEY` as a repository Actions secret before enabling required checks; the workflow fails hard when the token is missing.
+
+**Local secrets (never commit):**
+
+- Copy [`.cursor/mcp.json.example`](.cursor/mcp.json.example) to `.cursor/mcp.json` (gitignored) and set `ELEVENLABS_API_KEY` locally.
+- Copy [`.env.docker.example`](.env.docker.example) to `.env.docker` (gitignored) for Docker Compose Postgres credentials (`POSTGRES_PASSWORD`, `SPRING_DATASOURCE_PASSWORD`).
 
 ## Document Pipeline and RAG
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Core stack:
 |------|------|
 | `backend/` | Spring Boot API for chat, Realtime voice, auth, admin tools, RAG, experiments, budgets, and observability |
 | `frontend/homepage/` | Vue SPA. See [frontend/homepage/README.md](frontend/homepage/README.md) for scripts, routes, analytics, and Orval notes |
-| `scripts/dev.ps1` | Windows helper that starts Docker infrastructure and opens backend + Vite terminals |
-| `docker-compose.yml` | PostgreSQL/pgvector, backend, and Nginx-hosted frontend |
+| `scripts/dev.ps1` | Windows helper that starts Docker infrastructure and opens backend + Vite terminals (recommended daily dev) |
+| `docker-compose.yml` | PostgreSQL/pgvector, backend, and Nginx-hosted frontend (prod-like images) |
+| `docker-compose.dev.yml` | Full stack in Docker with Vite HMR and Spring DevTools auto-reload |
 | `.env.example` | Documented runtime configuration for backend secrets and optional integrations |
 | `.github/workflows/` | Maven/frontend tests, GitGuardian secret scanning, Semgrep, and Docker image publishing |
 
@@ -33,6 +34,10 @@ Seed documents for the vector store go in `backend/data/docs/` (gitignored). The
 
 ## Run Locally
 
+**Recommended for daily development:** [Hybrid Dev](#hybrid-dev-recommended) or [Full Stack Dev in Docker](#full-stack-dev-in-docker). Both auto-reload on code changes.
+
+**Prod-like Docker** (`docker compose up -d --build`) does **not** auto-reload — run `--build` again after each code change, or use [Compose Watch](#compose-watch-prod-image-smoke-test) to rebuild images automatically (slower).
+
 ### Full Stack in Docker
 
 Copy `.env.example` to `backend/.env`, set at least `OPENAI_API_KEY` and `OPENAI_CHAT_ENABLED=true`, then run:
@@ -40,6 +45,8 @@ Copy `.env.example` to `backend/.env`, set at least `OPENAI_API_KEY` and `OPENAI
 ```bash
 docker compose up -d --build
 ```
+
+This builds frozen images (JAR + Nginx static assets). For day-to-day coding with live reload, use **Hybrid Dev** or **Full Stack Dev in Docker** below instead.
 
 Typical URLs:
 
@@ -50,15 +57,13 @@ Typical URLs:
 
 The backend container mounts `./backend/data` read-only, so `file:./data/docs/` resolves to `backend/data/docs/` inside the container.
 
-### Hybrid Dev
+### Hybrid Dev (recommended)
 
-Run the database in Docker:
+Run only the database in Docker, then start backend and frontend on the host with auto-reload:
 
 ```bash
 docker compose up -d db
 ```
-
-Then start the apps on the host:
 
 ```bash
 cd backend
@@ -71,7 +76,42 @@ npm install
 npm run dev
 ```
 
-On Windows, `.\scripts\dev.ps1` starts the same setup after you copy `.env.example` to `backend/.env`.
+**Auto-reload:**
+
+- **Frontend:** Vite HMR — changes in `.vue`, `.ts`, and CSS appear in the browser almost instantly.
+- **Backend:** `spring-boot-devtools` restarts the app when compiled classes change (~5–15 s). Changes to `pom.xml` or new dependencies still require stopping and re-running Maven.
+
+On Windows, **`.\scripts\dev.ps1`** is the fastest path: it starts Postgres, waits for port `5432`, then opens backend and frontend in separate terminals. Copy `.env.example` to `backend/.env` (or repo-root `.env` as documented in `application.yaml`) first.
+
+Typical URLs: same as full stack — app [http://localhost:5173](http://localhost:5173), API [http://localhost:8080](http://localhost:8080).
+
+### Full Stack Dev in Docker
+
+For auto-reload without a local JDK or Node install:
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+Copy `.env.example` to `backend/.env` before starting. The dev compose file runs `mvn spring-boot:run` and `npm run dev` inside containers with source mounted from the repo.
+
+**Auto-reload:** same as hybrid — Vite HMR for the frontend, Spring DevTools restart for the backend. ONNX rerank assets from the prod Dockerfile are not bundled; set `PORTFOLIO_RETRIEVAL_RERANK_ENABLED=false` in `backend/.env` if reranking is not needed locally.
+
+### Compose Watch (prod-image smoke test)
+
+To verify prod images while editing code (rebuilds entire images on change — slower than dev mode):
+
+```bash
+docker compose watch
+```
+
+Or start the stack and watch in one step:
+
+```bash
+docker compose up --watch
+```
+
+Use this before deploy to confirm the production Dockerfile still builds and runs; use **Hybrid Dev** or **docker-compose.dev.yml** for everyday iteration.
 
 ## Configuration
 

--- a/backend/src/main/java/com/kevinmazali/portfolio/config/HttpClientConfig.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/HttpClientConfig.java
@@ -1,6 +1,7 @@
 package com.kevinmazali.portfolio.config;
 
 import com.kevinmazali.portfolio.service.OpenAiRealtimeHttpInvoker;
+import com.kevinmazali.portfolio.service.OpenAiSpeechHttpInvoker;
 import com.kevinmazali.portfolio.service.ElevenLabsRealtimeHttpInvoker;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
@@ -28,6 +29,14 @@ public class HttpClientConfig {
             HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
         return (request) ->
             client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    @Bean
+    OpenAiSpeechHttpInvoker openAiSpeechHttpInvoker() {
+        HttpClient client =
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
+        return (request) ->
+            client.send(request, HttpResponse.BodyHandlers.ofByteArray());
     }
 
     @Bean

--- a/backend/src/main/java/com/kevinmazali/portfolio/config/WebConfig.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/WebConfig.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.lang.NonNull;
 
 /**
- * Registers servlet filters that rate-limit {@code POST /ask}, {@code POST /transcribe}, {@code POST /realtime/session},
+ * Registers servlet filters that rate-limit {@code POST /ask}, {@code POST /transcribe}, {@code POST /synthesize}, {@code POST /realtime/session},
  * {@code POST /realtime/elevenlabs/token}, {@code POST /realtime/lookup}, {@code POST /auth/login},
  * {@code POST /feedback}, {@code POST /admin/tools/experiments/run}, and
  * {@code POST /admin/tools/experiments/datasets/generate} (token buckets per client key or IP).
@@ -197,7 +197,7 @@ public class WebConfig {
                 }
             }
         });
-        registration.addUrlPatterns("/ask", "/transcribe");
+        registration.addUrlPatterns("/ask", "/transcribe", "/synthesize");
         registration.setName("askRateLimitFilter");
         registration.setOrder(1);
         return registration;

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/RealtimeController.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/RealtimeController.java
@@ -13,6 +13,8 @@ import com.kevinmazali.portfolio.service.RealtimeLookupService;
 import com.kevinmazali.portfolio.service.RealtimeModelCatalog;
 import com.kevinmazali.portfolio.service.RealtimeSessionService;
 import com.kevinmazali.portfolio.service.RequestLogService;
+import com.kevinmazali.portfolio.service.SpeechSynthesisService;
+import com.kevinmazali.portfolio.service.TranscriptionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +39,8 @@ public class RealtimeController {
   private final RealtimeLookupService realtimeLookupService;
   private final RealtimeModelCatalog realtimeModelCatalog;
   private final ElevenLabsRealtimeTokenService elevenLabsRealtimeTokenService;
+  private final TranscriptionService transcriptionService;
+  private final SpeechSynthesisService speechSynthesisService;
   private final RequestLogService requestLogService;
 
   public RealtimeController(
@@ -45,21 +49,28 @@ public class RealtimeController {
       RealtimeLookupService realtimeLookupService,
       RealtimeModelCatalog realtimeModelCatalog,
       ElevenLabsRealtimeTokenService elevenLabsRealtimeTokenService,
+      TranscriptionService transcriptionService,
+      SpeechSynthesisService speechSynthesisService,
       RequestLogService requestLogService) {
     this.realtimeProperties = realtimeProperties;
     this.realtimeSessionService = realtimeSessionService;
     this.realtimeLookupService = realtimeLookupService;
     this.realtimeModelCatalog = realtimeModelCatalog;
     this.elevenLabsRealtimeTokenService = elevenLabsRealtimeTokenService;
+    this.transcriptionService = transcriptionService;
+    this.speechSynthesisService = speechSynthesisService;
     this.requestLogService = requestLogService;
   }
 
   @Operation(summary = "Realtime voice available", description = "True when at least one realtime voice provider is configured.")
   @GetMapping("/realtime/status")
   public ResponseEntity<RealtimeStatusResponse> status() {
-    boolean ok = realtimeModelCatalog.hasAvailableModels();
+    boolean liveEnabled = realtimeModelCatalog.hasAvailableModels();
+    boolean standardEnabled = transcriptionService.isTranscriptionConfigured() && speechSynthesisService.isConfigured();
     return ResponseEntity.ok(new RealtimeStatusResponse(
-        ok,
+        standardEnabled || liveEnabled,
+        standardEnabled,
+        liveEnabled,
         RealtimeProperties.ALLOWED_VOICES,
         RealtimeProperties.ALLOWED_REASONING_EFFORTS,
         realtimeProperties.defaultVoice(),
@@ -138,10 +149,6 @@ public class RealtimeController {
       description = "Returns short snippets for the Realtime voice assistant; not a full RAG answer.")
   @PostMapping(value = "/realtime/lookup", consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> lookup(@RequestBody(required = false) RealtimeLookupRequest request) {
-    if (!realtimeProperties.isEnabled()) {
-      return ResponseEntity.status(503)
-          .body(new ApiError("Voice chat is disabled.", "REALTIME_DISABLED"));
-    }
     try {
       String query = request == null ? null : request.query();
       String language = request == null ? null : request.language();

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/SpeechSynthesisController.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/SpeechSynthesisController.java
@@ -1,0 +1,69 @@
+package com.kevinmazali.portfolio.controller;
+
+import com.kevinmazali.portfolio.model.ApiError;
+import com.kevinmazali.portfolio.model.SynthesizeRequest;
+import com.kevinmazali.portfolio.service.RequestLogService;
+import com.kevinmazali.portfolio.service.SpeechSynthesisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Text-to-speech endpoint for turn-based standard voice mode.
+ */
+@Slf4j
+@RestController
+@Tag(name = "Chat", description = "RAG-backed question answering")
+public class SpeechSynthesisController {
+
+  private final SpeechSynthesisService speechSynthesisService;
+  private final RequestLogService requestLogService;
+
+  public SpeechSynthesisController(
+      SpeechSynthesisService speechSynthesisService,
+      RequestLogService requestLogService) {
+    this.speechSynthesisService = speechSynthesisService;
+    this.requestLogService = requestLogService;
+  }
+
+  @Operation(summary = "Synthesize speech", description = "Convert short text to MP3 audio for standard voice mode.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "MP3 audio bytes"),
+      @ApiResponse(responseCode = "400", description = "Invalid text payload",
+          content = @Content(schema = @Schema(implementation = ApiError.class))),
+      @ApiResponse(responseCode = "429", description = "Budget or rate limit exceeded",
+          content = @Content(schema = @Schema(implementation = ApiError.class))),
+      @ApiResponse(responseCode = "503", description = "Speech synthesis unavailable",
+          content = @Content(schema = @Schema(implementation = ApiError.class)))
+  })
+  @PostMapping(value = "/synthesize", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> synthesize(
+      @RequestBody(required = false) SynthesizeRequest request,
+      @RequestHeader(value = "X-Chat-Language", required = false) String chatLanguage) {
+    String text = request == null ? null : request.text();
+    requestLogService.save("/synthesize", "POST", text == null ? "null" : "chars:" + text.length(), null);
+    try {
+      byte[] audio = speechSynthesisService.synthesize(text, chatLanguage);
+      return ResponseEntity.ok()
+          .contentType(MediaType.parseMediaType("audio/mpeg"))
+          .header(HttpHeaders.CACHE_CONTROL, "no-store")
+          .body(audio);
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().body(new ApiError(e.getMessage()));
+    } catch (IllegalStateException e) {
+      log.warn("/synthesize unavailable: {}", e.getMessage());
+      return ResponseEntity.status(503).body(new ApiError("Speech synthesis is temporarily unavailable."));
+    }
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/RealtimeLookupResponse.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/RealtimeLookupResponse.java
@@ -8,4 +8,13 @@ public record RealtimeLookupResponse(
     @Schema(description = "True when at least one snippet was found")
     boolean found,
     @Schema(description = "At most five concise snippets")
-    List<RealtimeLookupSnippet> snippets) {}
+    List<RealtimeLookupSnippet> snippets,
+    @Schema(description = "Match confidence: high, low, or none")
+    String confidence) {
+
+  public RealtimeLookupResponse {
+    if (confidence == null || confidence.isBlank()) {
+      confidence = found ? "high" : "none";
+    }
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/RealtimeStatusResponse.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/RealtimeStatusResponse.java
@@ -7,6 +7,8 @@ import java.util.List;
  */
 public record RealtimeStatusResponse(
     boolean enabled,
+    boolean standardEnabled,
+    boolean liveEnabled,
     List<String> voices,
     List<String> reasoningEfforts,
     String defaultVoice,

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/SynthesizeRequest.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/SynthesizeRequest.java
@@ -1,0 +1,8 @@
+package com.kevinmazali.portfolio.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Text payload for voice synthesis")
+public record SynthesizeRequest(
+    @Schema(description = "Plain text to synthesize", example = "Hei! Velkommen til Kevin sin portfolio.")
+    String text) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/OpenAiSpeechHttpInvoker.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/OpenAiSpeechHttpInvoker.java
@@ -1,0 +1,14 @@
+package com.kevinmazali.portfolio.service;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Executes synchronous JDK {@link java.net.http.HttpClient} calls for OpenAI speech synthesis.
+ */
+@FunctionalInterface
+public interface OpenAiSpeechHttpInvoker {
+
+  HttpResponse<byte[]> invoke(HttpRequest request) throws IOException, InterruptedException;
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/RealtimeLookupService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/RealtimeLookupService.java
@@ -30,6 +30,10 @@ public class RealtimeLookupService {
   private static final int VECTOR_TOP_K = 5;
   private static final int MAX_SNIPPET_CHARS = 500;
   private static final long CACHE_TTL_NANOS = Duration.ofSeconds(60).toNanos();
+  /** Profile scores at or above this are treated as high-confidence matches. */
+  private static final int HIGH_CONFIDENCE_PROFILE_SCORE = 6;
+  /** Snippets shorter than this with only weak matches are low-confidence. */
+  private static final int SHORT_SNIPPET_CHARS = 20;
 
   private final RealtimeProfileService profileService;
   private final VectorStore vectorStore;
@@ -50,19 +54,41 @@ public class RealtimeLookupService {
       return cached.response();
     }
 
-    List<RealtimeLookupSnippet> snippets = new ArrayList<>();
-    snippets.addAll(profileService.lookup(query, language, MAX_SNIPPETS));
+    RealtimeProfileService.ProfileLookupResult profileLookup =
+        profileService.lookupDetailed(query, language, MAX_SNIPPETS);
+    List<RealtimeLookupSnippet> snippets = new ArrayList<>(profileLookup.snippets());
+    List<RealtimeLookupSnippet> vectorResults = List.of();
     if (snippets.size() < 2) {
-      snippets.addAll(vectorSnippets(query, MAX_SNIPPETS - snippets.size()));
+      vectorResults = vectorSnippets(query, MAX_SNIPPETS - snippets.size());
+      snippets.addAll(vectorResults);
     }
 
     List<RealtimeLookupSnippet> resultSnippets = dedupe(snippets).stream()
         .limit(MAX_SNIPPETS)
         .toList();
+    String confidence = computeConfidence(
+        resultSnippets, profileLookup.bestScore(), !vectorResults.isEmpty());
     RealtimeLookupResponse response =
-        new RealtimeLookupResponse(!resultSnippets.isEmpty(), resultSnippets);
+        new RealtimeLookupResponse(!resultSnippets.isEmpty(), resultSnippets, confidence);
     cache.put(cacheKey, new CacheEntry(now, response));
     return response;
+  }
+
+  static String computeConfidence(
+      List<RealtimeLookupSnippet> snippets, int bestProfileScore, boolean hasVectorResults) {
+    if (snippets.isEmpty()) {
+      return "none";
+    }
+    if (hasVectorResults || bestProfileScore >= HIGH_CONFIDENCE_PROFILE_SCORE) {
+      return "high";
+    }
+    if (snippets.size() == 1 && snippets.get(0).text().length() < SHORT_SNIPPET_CHARS) {
+      return "low";
+    }
+    if (bestProfileScore >= RealtimeProfileService.MIN_RELEVANCE_SCORE) {
+      return "low";
+    }
+    return "low";
   }
 
   private static String validateQuery(String rawQuery) {

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/RealtimeProfileService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/RealtimeProfileService.java
@@ -24,6 +24,8 @@ public class RealtimeProfileService {
 
   private static final String PROFILE_PATH = "realtime/kevin-profile.json";
   private static final int DEFAULT_MAX_RESULTS = 5;
+  /** Minimum keyword score for a profile fact to be returned as relevant. */
+  static final int MIN_RELEVANCE_SCORE = 4;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final JsonNode root;
@@ -41,13 +43,19 @@ public class RealtimeProfileService {
     return StringUtils.hasText(card) ? card.trim() : "";
   }
 
+  public record ProfileLookupResult(List<RealtimeLookupSnippet> snippets, int bestScore) {}
+
   public List<RealtimeLookupSnippet> lookup(String query, String language) {
-    return lookup(query, language, DEFAULT_MAX_RESULTS);
+    return lookupDetailed(query, language, DEFAULT_MAX_RESULTS).snippets();
   }
 
   public List<RealtimeLookupSnippet> lookup(String query, String language, int maxResults) {
+    return lookupDetailed(query, language, maxResults).snippets();
+  }
+
+  public ProfileLookupResult lookupDetailed(String query, String language, int maxResults) {
     if (!StringUtils.hasText(query) || maxResults <= 0) {
-      return List.of();
+      return new ProfileLookupResult(List.of(), 0);
     }
     String lang = normalizeLang(language);
     String normalizedQuery = normalize(query);
@@ -55,26 +63,29 @@ public class RealtimeProfileService {
     List<ScoredSnippet> scored = new ArrayList<>();
     JsonNode facts = root.path("facts");
     if (!facts.isArray()) {
-      return List.of();
+      return new ProfileLookupResult(List.of(), 0);
     }
     int order = 0;
     for (JsonNode fact : facts) {
       String title = localized(fact.path("title"), lang);
       String text = localized(fact.path("text"), lang);
       List<String> tags = tags(fact.path("tags"));
-      int score = score(normalizedQuery, terms, title, text, tags);
-      if (score > 0) {
+      int factScore = score(normalizedQuery, terms, title, text, tags);
+      if (factScore > 0) {
         scored.add(new ScoredSnippet(
-            new RealtimeLookupSnippet("profile", title, text), score, order));
+            new RealtimeLookupSnippet("profile", title, text), factScore, order));
       }
       order++;
     }
-    return scored.stream()
+    int bestScore = scored.stream().mapToInt(ScoredSnippet::score).max().orElse(0);
+    List<RealtimeLookupSnippet> snippets = scored.stream()
+        .filter(s -> s.score() >= MIN_RELEVANCE_SCORE)
         .sorted(Comparator.comparingInt(ScoredSnippet::score).reversed()
             .thenComparingInt(ScoredSnippet::order))
         .map(ScoredSnippet::snippet)
         .limit(Math.max(1, maxResults))
         .toList();
+    return new ProfileLookupResult(snippets, bestScore);
   }
 
   public static String normalizeLang(String raw) {

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/SpeechSynthesisService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/SpeechSynthesisService.java
@@ -1,0 +1,136 @@
+package com.kevinmazali.portfolio.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.util.AiRequestContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Turn-based text-to-speech for the standard voice mode.
+ */
+@Slf4j
+@Service
+public class SpeechSynthesisService {
+
+  private static final String OPENAI_SPEECH_URL = "https://api.openai.com/v1/audio/speech";
+  private static final int MAX_TEXT_CHARS = 1200;
+
+  private final AiBudgetService aiBudgetService;
+  private final AiBudgetProperties budgetProperties;
+  private final AiCircuitBreaker aiCircuitBreaker;
+  private final String openAiApiKey;
+  private final String modelId;
+  private final String defaultVoice;
+  private final OpenAiSpeechHttpInvoker openAiSpeechHttpInvoker;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public SpeechSynthesisService(
+      AiBudgetService aiBudgetService,
+      AiBudgetProperties budgetProperties,
+      AiCircuitBreaker aiCircuitBreaker,
+      OpenAiSpeechHttpInvoker openAiSpeechHttpInvoker,
+      @Value("${spring.ai.openai.api-key:}") String openAiApiKey,
+      @Value("${spring.ai.openai.audio.speech.options.model:tts-1}") String modelId,
+      @Value("${spring.ai.openai.audio.speech.options.voice:nova}") String defaultVoice) {
+    this.aiBudgetService = aiBudgetService;
+    this.budgetProperties = budgetProperties;
+    this.aiCircuitBreaker = aiCircuitBreaker;
+    this.openAiSpeechHttpInvoker = openAiSpeechHttpInvoker;
+    this.openAiApiKey = openAiApiKey;
+    this.modelId = modelId;
+    this.defaultVoice = defaultVoice;
+  }
+
+  public boolean isConfigured() {
+    return StringUtils.hasText(openAiApiKey);
+  }
+
+  public byte[] synthesize(String text, String language) {
+    if (!isConfigured()) {
+      throw new IllegalStateException("OpenAI API key is not configured.");
+    }
+    String normalizedText = normalizeText(text);
+    String voice = resolveVoice(language);
+
+    String budgetUserId = AiRequestContext.budgetUserIdentifier(budgetProperties);
+    boolean anonymous = AiRequestContext.isAnonymousInteractiveUser();
+    aiCircuitBreaker.assertClosed();
+    aiBudgetService.assertWithinBudget(budgetUserId, anonymous);
+
+    ObjectNode body = objectMapper.createObjectNode();
+    body.put("model", modelId);
+    body.put("voice", voice);
+    body.put("input", normalizedText);
+    body.put("format", "mp3");
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(OPENAI_SPEECH_URL))
+        .timeout(Duration.ofSeconds(45))
+        .header("Authorization", "Bearer " + openAiApiKey)
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body.toString(), StandardCharsets.UTF_8))
+        .build();
+
+    long startNs = System.nanoTime();
+    try {
+      HttpResponse<byte[]> response = openAiSpeechHttpInvoker.invoke(request);
+      int responseStatus = response.statusCode();
+      if (responseStatus < 200 || responseStatus >= 300) {
+        String detail = new String(response.body(), StandardCharsets.UTF_8);
+        String msg = detail.length() > 350 ? detail.substring(0, 350) + "..." : detail;
+        throw new IllegalStateException("OpenAI speech API failed (HTTP " + responseStatus + "): " + msg);
+      }
+      double latencySec = (System.nanoTime() - startNs) / 1_000_000_000.0;
+      aiBudgetService.recordUsage(
+          budgetUserId,
+          modelId,
+          pseudoPromptTokensFromChars(normalizedText.length()),
+          0,
+          anonymous,
+          latencySec,
+          "audio_synthesis");
+      return response.body();
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      throw new IllegalStateException("Could not reach OpenAI speech API: " + e.getMessage(), e);
+    }
+  }
+
+  static int pseudoPromptTokensFromChars(int chars) {
+    return Math.max(1, chars);
+  }
+
+  private static String normalizeText(String text) {
+    if (!StringUtils.hasText(text)) {
+      throw new IllegalArgumentException("Text is required.");
+    }
+    String normalized = text.trim();
+    if (normalized.length() > MAX_TEXT_CHARS) {
+      throw new IllegalArgumentException("Text must be at most " + MAX_TEXT_CHARS + " characters.");
+    }
+    return normalized;
+  }
+
+  private String resolveVoice(String language) {
+    if (!StringUtils.hasText(language)) {
+      return defaultVoice;
+    }
+    String lang = language.trim().toLowerCase();
+    if ("no".equals(lang) || "nb".equals(lang) || "nn".equals(lang)) {
+      return defaultVoice;
+    }
+    return defaultVoice;
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/TranscriptionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/TranscriptionService.java
@@ -119,6 +119,10 @@ public class TranscriptionService {
     return text;
   }
 
+  public boolean isTranscriptionConfigured() {
+    return transcriptionModel.getIfAvailable() != null;
+  }
+
   /**
    * Calls Spring AI with an explicit language hint and returns trimmed text.
    */

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -41,6 +41,10 @@ spring:
             response-format: TEXT
             language: "no"
             temperature: 0
+        speech:
+          options:
+            model: tts-1
+            voice: nova
     anthropic:
       api-key: ${ANTHROPIC_API_KEY:}
       chat:
@@ -99,6 +103,9 @@ portfolio:
           output-per-million-usd: 0.00
         gpt-4o-transcribe:
           input-per-million-usd: 0.40
+          output-per-million-usd: 0.00
+        tts-1:
+          input-per-million-usd: 15.00
           output-per-million-usd: 0.00
         # GPT-Realtime-2 audio (USD per 1M audio tokens; reservation uses same estimateCostUsd math)
         gpt-realtime-2:

--- a/backend/src/main/resources/prompts/realtime-voice-en.txt
+++ b/backend/src/main/resources/prompts/realtime-voice-en.txt
@@ -10,6 +10,8 @@ Rules (same intent as the text chatbot):
 - Do not call tools for grades, private details, sensitive information, or questions outside Kevin's public profile. For document-grounded deep answers, suggest the text chat on the site.
 - Never invent specific grades, employers, dates, or private details. For grades, use a light refusal consistent with the site's policy. For sensitive private topics, decline politely.
 - If the question is not about Kevin or his profile, briefly say you focus on Kevin and suggest a topic.
+- If you are unsure what the user said or the transcription seems unclear, politely ask them to repeat or rephrase before attempting an answer. Never guess at unclear input.
+- If `lookup_kevin_info` returns no relevant results or very weak results, say you do not have information about that specific topic rather than guessing. Suggest a topic you can help with.
 - You are an AI assistant, not Kevin; keep that clear if users seem confused.
 
 Tone: friendly, professional, succinct for speech.

--- a/backend/src/main/resources/prompts/realtime-voice-no.txt
+++ b/backend/src/main/resources/prompts/realtime-voice-no.txt
@@ -10,5 +10,7 @@ Regler (samme hensikt som tekstchatten):
 - Ikke kall verktøy for karakterer, private detaljer, sensitiv informasjon eller spørsmål utenfor Kevin sin offentlige profil. For dokumentforankrede dybdesvar, foreslå tekstchatten på sida.
 - Oppfinn ikke karakterer, arbeidsgivere, datoer eller private detaljer. For karakterer: avvis vittig. For sensitivt: avvis høflig.
 - Hvis spørsmålet ikke handler om Kevin eller profilen hans, si kort at du bare svarer om Kevin og foreslå et tema.
+- Hvis du er usikker på hva brukeren sa, eller transkripsjonen virker uklar, be høflig om å få det gjentatt eller omformulert før du svarer. Ikke gjett når input er uklar.
+- Hvis `lookup_kevin_info` ikke gir relevante treff eller bare svake treff, si at du ikke har informasjon om akkurat det temaet i stedet for å gjette. Foreslå et tema du kan hjelpe med.
 
 Du er en KI-assistent, ikke Kevin; vær tydelig hvis brukeren blander dette.

--- a/backend/src/test/java/com/kevinmazali/portfolio/config/BudgetModelConsistencyTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/config/BudgetModelConsistencyTest.java
@@ -26,7 +26,7 @@ class BudgetModelConsistencyTest {
    * Budget YAML entries for non-chat models (e.g. OpenAI Whisper) must not require a {@link SupportedChatModel} enum value.
    */
   private static final Set<String> BUDGET_KEYS_EXEMPT_FROM_CHAT_ENUM =
-      of("whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-realtime-2");
+      of("whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "tts-1", "gpt-realtime-2");
 
   private static Set<String> budgetModelKeys;
 

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/RealtimeControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/RealtimeControllerTest.java
@@ -261,7 +261,8 @@ class RealtimeControllerTest {
     when(realtimeLookupService.lookup(eq("NTNU"), eq("en")))
         .thenReturn(new RealtimeLookupResponse(
             true,
-            List.of(new RealtimeLookupSnippet("profile", "Data engineering", "Kevin studies at NTNU."))));
+            List.of(new RealtimeLookupSnippet("profile", "Data engineering", "Kevin studies at NTNU.")),
+            "high"));
 
     mockMvc.perform(post("/realtime/lookup")
             .content("{\"query\":\"NTNU\",\"language\":\"en\"}")
@@ -278,7 +279,7 @@ class RealtimeControllerTest {
   void lookupStillWorksWhenRealtimeFlagDisabled() throws Exception {
     realtimeProperties.setEnabled(false);
     when(realtimeLookupService.lookup(eq("NTNU"), eq("en")))
-        .thenReturn(new RealtimeLookupResponse(true, List.of()));
+        .thenReturn(new RealtimeLookupResponse(true, List.of(), "high"));
 
     mockMvc.perform(post("/realtime/lookup")
             .content("{\"query\":\"NTNU\",\"language\":\"en\"}")

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/RealtimeControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/RealtimeControllerTest.java
@@ -18,6 +18,8 @@ import com.kevinmazali.portfolio.service.RealtimeLookupService;
 import com.kevinmazali.portfolio.service.RealtimeModelCatalog;
 import com.kevinmazali.portfolio.service.RealtimeSessionService;
 import com.kevinmazali.portfolio.service.RequestLogService;
+import com.kevinmazali.portfolio.service.SpeechSynthesisService;
+import com.kevinmazali.portfolio.service.TranscriptionService;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -79,6 +81,12 @@ class RealtimeControllerTest {
   private ElevenLabsRealtimeTokenService elevenLabsRealtimeTokenService;
 
   @MockitoBean
+  private TranscriptionService transcriptionService;
+
+  @MockitoBean
+  private SpeechSynthesisService speechSynthesisService;
+
+  @MockitoBean
   private RequestLogService requestLogService;
 
   @AfterEach
@@ -89,10 +97,14 @@ class RealtimeControllerTest {
   @Test
   void statusEnabledWhenFlagAndKey() throws Exception {
     when(realtimeModelCatalog.hasAvailableModels()).thenReturn(true);
+    when(transcriptionService.isTranscriptionConfigured()).thenReturn(true);
+    when(speechSynthesisService.isConfigured()).thenReturn(true);
 
     mockMvc.perform(get("/realtime/status"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.enabled").value(true))
+        .andExpect(jsonPath("$.standardEnabled").value(true))
+        .andExpect(jsonPath("$.liveEnabled").value(true))
         .andExpect(jsonPath("$.voices[0]").value("marin"))
         .andExpect(jsonPath("$.voices[1]").value("cedar"))
         .andExpect(jsonPath("$.reasoningEfforts[0]").value("low"))
@@ -122,9 +134,14 @@ class RealtimeControllerTest {
   @Test
   void statusDisabledWhenFeatureFlagFalse() throws Exception {
     realtimeProperties.setEnabled(false);
+    when(realtimeModelCatalog.hasAvailableModels()).thenReturn(false);
+    when(transcriptionService.isTranscriptionConfigured()).thenReturn(false);
+    when(speechSynthesisService.isConfigured()).thenReturn(false);
     mockMvc.perform(get("/realtime/status"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.enabled").value(false));
+        .andExpect(jsonPath("$.enabled").value(false))
+        .andExpect(jsonPath("$.standardEnabled").value(false))
+        .andExpect(jsonPath("$.liveEnabled").value(false));
   }
 
   @Test
@@ -258,16 +275,18 @@ class RealtimeControllerTest {
   }
 
   @Test
-  void lookupReturns503WhenFeatureDisabled() throws Exception {
+  void lookupStillWorksWhenRealtimeFlagDisabled() throws Exception {
     realtimeProperties.setEnabled(false);
+    when(realtimeLookupService.lookup(eq("NTNU"), eq("en")))
+        .thenReturn(new RealtimeLookupResponse(true, List.of()));
 
     mockMvc.perform(post("/realtime/lookup")
             .content("{\"query\":\"NTNU\",\"language\":\"en\"}")
             .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isServiceUnavailable())
-        .andExpect(jsonPath("$.code").value("REALTIME_DISABLED"));
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.found").value(true));
 
-    verify(realtimeLookupService, never()).lookup(any(), any());
+    verify(realtimeLookupService).lookup(eq("NTNU"), eq("en"));
   }
 
   @Test
@@ -320,13 +339,24 @@ class RealtimeControllerMissingOpenAiKeyMvcTest {
   private ElevenLabsRealtimeTokenService elevenLabsRealtimeTokenService;
 
   @MockitoBean
+  private TranscriptionService transcriptionService;
+
+  @MockitoBean
+  private SpeechSynthesisService speechSynthesisService;
+
+  @MockitoBean
   private RequestLogService requestLogService;
 
   @Test
   void statusDisabledWhenApiKeyUnset() throws Exception {
+    when(realtimeModelCatalog.hasAvailableModels()).thenReturn(false);
+    when(transcriptionService.isTranscriptionConfigured()).thenReturn(false);
+    when(speechSynthesisService.isConfigured()).thenReturn(false);
     mockMvc.perform(get("/realtime/status"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.enabled").value(false));
+        .andExpect(jsonPath("$.enabled").value(false))
+        .andExpect(jsonPath("$.standardEnabled").value(false))
+        .andExpect(jsonPath("$.liveEnabled").value(false));
   }
 
   @Test

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/SpeechSynthesisControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/SpeechSynthesisControllerTest.java
@@ -1,0 +1,98 @@
+package com.kevinmazali.portfolio.controller;
+
+import com.kevinmazali.portfolio.MockConfig;
+import com.kevinmazali.portfolio.MvcTestUserDetailsConfig;
+import com.kevinmazali.portfolio.config.ApiErrorConfiguration;
+import com.kevinmazali.portfolio.config.AskRateLimitProperties;
+import com.kevinmazali.portfolio.config.DatasetGenerateRateLimitProperties;
+import com.kevinmazali.portfolio.config.ExperimentRunRateLimitProperties;
+import com.kevinmazali.portfolio.config.RealtimeRateLimitProperties;
+import com.kevinmazali.portfolio.config.SecurityConfig;
+import com.kevinmazali.portfolio.config.WebConfig;
+import com.kevinmazali.portfolio.controller.advice.GlobalApiExceptionHandler;
+import com.kevinmazali.portfolio.service.RequestLogService;
+import com.kevinmazali.portfolio.service.SpeechSynthesisService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SpeechSynthesisController.class)
+@EnableConfigurationProperties({
+    AskRateLimitProperties.class,
+    ExperimentRunRateLimitProperties.class,
+    DatasetGenerateRateLimitProperties.class,
+    RealtimeRateLimitProperties.class
+})
+@Import({
+    WebConfig.class,
+    SecurityConfig.class,
+    MvcTestUserDetailsConfig.class,
+    MockConfig.class,
+    GlobalApiExceptionHandler.class,
+    ApiErrorConfiguration.class
+})
+class SpeechSynthesisControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private SpeechSynthesisService speechSynthesisService;
+
+  @MockitoBean
+  private RequestLogService requestLogService;
+
+  @Test
+  void synthesizeReturnsMp3Audio() throws Exception {
+    when(speechSynthesisService.synthesize("Hello", "en")).thenReturn(new byte[] {1, 2, 3});
+
+    mockMvc.perform(post("/synthesize")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("X-Chat-Language", "en")
+            .content("{\"text\":\"Hello\"}"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith("audio/mpeg"))
+        .andExpect(content().bytes(new byte[] {1, 2, 3}));
+
+    verify(speechSynthesisService).synthesize(eq("Hello"), eq("en"));
+  }
+
+  @Test
+  void synthesizeReturns400OnValidationFailure() throws Exception {
+    when(speechSynthesisService.synthesize("", "en"))
+        .thenThrow(new IllegalArgumentException("Text is required."));
+
+    mockMvc.perform(post("/synthesize")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("X-Chat-Language", "en")
+            .content("{\"text\":\"\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("Text is required."));
+  }
+
+  @Test
+  void synthesizeReturns503WhenUnavailable() throws Exception {
+    when(speechSynthesisService.synthesize("Hei", "no"))
+        .thenThrow(new IllegalStateException("OpenAI API key is not configured."));
+
+    mockMvc.perform(post("/synthesize")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("X-Chat-Language", "no")
+            .content("{\"text\":\"Hei\"}"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.error").value("Speech synthesis is temporarily unavailable."));
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/RealtimeLookupServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/RealtimeLookupServiceTest.java
@@ -38,6 +38,7 @@ class RealtimeLookupServiceTest {
     RealtimeLookupResponse response = service.lookup("NTNU", "en");
 
     assertThat(response.found()).isTrue();
+    assertThat(response.confidence()).isEqualTo("high");
     assertThat(response.snippets()).hasSizeGreaterThanOrEqualTo(2);
     assertThat(response.snippets()).allMatch(s -> "profile".equals(s.sourceType()));
     verify(vectorStore, never()).similaritySearch(any(SearchRequest.class));
@@ -54,6 +55,7 @@ class RealtimeLookupServiceTest {
     RealtimeLookupResponse response = service.lookup("rare distributed systems topic", "en");
 
     assertThat(response.found()).isTrue();
+    assertThat(response.confidence()).isEqualTo("high");
     assertThat(response.snippets()).anySatisfy(snippet -> {
       assertThat(snippet.sourceType()).isEqualTo("rag");
       assertThat(snippet.title()).isEqualTo("rare.md");
@@ -74,6 +76,7 @@ class RealtimeLookupServiceTest {
     RealtimeLookupResponse response = service.lookup("unmatched zzzzzzz topic", "en");
 
     assertThat(response.found()).isFalse();
+    assertThat(response.confidence()).isEqualTo("none");
     assertThat(response.snippets()).isEmpty();
   }
 
@@ -86,6 +89,26 @@ class RealtimeLookupServiceTest {
     assertThatThrownBy(() -> service.lookup("x".repeat(301), "en"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("300");
+  }
+
+  @Test
+  void computeConfidenceMarksWeakProfileMatchesAsLow() {
+    assertThat(RealtimeLookupService.computeConfidence(
+            List.of(new com.kevinmazali.portfolio.model.RealtimeLookupSnippet(
+                "profile", "Title", "Short")),
+            5,
+            false))
+        .isEqualTo("low");
+  }
+
+  @Test
+  void computeConfidenceMarksStrongProfileMatchesAsHigh() {
+    assertThat(RealtimeLookupService.computeConfidence(
+            List.of(new com.kevinmazali.portfolio.model.RealtimeLookupSnippet(
+                "profile", "Title", "Kevin studies at NTNU.")),
+            8,
+            false))
+        .isEqualTo("high");
   }
 
   @Test

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/SpeechSynthesisServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/SpeechSynthesisServiceTest.java
@@ -109,4 +109,29 @@ class SpeechSynthesisServiceTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("OpenAI speech API failed");
   }
+
+  @Test
+  void isConfiguredFalseWithoutApiKey() {
+    AiBudgetProperties budgetProperties = new AiBudgetProperties();
+    SpeechSynthesisService unconfigured = new SpeechSynthesisService(
+        aiBudgetService,
+        budgetProperties,
+        aiCircuitBreaker,
+        openAiSpeechHttpInvoker,
+        "",
+        "tts-1",
+        "nova");
+
+    assertThat(unconfigured.isConfigured()).isFalse();
+    assertThatThrownBy(() -> unconfigured.synthesize("hello", "en"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not configured");
+  }
+
+  @Test
+  void synthesizeRejectsOverlongText() {
+    assertThatThrownBy(() -> service.synthesize("x".repeat(1201), "en"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("at most");
+  }
 }

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/SpeechSynthesisServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/SpeechSynthesisServiceTest.java
@@ -1,0 +1,112 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.exception.AiCircuitOpenException;
+import com.kevinmazali.portfolio.exception.BudgetExceededException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpeechSynthesisServiceTest {
+
+  @Mock
+  private AiBudgetService aiBudgetService;
+
+  @Mock
+  private AiCircuitBreaker aiCircuitBreaker;
+
+  @Mock
+  private OpenAiSpeechHttpInvoker openAiSpeechHttpInvoker;
+
+  @Mock
+  private HttpResponse<byte[]> httpResponse;
+
+  private SpeechSynthesisService service;
+
+  @BeforeEach
+  void setUp() {
+    AiBudgetProperties budgetProperties = new AiBudgetProperties();
+    budgetProperties.setEnabled(false);
+    service = new SpeechSynthesisService(
+        aiBudgetService,
+        budgetProperties,
+        aiCircuitBreaker,
+        openAiSpeechHttpInvoker,
+        "sk-test",
+        "tts-1",
+        "nova");
+  }
+
+  @Test
+  void synthesizeReturnsAudioAndRecordsUsage() throws Exception {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn(new byte[] {1, 2});
+    when(openAiSpeechHttpInvoker.invoke(any(HttpRequest.class))).thenReturn(httpResponse);
+
+    byte[] result = service.synthesize("Hei", "no");
+
+    assertThat(result).containsExactly(1, 2);
+    verify(aiBudgetService).recordUsage(
+        anyString(),
+        eq("tts-1"),
+        eq(3),
+        eq(0),
+        anyBoolean(),
+        anyDouble(),
+        eq("audio_synthesis"));
+  }
+
+  @Test
+  void synthesizeRejectsBlankText() {
+    assertThatThrownBy(() -> service.synthesize("  ", "en"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Text is required");
+  }
+
+  @Test
+  void synthesizePropagatesBudgetExceeded() {
+    doThrow(new BudgetExceededException("cap"))
+        .when(aiBudgetService).assertWithinBudget(anyString(), anyBoolean());
+    assertThatThrownBy(() -> service.synthesize("hello", "en"))
+        .isInstanceOf(BudgetExceededException.class);
+    verifyNoInteractions(openAiSpeechHttpInvoker);
+  }
+
+  @Test
+  void synthesizePropagatesCircuitOpen() {
+    doThrow(new AiCircuitOpenException("circuit"))
+        .when(aiCircuitBreaker).assertClosed();
+    assertThatThrownBy(() -> service.synthesize("hello", "en"))
+        .isInstanceOf(AiCircuitOpenException.class);
+    verifyNoInteractions(openAiSpeechHttpInvoker);
+  }
+
+  @Test
+  void synthesizeThrowsWhenOpenAiRejects() throws Exception {
+    when(httpResponse.statusCode()).thenReturn(400);
+    when(httpResponse.body()).thenReturn("{\"error\":\"bad\"}".getBytes());
+    when(openAiSpeechHttpInvoker.invoke(any(HttpRequest.class))).thenReturn(httpResponse);
+
+    assertThatThrownBy(() -> service.synthesize("hello", "en"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("OpenAI speech API failed");
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,9 @@ services:
   db:
     image: pgvector/pgvector:pg17
     container_name: aboutme-postgres
+    env_file:
+      - path: .env.docker
+        required: false
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -31,6 +34,8 @@ services:
       mvn -B spring-boot:run
       -Dspring-boot.run.jvmArguments="-Dspring.devtools.restart.enabled=true"
     env_file:
+      - path: .env.docker
+        required: false
       - path: backend/.env
         required: false
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,66 @@
+# Development stack: live reload via Vite HMR and spring-boot-devtools.
+# Usage: docker compose -f docker-compose.dev.yml up
+# Prod-like images: docker compose up -d --build (see docker-compose.yml)
+
+services:
+  db:
+    image: pgvector/pgvector:pg17
+    container_name: aboutme-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: aboutme
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d aboutme"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  backend:
+    image: maven:3.9-eclipse-temurin-21
+    container_name: aboutme-backend-dev
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+      - m2_cache:/root/.m2
+    command: >-
+      mvn -B spring-boot:run
+      -Dspring-boot.run.jvmArguments="-Dspring.devtools.restart.enabled=true"
+    env_file:
+      - path: backend/.env
+        required: false
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/aboutme
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      PORT: "8080"
+      SANITIZER_ENABLED: "true"
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    image: node:22-alpine
+    container_name: aboutme-frontend-dev
+    working_dir: /app
+    volumes:
+      - ./frontend/homepage:/app
+      - fe_node_modules:/app/node_modules
+    command: sh -c "npm install --no-audit --no-fund && npm run dev -- --host 0.0.0.0"
+    environment:
+      VITE_API_PROXY_TARGET: http://backend:8080
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:
+  m2_cache:
+  fe_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,12 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+    develop:
+      watch:
+        - action: rebuild
+          path: ./backend/src
+        - action: rebuild
+          path: ./backend/pom.xml
     container_name: aboutme-backend
     depends_on:
       db:
@@ -43,6 +49,12 @@ services:
     build:
       context: ./frontend/homepage
       dockerfile: Dockerfile
+    develop:
+      watch:
+        - action: rebuild
+          path: ./frontend/homepage/src
+        - action: rebuild
+          path: ./frontend/homepage/package.json
     container_name: aboutme-frontend
     depends_on:
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   db:
     image: pgvector/pgvector:pg17
     container_name: aboutme-postgres
+    env_file:
+      - path: .env.docker
+        required: false
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -32,6 +35,8 @@ services:
         condition: service_healthy
     # Secrets live in backend/.env (same keys as .env.example). Do not set empty OPENAI_API_KEY here (overrides file).
     env_file:
+      - path: .env.docker
+        required: false
       - path: backend/.env
         required: false
     environment:

--- a/frontend/homepage/cypress/e2e/voice-feedback.cy.ts
+++ b/frontend/homepage/cypress/e2e/voice-feedback.cy.ts
@@ -6,7 +6,17 @@ const FAKE_MODELS = [
   { id: 'gpt-5.4-mini', provider: 'OPENAI', label: 'GPT-5.4 mini', tags: ['FAST'] },
 ]
 
-describe('Voice page (realtime disabled)', () => {
+const VOICE_DISABLED_STATUS = {
+  enabled: false,
+  standardEnabled: false,
+  liveEnabled: false,
+  voices: ['marin', 'cedar'],
+  reasoningEfforts: ['low', 'medium', 'high'],
+  defaultVoice: 'marin',
+  defaultReasoningEffort: 'low',
+}
+
+describe('Voice page (voice disabled)', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/chat/models', {
       statusCode: 200,
@@ -14,28 +24,34 @@ describe('Voice page (realtime disabled)', () => {
     }).as('chatModels')
     cy.intercept('GET', '**/api/realtime/status', {
       statusCode: 200,
-      body: { enabled: false },
+      body: VOICE_DISABLED_STATUS,
     }).as('realtimeStatus')
+    cy.intercept('GET', '**/api/realtime/models', {
+      statusCode: 200,
+      body: [],
+    }).as('realtimeModels')
   })
 
-  it('shows unavailable copy when server reports realtime off', () => {
+  it('shows standard-mode unavailable copy when server reports voice off', () => {
     cy.visit('/voice', {
       onBeforeLoad(win) {
         win.localStorage.setItem('lang', 'en')
       },
     })
     cy.wait('@realtimeStatus')
-    cy.contains('Voice chat is not enabled on the server right now.').should('be.visible')
+    cy.wait('@realtimeModels')
+    cy.contains('Standard voice mode is not available right now.').should('be.visible')
   })
 
-  it('shows Norwegian unavailable copy when lang is no', () => {
+  it('shows Norwegian standard-mode unavailable copy when lang is no', () => {
     cy.visit('/voice', {
       onBeforeLoad(win) {
         win.localStorage.setItem('lang', 'no')
       },
     })
     cy.wait('@realtimeStatus')
-    cy.contains('Stemmechat er ikke slått på hos serveren akkurat nå.').should('be.visible')
+    cy.wait('@realtimeModels')
+    cy.contains('Standard stemmemodus er ikke tilgjengelig akkurat nå.').should('be.visible')
   })
 })
 

--- a/frontend/homepage/cypress/e2e/voice-standard-flow.cy.ts
+++ b/frontend/homepage/cypress/e2e/voice-standard-flow.cy.ts
@@ -1,0 +1,71 @@
+function withFakeMicrophone() {
+  return {
+    onBeforeLoad(win: Cypress.AUTWindow) {
+      win.sessionStorage.clear()
+      win.localStorage.setItem('lang', 'en')
+      Object.defineProperty(win.navigator, 'mediaDevices', {
+        configurable: true,
+        value: {
+          getUserMedia: async () => {
+            const ctx = new win.AudioContext()
+            await ctx.resume().catch(() => {})
+            const osc = ctx.createOscillator()
+            const dst = ctx.createMediaStreamDestination()
+            osc.connect(dst)
+            osc.frequency.value = 440
+            osc.start()
+            return dst.stream
+          },
+        },
+      })
+    },
+  }
+}
+
+describe('Standard voice mode', () => {
+  it('runs STT -> lookup -> synthesize pipeline', () => {
+    cy.intercept('GET', '**/api/realtime/status', {
+      statusCode: 200,
+      body: {
+        enabled: true,
+        standardEnabled: true,
+        liveEnabled: true,
+        voices: ['marin', 'cedar'],
+        reasoningEfforts: ['low', 'medium', 'high'],
+        defaultVoice: 'marin',
+        defaultReasoningEffort: 'low',
+      },
+    }).as('status')
+    cy.intercept('GET', '**/api/realtime/models', {
+      statusCode: 200,
+      body: [{ provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI', defaultOption: true }],
+    }).as('models')
+    cy.intercept('POST', '**/api/transcribe', {
+      statusCode: 200,
+      body: { text: 'what does Kevin study' },
+    }).as('transcribe')
+    cy.intercept('POST', '**/api/realtime/lookup', {
+      statusCode: 200,
+      body: {
+        found: true,
+        snippets: [{ sourceType: 'profile', title: 'NTNU', text: 'Kevin studies data engineering at NTNU.' }],
+      },
+    }).as('lookup')
+    cy.intercept('POST', '**/api/synthesize', {
+      statusCode: 200,
+      headers: { 'content-type': 'audio/mpeg' },
+      body: 'FAKEAUDIO',
+    }).as('synthesize')
+
+    cy.visit('/voice', withFakeMicrophone())
+    cy.wait('@status')
+    cy.wait('@models')
+    cy.contains('button', 'English').click()
+    cy.contains('button', /start recording/i).click()
+    cy.wait(800)
+    cy.contains('button', /stop recording/i).click()
+    cy.wait('@transcribe')
+    cy.wait('@lookup')
+    cy.wait('@synthesize')
+  })
+})

--- a/frontend/homepage/cypress/e2e/voice-standard-flow.cy.ts
+++ b/frontend/homepage/cypress/e2e/voice-standard-flow.cy.ts
@@ -1,3 +1,9 @@
+function waitForRecordedAudioChunks() {
+  // Aligns with useSpeechTranscription's 250ms MediaRecorder timeslice; stopping sooner yields an empty blob (no /transcribe).
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(800)
+}
+
 function withFakeMicrophone() {
   return {
     onBeforeLoad(win: Cypress.AUTWindow) {
@@ -61,10 +67,11 @@ describe('Standard voice mode', () => {
     cy.wait('@status')
     cy.wait('@models')
     cy.contains('button', 'English').click()
-    cy.contains('button', /start recording/i).click()
-    cy.contains('button', /stop recording/i).should('be.visible')
-    cy.contains('button', /stop recording/i).click()
-    cy.wait('@transcribe')
+    cy.contains('button', /start recording/i).click({ force: true })
+    cy.get('[role="img"][aria-label="Recording..."]', { timeout: 15_000 }).should('be.visible')
+    waitForRecordedAudioChunks()
+    cy.contains('button', /stop recording/i).click({ force: true })
+    cy.wait('@transcribe', { timeout: 15_000 })
     cy.wait('@lookup')
     cy.wait('@synthesize')
   })

--- a/frontend/homepage/cypress/e2e/voice-standard-flow.cy.ts
+++ b/frontend/homepage/cypress/e2e/voice-standard-flow.cy.ts
@@ -62,7 +62,7 @@ describe('Standard voice mode', () => {
     cy.wait('@models')
     cy.contains('button', 'English').click()
     cy.contains('button', /start recording/i).click()
-    cy.wait(800)
+    cy.contains('button', /stop recording/i).should('be.visible')
     cy.contains('button', /stop recording/i).click()
     cy.wait('@transcribe')
     cy.wait('@lookup')

--- a/frontend/homepage/src/components/voice/RealtimeVoicePanel.vue
+++ b/frontend/homepage/src/components/voice/RealtimeVoicePanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { Mic, MicOff, Loader2, TriangleAlert } from 'lucide-vue-next'
+import { Mic, MicOff, Loader2, TriangleAlert, Square } from 'lucide-vue-next'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import AiStatusDialog from '@/components/AiStatusDialog.vue'
@@ -34,8 +34,10 @@ const {
   sessionNotice,
   assistantTranscript,
   userTranscript,
+  isModelSpeaking,
   connect,
   disconnect,
+  stopResponse,
   maxSessionMs,
 } = useRealtimeVoice(computed(() => props.language), selectedRealtimeOptions, selectedVoiceModel)
 
@@ -47,6 +49,7 @@ const copy = computed(() => {
       : 'Live stemmechat er ikke slått på hos serveren akkurat nå.',
     connect: en ? 'Start live voice' : 'Start live stemme',
     disconnect: en ? 'End session' : 'Avslutt',
+    stopSpeaking: en ? 'Stop speaking' : 'Stopp tale',
     connecting: en ? 'Connecting…' : 'Kobler til…',
     live: en ? 'Live' : 'Aktiv',
     modelLabel: en ? 'Provider/model' : 'Leverandør/modell',
@@ -182,6 +185,17 @@ function setVoiceModelFromEvent(event: Event) {
         </Button>
         <Button v-if="connectionState === 'connecting'" type="button" variant="secondary" disabled>
           {{ copy.connecting }}
+        </Button>
+        <Button
+          v-if="connectionState === 'connected' && isModelSpeaking && selectedVoiceProvider === 'OPENAI'"
+          type="button"
+          variant="secondary"
+          class="rounded-2xl"
+          data-testid="live-voice-stop-speaking"
+          @click="stopResponse"
+        >
+          <Square class="me-2 inline size-4" aria-hidden="true" />
+          {{ copy.stopSpeaking }}
         </Button>
         <Button
           v-if="connectionState === 'connected'"

--- a/frontend/homepage/src/components/voice/RealtimeVoicePanel.vue
+++ b/frontend/homepage/src/components/voice/RealtimeVoicePanel.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Mic, MicOff, Loader2, TriangleAlert } from 'lucide-vue-next'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import AiStatusDialog from '@/components/AiStatusDialog.vue'
+import { useVoiceModelStore } from '@/stores/voice-model'
+import { useRealtimeVoice } from '@/composables/useRealtimeVoice'
+import type { RealtimeReasoningEffort, RealtimeVoiceChoice } from '@/lib/realtime-voice'
+
+const props = defineProps<{
+  language: 'en' | 'no'
+  available: boolean | null
+  voiceOptions: RealtimeVoiceChoice[]
+  reasoningOptions: RealtimeReasoningEffort[]
+  defaultVoice: RealtimeVoiceChoice
+  defaultReasoningEffort: RealtimeReasoningEffort
+}>()
+
+const voiceModelStore = useVoiceModelStore()
+const selectedVoice = ref<RealtimeVoiceChoice>(props.defaultVoice)
+const selectedReasoningEffort = ref<RealtimeReasoningEffort>(props.defaultReasoningEffort)
+const aiErrorDialogOpen = ref(false)
+const selectedRealtimeOptions = computed(() => ({
+  voice: selectedVoice.value,
+  reasoningEffort: selectedReasoningEffort.value,
+}))
+const selectedVoiceModel = computed(() => voiceModelStore.selectedModel)
+const selectedVoiceProvider = computed(() => selectedVoiceModel.value?.provider ?? 'OPENAI')
+
+const {
+  connectionState,
+  errorMessage,
+  sessionNotice,
+  assistantTranscript,
+  userTranscript,
+  connect,
+  disconnect,
+  maxSessionMs,
+} = useRealtimeVoice(computed(() => props.language), selectedRealtimeOptions, selectedVoiceModel)
+
+const copy = computed(() => {
+  const en = props.language === 'en'
+  return {
+    unavailable: en
+      ? 'Live voice is not enabled on the server right now.'
+      : 'Live stemmechat er ikke slått på hos serveren akkurat nå.',
+    connect: en ? 'Start live voice' : 'Start live stemme',
+    disconnect: en ? 'End session' : 'Avslutt',
+    connecting: en ? 'Connecting…' : 'Kobler til…',
+    live: en ? 'Live' : 'Aktiv',
+    modelLabel: en ? 'Provider/model' : 'Leverandør/modell',
+    voiceLabel: en ? 'Voice' : 'Stemme',
+    reasoningLabel: en ? 'Reasoning' : 'Resonnering',
+    you: en ? 'You (transcript)' : 'Du (transkripsjon)',
+    assistant: en ? 'Assistant (transcript)' : 'Assistent (transkripsjon)',
+    warningTitle: en ? 'Experimental mode' : 'Eksperimentell modus',
+    warningBody: en
+      ? 'Live WebRTC voice is faster, but can be unstable. Sessions can drop and each session ends after ~3 minutes.'
+      : 'Live WebRTC-stemme er raskere, men kan være ustabil. Økter kan falle ut og avsluttes etter ca. 3 minutter.',
+  }
+})
+
+const voiceLabels: Record<RealtimeVoiceChoice, string> = { marin: 'Marin', cedar: 'Cedar' }
+const reasoningLabels = computed<Record<RealtimeReasoningEffort, string>>(() => ({
+  low: props.language === 'en' ? 'Fast' : 'Rask',
+  medium: props.language === 'en' ? 'Balanced' : 'Balansert',
+  high: props.language === 'en' ? 'Thorough' : 'Grundig',
+}))
+
+const sessionControlsDisabled = computed(
+  () => connectionState.value === 'connecting' || connectionState.value === 'connected',
+)
+
+const errorDialogCopy = computed(() => ({
+  title: props.language === 'en' ? 'Voice could not start' : 'Stemme kunne ikke starte',
+  description:
+    props.language === 'en'
+      ? 'The live AI service needs a fresh session before it can continue.'
+      : 'Live AI-tjenesten trenger en ny økt før den kan fortsette.',
+  retry: props.language === 'en' ? 'Try again' : 'Prøv igjen',
+}))
+
+watch(errorMessage, (message) => {
+  aiErrorDialogOpen.value = message.trim() !== ''
+})
+
+function setVoiceModelFromEvent(event: Event) {
+  const target = event.target
+  if (target instanceof HTMLSelectElement) {
+    voiceModelStore.setSelectedModelId(target.value)
+  }
+}
+</script>
+
+<template>
+  <AiStatusDialog
+    v-model:open="aiErrorDialogOpen"
+    :title="errorDialogCopy.title"
+    :description="errorDialogCopy.description"
+    :message="errorMessage"
+    :retry-label="errorDialogCopy.retry"
+    show-retry
+    @retry="connect"
+  />
+
+  <Alert class="mb-4 border-amber-300 bg-amber-50/90 text-amber-900">
+    <TriangleAlert class="size-4" aria-hidden="true" />
+    <AlertTitle>{{ copy.warningTitle }}</AlertTitle>
+    <AlertDescription>{{ copy.warningBody }}</AlertDescription>
+  </Alert>
+
+  <div
+    v-if="available === false"
+    class="rounded-2xl border border-amber-200 bg-amber-50/90 px-4 py-3 text-center text-sm text-amber-900"
+  >
+    {{ copy.unavailable }}
+  </div>
+
+  <template v-else-if="available === true">
+    <div class="flex flex-col items-center gap-6">
+      <div
+        class="relative flex h-32 w-32 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-indigo-700 shadow-xl shadow-blue-500/25"
+        :class="{ 'ring-4 ring-blue-400/50 animate-pulse': connectionState === 'connected' }"
+      >
+        <Loader2 v-if="connectionState === 'connecting'" class="size-14 animate-spin text-white" aria-hidden="true" />
+        <Mic v-else class="size-14 text-white opacity-90" aria-hidden="true" />
+      </div>
+
+      <p v-if="connectionState === 'connected'" class="text-sm font-medium text-green-700">
+        {{ copy.live }} · ~{{ Math.round(maxSessionMs / 60_000) }} min max
+      </p>
+
+      <label class="w-full max-w-md text-left text-xs font-semibold uppercase text-slate-600">
+        {{ copy.modelLabel }}
+        <select
+          :value="voiceModelStore.selectedModelId"
+          data-testid="voice-model-select"
+          class="mt-1 h-10 w-full rounded-lg border border-blue-100 bg-white/90 px-3 text-sm font-medium normal-case text-slate-800 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="sessionControlsDisabled"
+          @change="setVoiceModelFromEvent"
+        >
+          <option
+            v-for="model in voiceModelStore.models"
+            :key="model.provider + ':' + model.id"
+            :value="model.provider + ':' + model.id"
+          >
+            {{ model.label }}
+          </option>
+        </select>
+      </label>
+
+      <div v-if="selectedVoiceProvider === 'OPENAI'" class="grid w-full max-w-md grid-cols-1 gap-3 sm:grid-cols-2">
+        <label class="text-left text-xs font-semibold uppercase text-slate-600">
+          {{ copy.voiceLabel }}
+          <select
+            v-model="selectedVoice"
+            data-testid="voice-select"
+            class="mt-1 h-10 w-full rounded-lg border border-blue-100 bg-white/90 px-3 text-sm font-medium normal-case text-slate-800 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+            :disabled="sessionControlsDisabled"
+          >
+            <option v-for="voice in voiceOptions" :key="voice" :value="voice">{{ voiceLabels[voice] }}</option>
+          </select>
+        </label>
+
+        <label class="text-left text-xs font-semibold uppercase text-slate-600">
+          {{ copy.reasoningLabel }}
+          <select
+            v-model="selectedReasoningEffort"
+            data-testid="reasoning-select"
+            class="mt-1 h-10 w-full rounded-lg border border-blue-100 bg-white/90 px-3 text-sm font-medium normal-case text-slate-800 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+            :disabled="sessionControlsDisabled"
+          >
+            <option v-for="effort in reasoningOptions" :key="effort" :value="effort">{{ reasoningLabels[effort] }}</option>
+          </select>
+        </label>
+      </div>
+
+      <div class="flex flex-wrap justify-center gap-3">
+        <Button v-if="connectionState === 'idle' || connectionState === 'error'" type="button" @click="connect">
+          {{ copy.connect }}
+        </Button>
+        <Button v-if="connectionState === 'connecting'" type="button" variant="secondary" disabled>
+          {{ copy.connecting }}
+        </Button>
+        <Button
+          v-if="connectionState === 'connected'"
+          type="button"
+          variant="outline"
+          class="rounded-2xl border-red-200 text-red-700 hover:bg-red-50"
+          @click="disconnect"
+        >
+          <MicOff class="me-2 inline size-4" aria-hidden="true" />
+          {{ copy.disconnect }}
+        </Button>
+      </div>
+    </div>
+
+    <Alert v-if="sessionNotice" class="mt-6 border-blue-200 bg-blue-50 text-slate-800">
+      <AlertDescription>{{ sessionNotice }}</AlertDescription>
+    </Alert>
+
+    <div
+      v-if="connectionState === 'connected' || userTranscript || assistantTranscript"
+      class="mt-8 space-y-4 rounded-2xl border border-blue-100 bg-white/85 p-4 shadow-sm backdrop-blur-md"
+    >
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ copy.you }}</p>
+        <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ userTranscript || '…' }}</p>
+      </div>
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ copy.assistant }}</p>
+        <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ assistantTranscript || '…' }}</p>
+      </div>
+    </div>
+  </template>
+
+  <div v-else class="flex justify-center py-12">
+    <Loader2 class="size-8 animate-spin text-blue-600" aria-hidden="true" />
+  </div>
+</template>

--- a/frontend/homepage/src/components/voice/StandardVoicePanel.vue
+++ b/frontend/homepage/src/components/voice/StandardVoicePanel.vue
@@ -19,6 +19,17 @@ const standard = useStandardVoice({
   language: languageComputed,
   languageConfirmed: computed(() => languageConfirmed.value),
 })
+const {
+  stage,
+  errorMessage,
+  transcriptText,
+  answerText,
+  isWorking,
+  isRecording,
+  isTranscribing,
+  recordingMediaStream,
+  toggleRecording,
+} = standard
 
 const copy = computed(() => {
   const no = props.language === 'no'
@@ -86,43 +97,43 @@ function confirmLanguage(lang: 'en' | 'no') {
           <Button
             type="button"
             class="rounded-xl"
-            :disabled="!languageConfirmed || standard.isWorking"
-            @click="standard.toggleRecording"
+            :disabled="!languageConfirmed || isWorking"
+            @click="toggleRecording"
           >
-            <Square v-if="standard.isRecording" class="me-2 size-4" aria-hidden="true" />
+            <Square v-if="isRecording" class="me-2 size-4" aria-hidden="true" />
             <Mic v-else class="me-2 size-4" aria-hidden="true" />
             {{
-              standard.isRecording
+              isRecording
                 ? copy.stop
-                : standard.isTranscribing
+                : isTranscribing
                   ? copy.recording
                   : copy.start
             }}
           </Button>
           <span class="text-sm text-slate-600">
-            {{ standard.stage === 'looking_up' ? copy.looking : standard.stage === 'speaking' ? copy.speaking : '' }}
+            {{ stage === 'looking_up' ? copy.looking : stage === 'speaking' ? copy.speaking : '' }}
           </span>
         </div>
         <AudioWaveform
-          v-if="standard.isRecording"
+          v-if="isRecording"
           class="mt-3 h-12"
-          :stream="standard.recordingMediaStream"
+          :stream="recordingMediaStream"
           :aria-label="copy.recording"
         />
       </div>
 
-      <Alert v-if="standard.errorMessage" class="border-amber-200 bg-amber-50 text-amber-900">
-        <AlertDescription>{{ standard.errorMessage }}</AlertDescription>
+      <Alert v-if="errorMessage" class="border-amber-200 bg-amber-50 text-amber-900">
+        <AlertDescription>{{ errorMessage }}</AlertDescription>
       </Alert>
 
-      <div v-if="standard.transcriptText || standard.answerText" class="space-y-4 rounded-2xl border border-blue-100 bg-white/85 p-4">
+      <div v-if="transcriptText || answerText" class="space-y-4 rounded-2xl border border-blue-100 bg-white/85 p-4">
         <div>
           <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ copy.transcript }}</p>
-          <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ standard.transcriptText || '…' }}</p>
+          <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ transcriptText || '…' }}</p>
         </div>
         <div>
           <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ copy.answer }}</p>
-          <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ standard.answerText || '…' }}</p>
+          <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ answerText || '…' }}</p>
         </div>
       </div>
     </div>

--- a/frontend/homepage/src/components/voice/StandardVoicePanel.vue
+++ b/frontend/homepage/src/components/voice/StandardVoicePanel.vue
@@ -25,10 +25,12 @@ const {
   transcriptText,
   answerText,
   isWorking,
+  canCancel,
   isRecording,
   isTranscribing,
   recordingMediaStream,
   toggleRecording,
+  cancel,
 } = standard
 
 const copy = computed(() => {
@@ -40,6 +42,7 @@ const copy = computed(() => {
     pickLanguage: no ? 'Velg språk før opptak' : 'Choose language before recording',
     start: no ? 'Start opptak' : 'Start recording',
     stop: no ? 'Stopp opptak' : 'Stop recording',
+    cancel: no ? 'Avbryt' : 'Cancel',
     recording: no ? 'Tar opp...' : 'Recording...',
     transcript: no ? 'Du sa' : 'You said',
     answer: no ? 'Svar' : 'Answer',
@@ -97,7 +100,7 @@ function confirmLanguage(lang: 'en' | 'no') {
           <Button
             type="button"
             class="rounded-xl"
-            :disabled="!languageConfirmed || isWorking"
+            :disabled="!languageConfirmed || (isWorking && !isRecording)"
             @click="toggleRecording"
           >
             <Square v-if="isRecording" class="me-2 size-4" aria-hidden="true" />
@@ -109,6 +112,17 @@ function confirmLanguage(lang: 'en' | 'no') {
                   ? copy.recording
                   : copy.start
             }}
+          </Button>
+          <Button
+            v-if="canCancel"
+            type="button"
+            variant="outline"
+            class="rounded-xl border-red-200 text-red-700 hover:bg-red-50"
+            data-testid="standard-voice-cancel"
+            @click="cancel"
+          >
+            <Square class="me-2 size-4" aria-hidden="true" />
+            {{ copy.cancel }}
           </Button>
           <span class="text-sm text-slate-600">
             {{ stage === 'looking_up' ? copy.looking : stage === 'speaking' ? copy.speaking : '' }}

--- a/frontend/homepage/src/components/voice/StandardVoicePanel.vue
+++ b/frontend/homepage/src/components/voice/StandardVoicePanel.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Mic, Square } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import AudioWaveform from '@/components/AudioWaveform.vue'
+import { useStandardVoice } from '@/composables/useStandardVoice'
+
+const props = defineProps<{
+  language: 'en' | 'no'
+  available: boolean | null
+}>()
+
+const selectedLanguage = ref<'en' | 'no'>(props.language)
+const languageConfirmed = ref(false)
+
+const languageComputed = computed(() => selectedLanguage.value)
+const standard = useStandardVoice({
+  language: languageComputed,
+  languageConfirmed: computed(() => languageConfirmed.value),
+})
+
+const copy = computed(() => {
+  const no = props.language === 'no'
+  return {
+    unavailable: no
+      ? 'Standard stemmemodus er ikke tilgjengelig akkurat nå.'
+      : 'Standard voice mode is not available right now.',
+    pickLanguage: no ? 'Velg språk før opptak' : 'Choose language before recording',
+    start: no ? 'Start opptak' : 'Start recording',
+    stop: no ? 'Stopp opptak' : 'Stop recording',
+    recording: no ? 'Tar opp...' : 'Recording...',
+    transcript: no ? 'Du sa' : 'You said',
+    answer: no ? 'Svar' : 'Answer',
+    looking: no ? 'Søker i fakta...' : 'Looking up facts...',
+    speaking: no ? 'Snakker...' : 'Speaking...',
+    introTitle: no ? 'Robust stemmemodus' : 'Robust voice mode',
+    introBody: no
+      ? 'Denne modusen er tregere, men mer stabil. Den bruker transkribering, faktaoppslag og TTS i tur.'
+      : 'This mode is slower, but more stable. It runs transcription, fact lookup, and TTS turn-by-turn.',
+  }
+})
+
+function confirmLanguage(lang: 'en' | 'no') {
+  selectedLanguage.value = lang
+  languageConfirmed.value = true
+}
+</script>
+
+<template>
+  <div>
+    <Alert class="mb-4 border-emerald-200 bg-emerald-50/90 text-emerald-900">
+      <AlertTitle>{{ copy.introTitle }}</AlertTitle>
+      <AlertDescription>{{ copy.introBody }}</AlertDescription>
+    </Alert>
+
+    <div v-if="available === false" class="rounded-2xl border border-amber-200 bg-amber-50/90 px-4 py-3 text-sm text-amber-900">
+      {{ copy.unavailable }}
+    </div>
+
+    <div v-else class="space-y-4">
+      <div class="rounded-2xl border border-blue-100 bg-white/85 p-4">
+        <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-600">{{ copy.pickLanguage }}</p>
+        <div class="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            class="rounded-xl border px-3 py-2 text-sm font-semibold"
+            :class="selectedLanguage === 'en' ? 'border-blue-300 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'"
+            @click="confirmLanguage('en')"
+          >
+            English
+          </button>
+          <button
+            type="button"
+            class="rounded-xl border px-3 py-2 text-sm font-semibold"
+            :class="selectedLanguage === 'no' ? 'border-blue-300 bg-blue-50 text-blue-900' : 'border-slate-200 bg-white text-slate-700'"
+            @click="confirmLanguage('no')"
+          >
+            Norsk
+          </button>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-blue-100 bg-white/85 p-4">
+        <div class="flex items-center gap-3">
+          <Button
+            type="button"
+            class="rounded-xl"
+            :disabled="!languageConfirmed || standard.isWorking"
+            @click="standard.toggleRecording"
+          >
+            <Square v-if="standard.isRecording" class="me-2 size-4" aria-hidden="true" />
+            <Mic v-else class="me-2 size-4" aria-hidden="true" />
+            {{
+              standard.isRecording
+                ? copy.stop
+                : standard.isTranscribing
+                  ? copy.recording
+                  : copy.start
+            }}
+          </Button>
+          <span class="text-sm text-slate-600">
+            {{ standard.stage === 'looking_up' ? copy.looking : standard.stage === 'speaking' ? copy.speaking : '' }}
+          </span>
+        </div>
+        <AudioWaveform
+          v-if="standard.isRecording"
+          class="mt-3 h-12"
+          :stream="standard.recordingMediaStream"
+          :aria-label="copy.recording"
+        />
+      </div>
+
+      <Alert v-if="standard.errorMessage" class="border-amber-200 bg-amber-50 text-amber-900">
+        <AlertDescription>{{ standard.errorMessage }}</AlertDescription>
+      </Alert>
+
+      <div v-if="standard.transcriptText || standard.answerText" class="space-y-4 rounded-2xl border border-blue-100 bg-white/85 p-4">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ copy.transcript }}</p>
+          <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ standard.transcriptText || '…' }}</p>
+        </div>
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ copy.answer }}</p>
+          <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">{{ standard.answerText || '…' }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/homepage/src/components/voice/VoiceModeSwitcher.vue
+++ b/frontend/homepage/src/components/voice/VoiceModeSwitcher.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ShieldCheck, TriangleAlert } from 'lucide-vue-next'
+import type { VoiceMode } from '@/stores/voice-mode'
+
+defineProps<{
+  modelValue: VoiceMode
+  language: 'en' | 'no'
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: VoiceMode]
+}>()
+</script>
+
+<template>
+  <div class="mb-6 grid grid-cols-1 gap-2 rounded-2xl border border-blue-100 bg-white/85 p-2 shadow-sm sm:grid-cols-2">
+    <button
+      type="button"
+      class="flex items-center justify-between rounded-xl px-3 py-3 text-left transition"
+      :class="
+        modelValue === 'standard'
+          ? 'bg-emerald-50 text-emerald-900 ring-1 ring-emerald-200'
+          : 'bg-white text-slate-700 hover:bg-slate-50'
+      "
+      @click="emit('update:modelValue', 'standard')"
+    >
+      <span class="inline-flex items-center gap-2 text-sm font-semibold">
+        <ShieldCheck class="size-4" aria-hidden="true" />
+        {{ language === 'no' ? 'Standard' : 'Standard' }}
+      </span>
+      <span class="text-xs">
+        {{ language === 'no' ? 'Anbefalt' : 'Recommended' }}
+      </span>
+    </button>
+    <button
+      type="button"
+      class="flex items-center justify-between rounded-xl px-3 py-3 text-left transition"
+      :class="
+        modelValue === 'live'
+          ? 'bg-amber-50 text-amber-900 ring-1 ring-amber-200'
+          : 'bg-white text-slate-700 hover:bg-slate-50'
+      "
+      @click="emit('update:modelValue', 'live')"
+    >
+      <span class="inline-flex items-center gap-2 text-sm font-semibold">
+        <TriangleAlert class="size-4" aria-hidden="true" />
+        {{ language === 'no' ? 'Live' : 'Live' }}
+      </span>
+      <span class="text-xs">
+        {{ language === 'no' ? 'Mindre stabil' : 'Less stable' }}
+      </span>
+    </button>
+  </div>
+</template>

--- a/frontend/homepage/src/components/voice/__tests__/RealtimeVoicePanel.spec.ts
+++ b/frontend/homepage/src/components/voice/__tests__/RealtimeVoicePanel.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import RealtimeVoicePanel from '../RealtimeVoicePanel.vue'
+
+vi.mock('@/composables/useRealtimeVoice', () => ({
+  useRealtimeVoice: () => ({
+    connectionState: ref('idle'),
+    errorMessage: ref(''),
+    sessionNotice: ref(''),
+    assistantTranscript: ref(''),
+    userTranscript: ref(''),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    maxSessionMs: 900_000,
+  }),
+}))
+
+describe('RealtimeVoicePanel', () => {
+  it('renders live voice intro when available', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const wrapper = mount(RealtimeVoicePanel, {
+      props: {
+        language: 'en',
+        available: true,
+        voiceOptions: ['marin', 'cedar'],
+        reasoningOptions: ['low', 'medium', 'high'],
+        defaultVoice: 'marin',
+        defaultReasoningEffort: 'low',
+      },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          Button: { template: '<button><slot /></button>' },
+          Alert: { template: '<div><slot /></div>' },
+          AlertTitle: { template: '<div><slot /></div>' },
+          AlertDescription: { template: '<div><slot /></div>' },
+          AiStatusDialog: true,
+          Mic: true,
+          MicOff: true,
+          Loader2: true,
+          TriangleAlert: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Start live voice')
+    expect(wrapper.text()).toContain('Experimental mode')
+  })
+})

--- a/frontend/homepage/src/components/voice/__tests__/StandardVoicePanel.spec.ts
+++ b/frontend/homepage/src/components/voice/__tests__/StandardVoicePanel.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StandardVoicePanel from '../StandardVoicePanel.vue'
+
+vi.mock('@/composables/useStandardVoice', () => ({
+  useStandardVoice: () => ({
+    stage: { value: 'idle' },
+    errorMessage: { value: '' },
+    transcriptText: { value: '' },
+    answerText: { value: '' },
+    isWorking: { value: false },
+    isRecording: { value: false },
+    isTranscribing: { value: false },
+    recordingMediaStream: { value: null },
+    toggleRecording: vi.fn(),
+  }),
+}))
+
+describe('StandardVoicePanel', () => {
+  it('renders intro copy and language picker when available', () => {
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'en', available: true },
+      global: {
+        stubs: {
+          Button: { template: '<button><slot /></button>' },
+          Alert: { template: '<div><slot /></div>' },
+          AlertTitle: { template: '<div><slot /></div>' },
+          AlertDescription: { template: '<div><slot /></div>' },
+          AudioWaveform: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Robust voice mode')
+    expect(wrapper.text()).toContain('English')
+    expect(wrapper.text()).toContain('Norsk')
+  })
+
+  it('shows unavailable message in Norwegian', () => {
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'no', available: false },
+      global: {
+        stubs: {
+          Button: { template: '<button><slot /></button>' },
+          Alert: { template: '<div><slot /></div>' },
+          AlertTitle: { template: '<div><slot /></div>' },
+          AlertDescription: { template: '<div><slot /></div>' },
+          AudioWaveform: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Standard stemmemodus er ikke tilgjengelig')
+  })
+})

--- a/frontend/homepage/src/components/voice/__tests__/StandardVoicePanel.spec.ts
+++ b/frontend/homepage/src/components/voice/__tests__/StandardVoicePanel.spec.ts
@@ -1,34 +1,47 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import StandardVoicePanel from '../StandardVoicePanel.vue'
 
+const useStandardVoiceMock = vi.hoisted(() => vi.fn())
+
 vi.mock('@/composables/useStandardVoice', () => ({
-  useStandardVoice: () => ({
-    stage: { value: 'idle' },
-    errorMessage: { value: '' },
-    transcriptText: { value: '' },
-    answerText: { value: '' },
-    isWorking: { value: false },
-    isRecording: { value: false },
-    isTranscribing: { value: false },
-    recordingMediaStream: { value: null },
-    toggleRecording: vi.fn(),
-  }),
+  useStandardVoice: (...args: unknown[]) => useStandardVoiceMock(...args),
 }))
+
+function mockStandardVoice(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    stage: ref('idle'),
+    errorMessage: ref(''),
+    transcriptText: ref(''),
+    answerText: ref(''),
+    isWorking: ref(false),
+    canCancel: ref(false),
+    isRecording: ref(false),
+    isTranscribing: ref(false),
+    recordingMediaStream: ref<MediaStream | null>(null),
+    toggleRecording: vi.fn(),
+    cancel: vi.fn(),
+  }
+  const api = { ...defaults, ...overrides }
+  useStandardVoiceMock.mockReturnValue(api)
+  return api
+}
+
+const globalStubs = {
+  Button: { template: '<button><slot /></button>' },
+  Alert: { template: '<div><slot /></div>' },
+  AlertTitle: { template: '<div><slot /></div>' },
+  AlertDescription: { template: '<div><slot /></div>' },
+  AudioWaveform: true,
+}
 
 describe('StandardVoicePanel', () => {
   it('renders intro copy and language picker when available', () => {
+    mockStandardVoice()
     const wrapper = mount(StandardVoicePanel, {
       props: { language: 'en', available: true },
-      global: {
-        stubs: {
-          Button: { template: '<button><slot /></button>' },
-          Alert: { template: '<div><slot /></div>' },
-          AlertTitle: { template: '<div><slot /></div>' },
-          AlertDescription: { template: '<div><slot /></div>' },
-          AudioWaveform: true,
-        },
-      },
+      global: { stubs: globalStubs },
     })
 
     expect(wrapper.text()).toContain('Robust voice mode')
@@ -37,19 +50,80 @@ describe('StandardVoicePanel', () => {
   })
 
   it('shows unavailable message in Norwegian', () => {
+    mockStandardVoice()
     const wrapper = mount(StandardVoicePanel, {
       props: { language: 'no', available: false },
-      global: {
-        stubs: {
-          Button: { template: '<button><slot /></button>' },
-          Alert: { template: '<div><slot /></div>' },
-          AlertTitle: { template: '<div><slot /></div>' },
-          AlertDescription: { template: '<div><slot /></div>' },
-          AudioWaveform: true,
-        },
-      },
+      global: { stubs: globalStubs },
     })
 
     expect(wrapper.text()).toContain('Standard stemmemodus er ikke tilgjengelig')
+  })
+
+  it('highlights selected language after confirmLanguage', async () => {
+    mockStandardVoice()
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'en', available: true },
+      global: { stubs: globalStubs },
+    })
+
+    await wrapper.findAll('button').find((b) => b.text() === 'Norsk')!.trigger('click')
+    const norskBtn = wrapper.findAll('button').find((b) => b.text() === 'Norsk')!
+    expect(norskBtn.classes()).toContain('border-blue-300')
+  })
+
+  it('shows cancel control and stage status while working', () => {
+    mockStandardVoice({
+      stage: ref('looking_up'),
+      canCancel: ref(true),
+      isWorking: ref(true),
+    })
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'en', available: true },
+      global: { stubs: globalStubs },
+    })
+
+    expect(wrapper.find('[data-testid="standard-voice-cancel"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Looking up facts...')
+  })
+
+  it('shows speaking status and transcript or answer blocks', () => {
+    mockStandardVoice({
+      stage: ref('speaking'),
+      transcriptText: ref('Hello Kevin'),
+      answerText: ref('Kevin studies at NTNU.'),
+    })
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'en', available: true },
+      global: { stubs: globalStubs },
+    })
+
+    expect(wrapper.text()).toContain('Speaking...')
+    expect(wrapper.text()).toContain('Hello Kevin')
+    expect(wrapper.text()).toContain('Kevin studies at NTNU.')
+  })
+
+  it('shows stop recording label while recording', () => {
+    mockStandardVoice({
+      isRecording: ref(true),
+      isWorking: ref(true),
+    })
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'en', available: true },
+      global: { stubs: globalStubs },
+    })
+
+    expect(wrapper.text()).toContain('Stop recording')
+  })
+
+  it('renders error alert when errorMessage is set', () => {
+    mockStandardVoice({
+      errorMessage: ref('Microphone unavailable'),
+    })
+    const wrapper = mount(StandardVoicePanel, {
+      props: { language: 'en', available: true },
+      global: { stubs: globalStubs },
+    })
+
+    expect(wrapper.text()).toContain('Microphone unavailable')
   })
 })

--- a/frontend/homepage/src/components/voice/__tests__/VoiceModeSwitcher.spec.ts
+++ b/frontend/homepage/src/components/voice/__tests__/VoiceModeSwitcher.spec.ts
@@ -10,4 +10,13 @@ describe('VoiceModeSwitcher', () => {
     await wrapper.get('button:nth-of-type(2)').trigger('click')
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['live'])
   })
+
+  it('renders Norwegian labels and highlights the active mode', () => {
+    const wrapper = mount(VoiceModeSwitcher, {
+      props: { modelValue: 'live', language: 'no' },
+    })
+    expect(wrapper.text()).toContain('Anbefalt')
+    expect(wrapper.text()).toContain('Mindre stabil')
+    expect(wrapper.get('button:nth-of-type(2)').classes()).toContain('bg-amber-50')
+  })
 })

--- a/frontend/homepage/src/components/voice/__tests__/VoiceModeSwitcher.spec.ts
+++ b/frontend/homepage/src/components/voice/__tests__/VoiceModeSwitcher.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import VoiceModeSwitcher from '../VoiceModeSwitcher.vue'
+
+describe('VoiceModeSwitcher', () => {
+  it('emits selected mode', async () => {
+    const wrapper = mount(VoiceModeSwitcher, {
+      props: { modelValue: 'standard', language: 'en' },
+    })
+    await wrapper.get('button:nth-of-type(2)').trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['live'])
+  })
+})

--- a/frontend/homepage/src/composables/__tests__/useRealtimeVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useRealtimeVoice.spec.ts
@@ -746,7 +746,7 @@ describe('useRealtimeVoice', () => {
 
     expect(lookupRealtimeInfoMock).not.toHaveBeenCalled()
     const outputEvent = JSON.parse(dataChannelSendMock.mock.calls[0][0])
-    expect(JSON.parse(outputEvent.item.output)).toEqual({ found: false, snippets: [] })
+    expect(JSON.parse(outputEvent.item.output)).toEqual({ found: false, snippets: [], confidence: 'none' })
 
     api.disconnect()
     scope.stop()

--- a/frontend/homepage/src/composables/__tests__/useSpeechTranscription.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useSpeechTranscription.spec.ts
@@ -93,7 +93,7 @@ describe('useSpeechTranscription', () => {
     await flushPromises()
 
     expect(onTranscript).toHaveBeenCalledWith('hello from mic')
-    expect(transcribeSpeech).toHaveBeenCalledWith(expect.any(Blob), 'en')
+    expect(transcribeSpeech).toHaveBeenCalledWith(expect.any(Blob), 'en', expect.any(AbortSignal))
     expect(api.isRecording.value).toBe(false)
     expect(api.isTranscribing.value).toBe(false)
 
@@ -251,7 +251,7 @@ describe('useSpeechTranscription', () => {
 
     await recordOnce(api)
 
-    expect(transcribeSpeech).toHaveBeenCalledWith(expect.any(Blob), 'no')
+    expect(transcribeSpeech).toHaveBeenCalledWith(expect.any(Blob), 'no', expect.any(AbortSignal))
     scope.stop()
   })
 

--- a/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, effectScope, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { useStandardVoice } from '../useStandardVoice'
+import { lookupRealtimeInfo } from '@/lib/realtime-voice'
+import { synthesizeSpeech } from '@/lib/synthesize-speech'
+import { captureProductAnalyticsEvent } from '@/lib/analytics'
+
+const toggleVoiceInputMock = vi.hoisted(() => vi.fn())
+const useSpeechTranscriptionMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/useSpeechTranscription', () => ({
+  useSpeechTranscription: (...args: unknown[]) => useSpeechTranscriptionMock(...args),
+}))
+
+vi.mock('@/lib/realtime-voice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/realtime-voice')>()
+  return {
+    ...actual,
+    lookupRealtimeInfo: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/synthesize-speech', () => ({
+  synthesizeSpeech: vi.fn(),
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  captureProductAnalyticsEvent: vi.fn(),
+}))
+
+describe('useStandardVoice', () => {
+  const isRecording = ref(false)
+  const isTranscribing = ref(false)
+  const voiceError = ref('')
+  const recordingMediaStream = ref<MediaStream | null>(null)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isRecording.value = false
+    isTranscribing.value = false
+    voiceError.value = ''
+    recordingMediaStream.value = null
+    toggleVoiceInputMock.mockResolvedValue(undefined)
+
+    useSpeechTranscriptionMock.mockImplementation(({ onTranscript }: { onTranscript: (text: string) => void }) => ({
+      isRecording,
+      isTranscribing,
+      voiceError,
+      recordingMediaStream,
+      supportsSpeechInput: ref(true),
+      toggleVoiceInput: toggleVoiceInputMock.mockImplementation(async () => {
+        onTranscript('what does Kevin study')
+      }),
+    }))
+
+    vi.mocked(lookupRealtimeInfo).mockResolvedValue({
+      found: true,
+      snippets: [{ sourceType: 'profile', title: 'NTNU', text: 'Kevin studies at NTNU.' }],
+    })
+    vi.mocked(synthesizeSpeech).mockResolvedValue({
+      ok: true,
+      blob: new Blob(['audio'], { type: 'audio/mpeg' }),
+    })
+
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createApi(languageConfirmed = true) {
+    const scope = effectScope()
+    let api!: ReturnType<typeof useStandardVoice>
+    scope.run(() => {
+      api = useStandardVoice({
+        language: computed(() => 'en' as const),
+        languageConfirmed: computed(() => languageConfirmed),
+      })
+    })
+    return { api: api!, scope }
+  }
+
+  it('requires language confirmation before recording', async () => {
+    const { api } = createApi(false)
+    await api.toggleRecording()
+    expect(api.stage.value).toBe('error')
+    expect(api.errorMessage.value).toContain('Choose language first')
+  })
+
+  it('runs lookup and synthesis after transcript arrives', async () => {
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(lookupRealtimeInfo).toHaveBeenCalledWith('what does Kevin study', 'en')
+    expect(synthesizeSpeech).toHaveBeenCalledWith('Kevin studies at NTNU.', 'en')
+    expect(api.stage.value).toBe('speaking')
+    expect(captureProductAnalyticsEvent).toHaveBeenCalled()
+  })
+
+  it('surfaces synthesis errors', async () => {
+    vi.mocked(synthesizeSpeech).mockResolvedValue({
+      ok: false,
+      status: 503,
+      message: 'Speech synthesis is temporarily unavailable.',
+    })
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(api.stage.value).toBe('error')
+    expect(api.errorMessage.value).toContain('Speech synthesis')
+  })
+
+  it('surfaces playback errors after successful synthesis', async () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockRejectedValue(new Error('blocked'))
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(api.stage.value).toBe('error')
+    expect(api.errorMessage.value).toContain('Could not play synthesized audio')
+  })
+
+  it('surfaces transcription errors from the mic pipeline', async () => {
+    useSpeechTranscriptionMock.mockImplementation(() => ({
+      isRecording,
+      isTranscribing,
+      voiceError: ref('Microphone unavailable'),
+      recordingMediaStream,
+      supportsSpeechInput: ref(true),
+      toggleVoiceInput: toggleVoiceInputMock,
+    }))
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(api.stage.value).toBe('error')
+    expect(api.errorMessage.value).toBe('Microphone unavailable')
+  })
+})

--- a/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
@@ -306,9 +306,9 @@ describe('useStandardVoice', () => {
   })
 
   it('returns to idle when synthesized playback ends', async () => {
-    let onended: (() => void) | null = null
+    let audioRef: HTMLAudioElement | undefined
     vi.spyOn(HTMLMediaElement.prototype, 'play').mockImplementation(async function (this: HTMLAudioElement) {
-      onended = this.onended
+      audioRef = this
     })
 
     const { api } = createApi(true)
@@ -316,7 +316,8 @@ describe('useStandardVoice', () => {
     await flushPromises()
     expect(api.stage.value).toBe('speaking')
 
-    onended?.call(null)
+    expect(typeof audioRef?.onended).toBe('function')
+    audioRef!.onended!(new Event('ended'))
     expect(api.stage.value).toBe('idle')
   })
 

--- a/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
@@ -306,9 +306,8 @@ describe('useStandardVoice', () => {
   })
 
   it('returns to idle when synthesized playback ends', async () => {
-    let audioRef: HTMLAudioElement | undefined
-    vi.spyOn(HTMLMediaElement.prototype, 'play').mockImplementation(async function (this: HTMLAudioElement) {
-      audioRef = this
+    const playSpy = vi.spyOn(HTMLMediaElement.prototype, 'play').mockImplementation(function (this: HTMLAudioElement) {
+      return Promise.resolve()
     })
 
     const { api } = createApi(true)
@@ -316,8 +315,9 @@ describe('useStandardVoice', () => {
     await flushPromises()
     expect(api.stage.value).toBe('speaking')
 
-    expect(typeof audioRef?.onended).toBe('function')
-    audioRef!.onended!(new Event('ended'))
+    const audioRef = playSpy.mock.contexts[0] as HTMLAudioElement
+    expect(typeof audioRef.onended).toBe('function')
+    audioRef.onended!(new Event('ended'))
     expect(api.stage.value).toBe('idle')
   })
 

--- a/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
@@ -89,6 +89,19 @@ describe('useStandardVoice', () => {
     expect(api.errorMessage.value).toContain('Choose language first')
   })
 
+  it('does not mark transcribing before stop is requested', async () => {
+    isRecording.value = true
+    const stagesDuringToggle: string[] = []
+    const { api } = createApi(true)
+    toggleVoiceInputMock.mockImplementation(async () => {
+      stagesDuringToggle.push(api.stage.value)
+    })
+    api.stage.value = 'recording'
+    await api.toggleRecording()
+    expect(stagesDuringToggle).toEqual(['recording'])
+    expect(toggleVoiceInputMock).toHaveBeenCalledTimes(1)
+  })
+
   it('runs lookup and synthesis after transcript arrives', async () => {
     const { api } = createApi(true)
     await api.toggleRecording()

--- a/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
@@ -52,10 +52,12 @@ describe('useStandardVoice', () => {
       toggleVoiceInput: toggleVoiceInputMock.mockImplementation(async () => {
         onTranscript('what does Kevin study')
       }),
+      cancel: vi.fn(),
     }))
 
     vi.mocked(lookupRealtimeInfo).mockResolvedValue({
       found: true,
+      confidence: 'high',
       snippets: [{ sourceType: 'profile', title: 'NTNU', text: 'Kevin studies at NTNU.' }],
     })
     vi.mocked(synthesizeSpeech).mockResolvedValue({
@@ -107,8 +109,8 @@ describe('useStandardVoice', () => {
     await api.toggleRecording()
     await flushPromises()
 
-    expect(lookupRealtimeInfo).toHaveBeenCalledWith('what does Kevin study', 'en')
-    expect(synthesizeSpeech).toHaveBeenCalledWith('Kevin studies at NTNU.', 'en')
+    expect(lookupRealtimeInfo).toHaveBeenCalledWith('what does Kevin study', 'en', expect.any(AbortSignal))
+    expect(synthesizeSpeech).toHaveBeenCalledWith('Kevin studies at NTNU.', 'en', expect.any(AbortSignal))
     expect(api.stage.value).toBe('speaking')
     expect(captureProductAnalyticsEvent).toHaveBeenCalled()
   })
@@ -147,6 +149,7 @@ describe('useStandardVoice', () => {
       recordingMediaStream,
       supportsSpeechInput: ref(true),
       toggleVoiceInput: toggleVoiceInputMock,
+      cancel: vi.fn(),
     }))
 
     const { api } = createApi(true)
@@ -155,5 +158,59 @@ describe('useStandardVoice', () => {
 
     expect(api.stage.value).toBe('error')
     expect(api.errorMessage.value).toBe('Microphone unavailable')
+  })
+
+  it('asks the user to repeat when transcript quality is uncertain', async () => {
+    toggleVoiceInputMock.mockImplementation(async ({ onTranscript }: { onTranscript: (text: string) => void }) => {
+      onTranscript('??')
+    })
+    useSpeechTranscriptionMock.mockImplementation(({ onTranscript }: { onTranscript: (text: string) => void }) => ({
+      isRecording,
+      isTranscribing,
+      voiceError,
+      recordingMediaStream,
+      supportsSpeechInput: ref(true),
+      toggleVoiceInput: toggleVoiceInputMock.mockImplementation(async () => {
+        onTranscript('??')
+      }),
+      cancel: vi.fn(),
+    }))
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(lookupRealtimeInfo).not.toHaveBeenCalled()
+    expect(synthesizeSpeech).toHaveBeenCalledWith(
+      expect.stringContaining("didn't catch that clearly"),
+      'en',
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('cancels an in-flight turn and returns to idle', async () => {
+    let resolveLookup: ((value: Awaited<ReturnType<typeof lookupRealtimeInfo>>) => void) | undefined
+    vi.mocked(lookupRealtimeInfo).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLookup = resolve
+        }),
+    )
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+    expect(api.stage.value).toBe('looking_up')
+
+    api.cancel()
+    expect(api.stage.value).toBe('idle')
+
+    resolveLookup?.({
+      found: true,
+      confidence: 'high',
+      snippets: [{ sourceType: 'profile', title: 'NTNU', text: 'Late answer.' }],
+    })
+    await flushPromises()
+    expect(api.stage.value).toBe('idle')
   })
 })

--- a/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useStandardVoice.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, effectScope, ref } from 'vue'
-import { flushPromises } from '@vue/test-utils'
+import { computed, defineComponent, effectScope, h, ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
 import { useStandardVoice } from '../useStandardVoice'
 import { lookupRealtimeInfo } from '@/lib/realtime-voice'
 import { synthesizeSpeech } from '@/lib/synthesize-speech'
@@ -72,12 +72,12 @@ describe('useStandardVoice', () => {
     vi.restoreAllMocks()
   })
 
-  function createApi(languageConfirmed = true) {
+  function createApi(languageConfirmed = true, language: 'en' | 'no' = 'en') {
     const scope = effectScope()
     let api!: ReturnType<typeof useStandardVoice>
     scope.run(() => {
       api = useStandardVoice({
-        language: computed(() => 'en' as const),
+        language: computed(() => language),
         languageConfirmed: computed(() => languageConfirmed),
       })
     })
@@ -91,6 +91,13 @@ describe('useStandardVoice', () => {
     expect(api.errorMessage.value).toContain('Choose language first')
   })
 
+  it('requires language confirmation in Norwegian', async () => {
+    const { api } = createApi(false, 'no')
+    await api.toggleRecording()
+    expect(api.stage.value).toBe('error')
+    expect(api.errorMessage.value).toContain('Velg språk først')
+  })
+
   it('does not mark transcribing before stop is requested', async () => {
     isRecording.value = true
     const stagesDuringToggle: string[] = []
@@ -102,6 +109,42 @@ describe('useStandardVoice', () => {
     await api.toggleRecording()
     expect(stagesDuringToggle).toEqual(['recording'])
     expect(toggleVoiceInputMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('speaks low-confidence lookup answers with hedging', async () => {
+    vi.mocked(lookupRealtimeInfo).mockResolvedValue({
+      found: true,
+      confidence: 'low',
+      snippets: [{ sourceType: 'profile', title: 'A', text: 'Maybe Kevin studies IT.' }],
+    })
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(synthesizeSpeech).toHaveBeenCalledWith(
+      expect.stringContaining('not sure I understood'),
+      'en',
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('speaks a not-found lookup answer', async () => {
+    vi.mocked(lookupRealtimeInfo).mockResolvedValue({
+      found: false,
+      confidence: 'low',
+      snippets: [],
+    })
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(synthesizeSpeech).toHaveBeenCalledWith(
+      expect.stringContaining("I don't have information about that"),
+      'en',
+      expect.any(AbortSignal),
+    )
   })
 
   it('runs lookup and synthesis after transcript arrives', async () => {
@@ -186,6 +229,112 @@ describe('useStandardVoice', () => {
       'en',
       expect.any(AbortSignal),
     )
+  })
+
+  it('sets transcribing stage after recording stops', async () => {
+    useSpeechTranscriptionMock.mockImplementation(() => ({
+      isRecording,
+      isTranscribing,
+      voiceError,
+      recordingMediaStream,
+      supportsSpeechInput: ref(true),
+      toggleVoiceInput: vi.fn(async () => {
+        isTranscribing.value = true
+      }),
+      cancel: vi.fn(),
+    }))
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    expect(api.stage.value).toBe('transcribing')
+  })
+
+  it('returns early from toggleRecording when turn was cancelled during mic toggle', async () => {
+    const { api } = createApi(true)
+    toggleVoiceInputMock.mockImplementation(async () => {
+      api.cancel()
+    })
+    await api.toggleRecording()
+    expect(api.stage.value).toBe('idle')
+  })
+
+  it('surfaces Norwegian playback errors', async () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockRejectedValue(new Error('blocked'))
+
+    const { api } = createApi(true, 'no')
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(api.stage.value).toBe('error')
+    expect(api.errorMessage.value).toContain('Kunne ikke spille av syntetisert lyd')
+  })
+
+  it('ignores lookup abort errors', async () => {
+    let onTranscript!: (text: string) => void
+    useSpeechTranscriptionMock.mockImplementation(({ onTranscript: onText }: { onTranscript: (text: string) => void }) => {
+      onTranscript = onText
+      return {
+        isRecording,
+        isTranscribing,
+        voiceError,
+        recordingMediaStream,
+        supportsSpeechInput: ref(true),
+        toggleVoiceInput: vi.fn(),
+        cancel: vi.fn(),
+      }
+    })
+    vi.mocked(lookupRealtimeInfo).mockRejectedValue(new DOMException('aborted', 'AbortError'))
+
+    const { api } = createApi(true)
+    onTranscript('hello')
+    await flushPromises()
+
+    expect(api.stage.value).not.toBe('error')
+  })
+
+  it('skips playback when the turn is cancelled after synthesis', async () => {
+    const { api } = createApi(true)
+    vi.mocked(synthesizeSpeech).mockImplementation(async () => {
+      api.cancel()
+      return { ok: true, blob: new Blob(['audio'], { type: 'audio/mpeg' }) }
+    })
+
+    await api.toggleRecording()
+    await flushPromises()
+
+    expect(api.stage.value).toBe('idle')
+    expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled()
+  })
+
+  it('returns to idle when synthesized playback ends', async () => {
+    let onended: (() => void) | null = null
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockImplementation(async function (this: HTMLAudioElement) {
+      onended = this.onended
+    })
+
+    const { api } = createApi(true)
+    await api.toggleRecording()
+    await flushPromises()
+    expect(api.stage.value).toBe('speaking')
+
+    onended?.call(null)
+    expect(api.stage.value).toBe('idle')
+  })
+
+  it('cleans up on component unmount', async () => {
+    let api!: ReturnType<typeof useStandardVoice>
+    const Host = defineComponent({
+      setup() {
+        api = useStandardVoice({
+          language: computed(() => 'en' as const),
+          languageConfirmed: computed(() => true),
+        })
+        return () => h('div')
+      },
+    })
+    const wrapper = mount(Host)
+    api.stage.value = 'recording'
+    wrapper.unmount()
+    expect(api.stage.value).toBe('idle')
   })
 
   it('cancels an in-flight turn and returns to idle', async () => {

--- a/frontend/homepage/src/composables/useRealtimeVoice.ts
+++ b/frontend/homepage/src/composables/useRealtimeVoice.ts
@@ -172,6 +172,8 @@ export function useRealtimeVoice(
   const assistantTranscript = ref('')
   /** Latest user transcript from input audio transcription */
   const userTranscript = ref('')
+  /** True while the model is generating a spoken response */
+  const isModelSpeaking = ref(false)
 
   let pc: RTCPeerConnection | null = null
   let localStream: MediaStream | null = null
@@ -276,12 +278,12 @@ export function useRealtimeVoice(
       }
     }
 
-    let output: RealtimeLookupResponse = { found: false, snippets: [] }
+    let output: RealtimeLookupResponse = { found: false, snippets: [], confidence: 'none' }
     if (query !== '') {
       try {
         output = await lookupRealtimeInfo(query, language.value)
       } catch {
-        output = { found: false, snippets: [] }
+        output = { found: false, snippets: [], confidence: 'none' }
       }
     }
 
@@ -334,16 +336,21 @@ export function useRealtimeVoice(
         handleMidSessionFailure(message)
         return
       }
+      if (t === 'response.created') {
+        isModelSpeaking.value = true
+        return
+      }
+      if (t === 'response.done' || t === 'response.cancelled') {
+        isModelSpeaking.value = false
+        handleResponseDone(ev)
+        return
+      }
       if (t === 'response.output_audio_transcript.delta' && typeof ev.delta === 'string') {
         assistantTranscript.value += ev.delta
         return
       }
       if (t === 'response.output_audio_transcript.done' && typeof ev.transcript === 'string') {
         assistantTranscript.value = ev.transcript
-        return
-      }
-      if (t === 'response.done') {
-        handleResponseDone(ev)
         return
       }
       if (t === 'conversation.item.input_audio_transcription.delta' && typeof ev.delta === 'string') {
@@ -379,6 +386,16 @@ export function useRealtimeVoice(
       userTranscript.value = text
     } else {
       assistantTranscript.value = text
+    }
+  }
+
+  function stopResponse() {
+    if (connectionState.value !== 'connected' || userEndedSession || midSessionFailureHandled) {
+      return
+    }
+    if (selectedProvider() === 'OPENAI') {
+      sendRealtimeClientEvent({ type: 'response.cancel' })
+      isModelSpeaking.value = false
     }
   }
 
@@ -574,6 +591,7 @@ export function useRealtimeVoice(
     sessionNotice.value = ''
     assistantTranscript.value = ''
     userTranscript.value = ''
+    isModelSpeaking.value = false
     userEndedSession = false
     midSessionFailureHandled = false
     connectionState.value = 'connecting'
@@ -629,8 +647,10 @@ export function useRealtimeVoice(
     sessionNotice,
     assistantTranscript,
     userTranscript,
+    isModelSpeaking,
     connect,
     disconnect: () => disconnect('user'),
+    stopResponse,
     maxSessionMs: REALTIME_SESSION_MAX_MS,
   }
 }

--- a/frontend/homepage/src/composables/useSpeechTranscription.ts
+++ b/frontend/homepage/src/composables/useSpeechTranscription.ts
@@ -26,6 +26,8 @@ export function useSpeechTranscription(options: UseSpeechTranscriptionOptions) {
 
   let mediaRecorder: MediaRecorder | null = null
   const audioChunks: Blob[] = []
+  let transcribeAbort: AbortController | null = null
+  let cancelRequested = false
 
   const supportsSpeechInput = computed(
     () => typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia,
@@ -38,6 +40,7 @@ export function useSpeechTranscription(options: UseSpeechTranscriptionOptions) {
 
   async function startRecording() {
     voiceError.value = ''
+    cancelRequested = false
     try {
       const stream = await navigator.mediaDevices!.getUserMedia({ audio: true })
       recordingMediaStream.value = stream
@@ -87,6 +90,12 @@ export function useSpeechTranscription(options: UseSpeechTranscriptionOptions) {
     stopMediaTracks()
     mediaRecorder = null
 
+    if (cancelRequested) {
+      cancelRequested = false
+      audioChunks.length = 0
+      return
+    }
+
     const blobType = audioChunks[0]?.type ?? 'audio/webm'
     const blob = new Blob(audioChunks, { type: blobType })
     audioChunks.length = 0
@@ -100,10 +109,14 @@ export function useSpeechTranscription(options: UseSpeechTranscriptionOptions) {
 
     isTranscribing.value = true
     voiceError.value = ''
+    transcribeAbort = new AbortController()
     try {
       const auth = (await import('@/stores/auth')).useAuthStore()
       auth.restore()
-      const r = await transcribeSpeech(blob, options.language.value)
+      const r = await transcribeSpeech(blob, options.language.value, transcribeAbort.signal)
+      if (cancelRequested) {
+        return
+      }
       if (r.status === 200 && r.data && typeof r.data === 'object' && r.data !== null && 'text' in r.data) {
         const t = String((r.data as { text: unknown }).text ?? '').trim().slice(0, options.maxChars)
         if (t) {
@@ -142,14 +155,38 @@ export function useSpeechTranscription(options: UseSpeechTranscriptionOptions) {
         (options.language.value === 'en'
           ? 'Could not transcribe audio.'
           : 'Kunne ikke transkribere lyd.')
-    } catch {
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return
+      }
       voiceError.value =
         options.language.value === 'en'
           ? 'Network error during transcription.'
           : 'Nettverksfeil ved transkripsjon.'
     } finally {
       isTranscribing.value = false
+      transcribeAbort = null
     }
+  }
+
+  function cancel() {
+    cancelRequested = true
+    transcribeAbort?.abort()
+    transcribeAbort = null
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      try {
+        mediaRecorder.stop()
+      } catch {
+        /* ignore */
+      }
+    } else {
+      isRecording.value = false
+      isTranscribing.value = false
+      stopMediaTracks()
+      mediaRecorder = null
+      audioChunks.length = 0
+    }
+    voiceError.value = ''
   }
 
   async function toggleVoiceInput() {
@@ -179,5 +216,6 @@ export function useSpeechTranscription(options: UseSpeechTranscriptionOptions) {
     recordingMediaStream,
     voiceError,
     toggleVoiceInput,
+    cancel,
   }
 }

--- a/frontend/homepage/src/composables/useStandardVoice.ts
+++ b/frontend/homepage/src/composables/useStandardVoice.ts
@@ -2,6 +2,7 @@ import { computed, onUnmounted, ref, type ComputedRef } from 'vue'
 import { lookupRealtimeInfo, type SpeechUiLang } from '@/lib/realtime-voice'
 import { formatLookupForSpeech } from '@/lib/voice-answer'
 import { synthesizeSpeech } from '@/lib/synthesize-speech'
+import { isTranscriptUncertain, repeatRequestMessage } from '@/lib/transcript-quality'
 import { useSpeechTranscription } from '@/composables/useSpeechTranscription'
 import { captureProductAnalyticsEvent } from '@/lib/analytics'
 import { POSTHOG_VOICE_EVENTS } from '@/lib/posthog-sdk'
@@ -19,15 +20,29 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
   const transcriptText = ref('')
   const answerText = ref('')
   const isWorking = computed(
-    () => stage.value === 'transcribing' || stage.value === 'looking_up' || stage.value === 'speaking',
+    () =>
+      stage.value === 'transcribing' ||
+      stage.value === 'looking_up' ||
+      stage.value === 'speaking' ||
+      stage.value === 'recording',
+  )
+  const canCancel = computed(
+    () =>
+      stage.value === 'recording' ||
+      stage.value === 'transcribing' ||
+      stage.value === 'looking_up' ||
+      stage.value === 'speaking',
   )
 
   let currentAudio: HTMLAudioElement | null = null
   let currentObjectUrl: string | null = null
+  let pipelineAbort: AbortController | null = null
+  let turnCancelled = false
 
   function stopPlayback() {
     if (currentAudio) {
       currentAudio.pause()
+      currentAudio.onended = null
       currentAudio = null
     }
     if (currentObjectUrl) {
@@ -36,24 +51,38 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
     }
   }
 
+  function beginTurn() {
+    turnCancelled = false
+    pipelineAbort?.abort()
+    pipelineAbort = new AbortController()
+    return pipelineAbort.signal
+  }
+
+  function isTurnActive(signal: AbortSignal): boolean {
+    return !turnCancelled && !signal.aborted
+  }
+
   const transcriptionApi = useSpeechTranscription({
     language: options.language,
     maxChars: 3000,
-    isBlocked: computed(() => isWorking.value || !options.languageConfirmed.value),
+    isBlocked: computed(
+      () =>
+        stage.value === 'transcribing' ||
+        stage.value === 'looking_up' ||
+        stage.value === 'speaking' ||
+        !options.languageConfirmed.value,
+    ),
     onTranscript: (text) => {
       void processTranscript(text)
     },
   })
 
-  async function processTranscript(text: string) {
-    transcriptText.value = text
-    errorMessage.value = ''
-    stage.value = 'looking_up'
-    const lookup = await lookupRealtimeInfo(text, options.language.value)
-    const answer = formatLookupForSpeech(lookup, options.language.value)
-    answerText.value = answer
-
-    const synthesized = await synthesizeSpeech(answer, options.language.value)
+  async function speakAnswer(text: string, signal: AbortSignal) {
+    answerText.value = text
+    const synthesized = await synthesizeSpeech(text, options.language.value, signal)
+    if (!isTurnActive(signal)) {
+      return
+    }
     if (!synthesized.ok) {
       stage.value = 'error'
       errorMessage.value = synthesized.message
@@ -63,19 +92,27 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
       })
       return
     }
+
     stopPlayback()
     currentObjectUrl = URL.createObjectURL(synthesized.blob)
     currentAudio = new Audio(currentObjectUrl)
     stage.value = 'speaking'
     currentAudio.onended = () => {
-      stage.value = 'idle'
+      if (isTurnActive(signal)) {
+        stage.value = 'idle'
+      }
     }
     try {
       await currentAudio.play()
-      captureProductAnalyticsEvent(POSTHOG_VOICE_EVENTS.STANDARD_TURN_COMPLETED, {
-        status: 'success',
-      })
+      if (isTurnActive(signal)) {
+        captureProductAnalyticsEvent(POSTHOG_VOICE_EVENTS.STANDARD_TURN_COMPLETED, {
+          status: 'success',
+        })
+      }
     } catch {
+      if (!isTurnActive(signal)) {
+        return
+      }
       stage.value = 'error'
       errorMessage.value =
         options.language.value === 'no'
@@ -88,6 +125,54 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
     }
   }
 
+  async function processTranscript(text: string) {
+    if (turnCancelled) {
+      return
+    }
+    const signal = pipelineAbort?.signal ?? beginTurn()
+    transcriptText.value = text
+    errorMessage.value = ''
+
+    if (isTranscriptUncertain(text)) {
+      await speakAnswer(repeatRequestMessage(options.language.value), signal)
+      return
+    }
+
+    stage.value = 'looking_up'
+    let lookup
+    try {
+      lookup = await lookupRealtimeInfo(text, options.language.value, signal)
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return
+      }
+      throw e
+    }
+    if (!isTurnActive(signal)) {
+      return
+    }
+
+    const answer = formatLookupForSpeech(lookup, options.language.value)
+    try {
+      await speakAnswer(answer, signal)
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        return
+      }
+      throw e
+    }
+  }
+
+  function cancel() {
+    turnCancelled = true
+    pipelineAbort?.abort()
+    pipelineAbort = null
+    stopPlayback()
+    transcriptionApi.cancel()
+    stage.value = 'idle'
+    errorMessage.value = ''
+  }
+
   async function toggleRecording() {
     if (!options.languageConfirmed.value) {
       errorMessage.value =
@@ -98,10 +183,14 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
       return
     }
     if (!transcriptionApi.isRecording.value) {
+      beginTurn()
       stage.value = 'recording'
       errorMessage.value = ''
     }
     await transcriptionApi.toggleVoiceInput()
+    if (turnCancelled) {
+      return
+    }
     if (transcriptionApi.isRecording.value) {
       stage.value = 'recording'
     } else if (transcriptionApi.isTranscribing.value) {
@@ -113,7 +202,9 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
     }
   }
 
-  onUnmounted(() => stopPlayback())
+  onUnmounted(() => {
+    cancel()
+  })
 
   return {
     stage,
@@ -121,11 +212,13 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
     transcriptText,
     answerText,
     isWorking,
+    canCancel,
     isRecording: transcriptionApi.isRecording,
     isTranscribing: transcriptionApi.isTranscribing,
     recordingMediaStream: transcriptionApi.recordingMediaStream,
     supportsSpeechInput: transcriptionApi.supportsSpeechInput,
     toggleRecording,
+    cancel,
     stopPlayback,
   }
 }

--- a/frontend/homepage/src/composables/useStandardVoice.ts
+++ b/frontend/homepage/src/composables/useStandardVoice.ts
@@ -1,0 +1,133 @@
+import { computed, onUnmounted, ref, type ComputedRef } from 'vue'
+import { lookupRealtimeInfo, type SpeechUiLang } from '@/lib/realtime-voice'
+import { formatLookupForSpeech } from '@/lib/voice-answer'
+import { synthesizeSpeech } from '@/lib/synthesize-speech'
+import { useSpeechTranscription } from '@/composables/useSpeechTranscription'
+import { captureProductAnalyticsEvent } from '@/lib/analytics'
+import { POSTHOG_VOICE_EVENTS } from '@/lib/posthog-sdk'
+
+type StandardVoiceStage = 'idle' | 'recording' | 'transcribing' | 'looking_up' | 'speaking' | 'error'
+
+type UseStandardVoiceOptions = {
+  language: ComputedRef<SpeechUiLang>
+  languageConfirmed: ComputedRef<boolean>
+}
+
+export function useStandardVoice(options: UseStandardVoiceOptions) {
+  const stage = ref<StandardVoiceStage>('idle')
+  const errorMessage = ref('')
+  const transcriptText = ref('')
+  const answerText = ref('')
+  const isWorking = computed(
+    () => stage.value === 'transcribing' || stage.value === 'looking_up' || stage.value === 'speaking',
+  )
+
+  let currentAudio: HTMLAudioElement | null = null
+  let currentObjectUrl: string | null = null
+
+  function stopPlayback() {
+    if (currentAudio) {
+      currentAudio.pause()
+      currentAudio = null
+    }
+    if (currentObjectUrl) {
+      URL.revokeObjectURL(currentObjectUrl)
+      currentObjectUrl = null
+    }
+  }
+
+  const transcriptionApi = useSpeechTranscription({
+    language: options.language,
+    maxChars: 3000,
+    isBlocked: computed(() => isWorking.value || !options.languageConfirmed.value),
+    onTranscript: (text) => {
+      void processTranscript(text)
+    },
+  })
+
+  async function processTranscript(text: string) {
+    transcriptText.value = text
+    errorMessage.value = ''
+    stage.value = 'looking_up'
+    const lookup = await lookupRealtimeInfo(text, options.language.value)
+    const answer = formatLookupForSpeech(lookup, options.language.value)
+    answerText.value = answer
+
+    const synthesized = await synthesizeSpeech(answer, options.language.value)
+    if (!synthesized.ok) {
+      stage.value = 'error'
+      errorMessage.value = synthesized.message
+      captureProductAnalyticsEvent(POSTHOG_VOICE_EVENTS.STANDARD_TURN_COMPLETED, {
+        status: 'error',
+        stage: 'synthesis',
+      })
+      return
+    }
+    stopPlayback()
+    currentObjectUrl = URL.createObjectURL(synthesized.blob)
+    currentAudio = new Audio(currentObjectUrl)
+    stage.value = 'speaking'
+    currentAudio.onended = () => {
+      stage.value = 'idle'
+    }
+    try {
+      await currentAudio.play()
+      captureProductAnalyticsEvent(POSTHOG_VOICE_EVENTS.STANDARD_TURN_COMPLETED, {
+        status: 'success',
+      })
+    } catch {
+      stage.value = 'error'
+      errorMessage.value =
+        options.language.value === 'no'
+          ? 'Kunne ikke spille av syntetisert lyd.'
+          : 'Could not play synthesized audio.'
+      captureProductAnalyticsEvent(POSTHOG_VOICE_EVENTS.STANDARD_TURN_COMPLETED, {
+        status: 'error',
+        stage: 'playback',
+      })
+    }
+  }
+
+  async function toggleRecording() {
+    if (!options.languageConfirmed.value) {
+      errorMessage.value =
+        options.language.value === 'no'
+          ? 'Velg språk først for robust stemmemodus.'
+          : 'Choose language first for standard voice mode.'
+      stage.value = 'error'
+      return
+    }
+    if (!transcriptionApi.isRecording.value) {
+      stage.value = 'recording'
+      errorMessage.value = ''
+    } else {
+      stage.value = 'transcribing'
+    }
+    await transcriptionApi.toggleVoiceInput()
+    if (transcriptionApi.isRecording.value) {
+      stage.value = 'recording'
+    } else if (transcriptionApi.isTranscribing.value) {
+      stage.value = 'transcribing'
+    }
+    if (transcriptionApi.voiceError.value) {
+      stage.value = 'error'
+      errorMessage.value = transcriptionApi.voiceError.value
+    }
+  }
+
+  onUnmounted(() => stopPlayback())
+
+  return {
+    stage,
+    errorMessage,
+    transcriptText,
+    answerText,
+    isWorking,
+    isRecording: transcriptionApi.isRecording,
+    isTranscribing: transcriptionApi.isTranscribing,
+    recordingMediaStream: transcriptionApi.recordingMediaStream,
+    supportsSpeechInput: transcriptionApi.supportsSpeechInput,
+    toggleRecording,
+    stopPlayback,
+  }
+}

--- a/frontend/homepage/src/composables/useStandardVoice.ts
+++ b/frontend/homepage/src/composables/useStandardVoice.ts
@@ -100,8 +100,6 @@ export function useStandardVoice(options: UseStandardVoiceOptions) {
     if (!transcriptionApi.isRecording.value) {
       stage.value = 'recording'
       errorMessage.value = ''
-    } else {
-      stage.value = 'transcribing'
     }
     await transcriptionApi.toggleVoiceInput()
     if (transcriptionApi.isRecording.value) {

--- a/frontend/homepage/src/lib/__tests__/realtime-voice.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/realtime-voice.spec.ts
@@ -43,6 +43,8 @@ describe('realtime-voice', () => {
     const { fetchRealtimeVoiceStatus } = await import('../realtime-voice')
     await expect(fetchRealtimeVoiceStatus()).resolves.toEqual({
       enabled: true,
+      standardEnabled: false,
+      liveEnabled: false,
       voices: ['marin', 'cedar'],
       reasoningEfforts: ['low', 'medium', 'high'],
       voice: 'cedar',

--- a/frontend/homepage/src/lib/__tests__/realtime-voice.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/realtime-voice.spec.ts
@@ -180,6 +180,7 @@ describe('realtime-voice', () => {
 
     await expect(lookupRealtimeInfo('NTNU', 'en')).resolves.toEqual({
       found: true,
+      confidence: 'high',
       snippets: [{ sourceType: 'profile', title: 'Data engineering', text: 'Kevin studies at NTNU.' }],
     })
 
@@ -197,12 +198,14 @@ describe('realtime-voice', () => {
     await expect(lookupRealtimeInfo('NTNU', 'no')).resolves.toEqual({
       found: false,
       snippets: [],
+      confidence: 'none',
     })
 
     mockCustomFetch.mockResolvedValueOnce({ status: 200, data: { found: true, snippets: [] } })
     await expect(lookupRealtimeInfo('NTNU', 'no')).resolves.toEqual({
       found: false,
       snippets: [],
+      confidence: 'none',
     })
   })
 

--- a/frontend/homepage/src/lib/__tests__/synthesize-speech.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/synthesize-speech.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { synthesizeSpeech } from '../synthesize-speech'
+
+describe('synthesizeSpeech', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns audio blob on success', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/mpeg' })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(blob),
+      }),
+    )
+
+    const result = await synthesizeSpeech('Hello', 'en')
+    expect(result).toEqual({ ok: true, blob })
+    expect(fetch).toHaveBeenCalledWith('/api/synthesize', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Chat-Language': 'en',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ text: 'Hello' }),
+    })
+  })
+
+  it('returns API error message when synthesis fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ error: 'Speech synthesis is temporarily unavailable.' }),
+      }),
+    )
+
+    const result = await synthesizeSpeech('Hello', 'no')
+    expect(result).toEqual({
+      ok: false,
+      status: 503,
+      message: 'Speech synthesis is temporarily unavailable.',
+    })
+  })
+
+  it('returns network error when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+
+    const result = await synthesizeSpeech('Hello', 'en')
+    expect(result).toEqual({ ok: false, status: 0, message: 'Network error' })
+  })
+
+  it('falls back to HTTP status when error body is not JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error('not json')),
+      }),
+    )
+
+    const result = await synthesizeSpeech('Hello', 'en')
+    expect(result).toEqual({ ok: false, status: 500, message: 'HTTP 500' })
+  })
+})

--- a/frontend/homepage/src/lib/__tests__/transcript-quality.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/transcript-quality.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isTranscriptUncertain, repeatRequestMessage } from '../transcript-quality'
+
+describe('transcript-quality', () => {
+  it('flags very short meaningful transcripts as uncertain', () => {
+    expect(isTranscriptUncertain('hi')).toBe(true)
+    expect(isTranscriptUncertain('kevin')).toBe(true)
+  })
+
+  it('accepts normal questions', () => {
+    expect(isTranscriptUncertain('What does Kevin study at NTNU?')).toBe(false)
+  })
+
+  it('flags garbled transcripts with low letter ratio', () => {
+    expect(isTranscriptUncertain('??? ### @@@')).toBe(true)
+  })
+
+  it('returns localized repeat prompts', () => {
+    expect(repeatRequestMessage('en')).toContain('say it again')
+    expect(repeatRequestMessage('no')).toContain('si det på nytt')
+  })
+})

--- a/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { formatLookupForSpeech } from '../voice-answer'
+
+describe('formatLookupForSpeech', () => {
+  it('joins first two non-empty snippets', () => {
+    const result = formatLookupForSpeech(
+      {
+        found: true,
+        snippets: [
+          { sourceType: 'profile', title: 'A', text: 'First' },
+          { sourceType: 'rag', title: 'B', text: 'Second' },
+          { sourceType: 'rag', title: 'C', text: 'Third' },
+        ],
+      },
+      'en',
+    )
+    expect(result).toBe('First Second')
+  })
+
+  it('returns localized fallback when no snippets found', () => {
+    expect(formatLookupForSpeech({ found: false, snippets: [] }, 'en')).toContain("couldn't find")
+    expect(formatLookupForSpeech({ found: false, snippets: [] }, 'no')).toContain('Beklager')
+  })
+})

--- a/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
@@ -21,4 +21,19 @@ describe('formatLookupForSpeech', () => {
     expect(formatLookupForSpeech({ found: false, snippets: [] }, 'en')).toContain("couldn't find")
     expect(formatLookupForSpeech({ found: false, snippets: [] }, 'no')).toContain('Beklager')
   })
+
+  it('skips empty snippet text', () => {
+    expect(
+      formatLookupForSpeech(
+        {
+          found: true,
+          snippets: [
+            { sourceType: 'profile', title: 'A', text: '   ' },
+            { sourceType: 'rag', title: 'B', text: 'Only this' },
+          ],
+        },
+        'en',
+      ),
+    ).toBe('Only this')
+  })
 })

--- a/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
@@ -6,6 +6,7 @@ describe('formatLookupForSpeech', () => {
     const result = formatLookupForSpeech(
       {
         found: true,
+        confidence: 'high',
         snippets: [
           { sourceType: 'profile', title: 'A', text: 'First' },
           { sourceType: 'rag', title: 'B', text: 'Second' },
@@ -18,8 +19,24 @@ describe('formatLookupForSpeech', () => {
   })
 
   it('returns localized fallback when no snippets found', () => {
-    expect(formatLookupForSpeech({ found: false, snippets: [] }, 'en')).toContain("couldn't find")
-    expect(formatLookupForSpeech({ found: false, snippets: [] }, 'no')).toContain('Beklager')
+    expect(formatLookupForSpeech({ found: false, confidence: 'none', snippets: [] }, 'en')).toContain(
+      "don't have information",
+    )
+    expect(formatLookupForSpeech({ found: false, confidence: 'none', snippets: [] }, 'no')).toContain('Jeg har ikke')
+  })
+
+  it('prefixes low-confidence answers with uncertainty messaging', () => {
+    const result = formatLookupForSpeech(
+      {
+        found: true,
+        confidence: 'low',
+        snippets: [{ sourceType: 'profile', title: 'A', text: 'Maybe Kevin studies IT.' }],
+      },
+      'en',
+    )
+    expect(result).toContain('not sure I understood')
+    expect(result).toContain('Maybe Kevin studies IT.')
+    expect(result).toContain('rephrasing')
   })
 
   it('skips empty snippet text', () => {
@@ -27,6 +44,7 @@ describe('formatLookupForSpeech', () => {
       formatLookupForSpeech(
         {
           found: true,
+          confidence: 'high',
           snippets: [
             { sourceType: 'profile', title: 'A', text: '   ' },
             { sourceType: 'rag', title: 'B', text: 'Only this' },

--- a/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/voice-answer.spec.ts
@@ -39,6 +39,20 @@ describe('formatLookupForSpeech', () => {
     expect(result).toContain('rephrasing')
   })
 
+  it('prefixes low-confidence answers in Norwegian', () => {
+    const result = formatLookupForSpeech(
+      {
+        found: true,
+        confidence: 'low',
+        snippets: [{ sourceType: 'profile', title: 'A', text: 'Kevin studerer IT.' }],
+      },
+      'no',
+    )
+    expect(result).toContain('Jeg er ikke helt sikker')
+    expect(result).toContain('Kevin studerer IT.')
+    expect(result).toContain('annen måte')
+  })
+
   it('skips empty snippet text', () => {
     expect(
       formatLookupForSpeech(

--- a/frontend/homepage/src/lib/posthog-sdk.ts
+++ b/frontend/homepage/src/lib/posthog-sdk.ts
@@ -34,6 +34,8 @@ export const POSTHOG_VOICE_EVENTS = {
   SESSION_STARTED: 'portfolio_voice_session_started',
   SESSION_ENDED: 'portfolio_voice_session_ended',
   SESSION_ERROR: 'portfolio_voice_session_error',
+  MODE_SELECTED: 'portfolio_voice_mode_selected',
+  STANDARD_TURN_COMPLETED: 'portfolio_standard_voice_turn_completed',
 } as const
 
 /** Feature flag keys created in PostHog (MCP / UI). */

--- a/frontend/homepage/src/lib/realtime-voice.ts
+++ b/frontend/homepage/src/lib/realtime-voice.ts
@@ -31,6 +31,8 @@ export type RealtimeVoiceModelOption = {
 
 export type RealtimeVoiceStatus = RealtimeVoiceSessionOptions & {
   enabled: boolean
+  standardEnabled: boolean
+  liveEnabled: boolean
   voices: RealtimeVoiceChoice[]
   reasoningEfforts: RealtimeReasoningEffort[]
 }
@@ -87,6 +89,8 @@ function parseRealtimeVoiceStatus(data: unknown): RealtimeVoiceStatus | null {
     reasoningEfforts?: unknown
     defaultVoice?: unknown
     defaultReasoningEffort?: unknown
+    standardEnabled?: unknown
+    liveEnabled?: unknown
   }
   const voices = Array.isArray(d.voices) ? d.voices.filter(isRealtimeVoice) : [...ALLOWED_REALTIME_VOICES]
   const reasoningEfforts = Array.isArray(d.reasoningEfforts)
@@ -102,6 +106,8 @@ function parseRealtimeVoiceStatus(data: unknown): RealtimeVoiceStatus | null {
 
   return {
     enabled: d.enabled === true,
+    standardEnabled: d.standardEnabled === true,
+    liveEnabled: d.liveEnabled === true,
     voices: voices.length > 0 ? voices : [...ALLOWED_REALTIME_VOICES],
     reasoningEfforts: reasoningEfforts.length > 0 ? reasoningEfforts : [...ALLOWED_REALTIME_REASONING_EFFORTS],
     voice: defaultVoice,
@@ -120,6 +126,8 @@ export async function fetchRealtimeVoiceStatus(): Promise<RealtimeVoiceStatus> {
     }
     return parseRealtimeVoiceStatus(r.data) ?? {
       enabled: false,
+      standardEnabled: false,
+      liveEnabled: false,
       voices: [...ALLOWED_REALTIME_VOICES],
       reasoningEfforts: [...ALLOWED_REALTIME_REASONING_EFFORTS],
       voice: DEFAULT_REALTIME_VOICE,
@@ -128,6 +136,8 @@ export async function fetchRealtimeVoiceStatus(): Promise<RealtimeVoiceStatus> {
   } catch {
     return {
       enabled: false,
+      standardEnabled: false,
+      liveEnabled: false,
       voices: [...ALLOWED_REALTIME_VOICES],
       reasoningEfforts: [...ALLOWED_REALTIME_REASONING_EFFORTS],
       voice: DEFAULT_REALTIME_VOICE,

--- a/frontend/homepage/src/lib/realtime-voice.ts
+++ b/frontend/homepage/src/lib/realtime-voice.ts
@@ -9,9 +9,12 @@ export type RealtimeLookupSnippet = {
   text: string
 }
 
+export type RealtimeLookupConfidence = 'high' | 'low' | 'none'
+
 export type RealtimeLookupResponse = {
   found: boolean
   snippets: RealtimeLookupSnippet[]
+  confidence?: RealtimeLookupConfidence
 }
 
 export type RealtimeVoiceChoice = 'marin' | 'cedar'
@@ -176,22 +179,35 @@ function isLookupSnippet(value: unknown): value is RealtimeLookupSnippet {
 export async function lookupRealtimeInfo(
   query: string,
   language: SpeechUiLang,
+  signal?: AbortSignal,
 ): Promise<RealtimeLookupResponse> {
   try {
     const r = await customFetch<{ data: unknown; status: number }>('/realtime/lookup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, language }),
+      signal,
     })
     if (r.status < 200 || r.status >= 300 || r.data === null || typeof r.data !== 'object') {
-      return { found: false, snippets: [] }
+      return { found: false, snippets: [], confidence: 'none' }
     }
-    const data = r.data as { found?: unknown; snippets?: unknown }
+    const data = r.data as { found?: unknown; snippets?: unknown; confidence?: unknown }
     const snippets = Array.isArray(data.snippets) ? data.snippets.filter(isLookupSnippet) : []
-    return { found: data.found === true && snippets.length > 0, snippets }
-  } catch {
-    return { found: false, snippets: [] }
+    const confidence = parseLookupConfidence(data.confidence, data.found === true && snippets.length > 0)
+    return { found: data.found === true && snippets.length > 0, snippets, confidence }
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      throw e
+    }
+    return { found: false, snippets: [], confidence: 'none' }
   }
+}
+
+function parseLookupConfidence(value: unknown, found: boolean): RealtimeLookupConfidence {
+  if (value === 'high' || value === 'low' || value === 'none') {
+    return value
+  }
+  return found ? 'high' : 'none'
 }
 
 /**

--- a/frontend/homepage/src/lib/synthesize-speech.ts
+++ b/frontend/homepage/src/lib/synthesize-speech.ts
@@ -4,7 +4,11 @@ export type SynthesizeResult =
   | { ok: true; blob: Blob }
   | { ok: false; status: number; message: string }
 
-export async function synthesizeSpeech(text: string, language: SpeechUiLang): Promise<SynthesizeResult> {
+export async function synthesizeSpeech(
+  text: string,
+  language: SpeechUiLang,
+  signal?: AbortSignal,
+): Promise<SynthesizeResult> {
   try {
     const res = await fetch('/api/synthesize', {
       method: 'POST',
@@ -14,6 +18,7 @@ export async function synthesizeSpeech(text: string, language: SpeechUiLang): Pr
       },
       credentials: 'include',
       body: JSON.stringify({ text }),
+      signal,
     })
     if (!res.ok) {
       let message = `HTTP ${res.status}`
@@ -28,7 +33,10 @@ export async function synthesizeSpeech(text: string, language: SpeechUiLang): Pr
       return { ok: false, status: res.status, message }
     }
     return { ok: true, blob: await res.blob() }
-  } catch {
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      throw e
+    }
     return { ok: false, status: 0, message: 'Network error' }
   }
 }

--- a/frontend/homepage/src/lib/synthesize-speech.ts
+++ b/frontend/homepage/src/lib/synthesize-speech.ts
@@ -1,0 +1,34 @@
+import type { SpeechUiLang } from './realtime-voice'
+
+export type SynthesizeResult =
+  | { ok: true; blob: Blob }
+  | { ok: false; status: number; message: string }
+
+export async function synthesizeSpeech(text: string, language: SpeechUiLang): Promise<SynthesizeResult> {
+  try {
+    const res = await fetch('/api/synthesize', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Chat-Language': language,
+      },
+      credentials: 'include',
+      body: JSON.stringify({ text }),
+    })
+    if (!res.ok) {
+      let message = `HTTP ${res.status}`
+      try {
+        const json = (await res.json()) as { error?: unknown }
+        if (typeof json.error === 'string' && json.error.trim() !== '') {
+          message = json.error
+        }
+      } catch {
+        // ignore JSON parsing fallback
+      }
+      return { ok: false, status: res.status, message }
+    }
+    return { ok: true, blob: await res.blob() }
+  } catch {
+    return { ok: false, status: 0, message: 'Network error' }
+  }
+}

--- a/frontend/homepage/src/lib/transcribe-audio.ts
+++ b/frontend/homepage/src/lib/transcribe-audio.ts
@@ -18,6 +18,7 @@ export type TranscribeLanguage = 'en' | 'no'
 export async function transcribeSpeech(
   blob: Blob,
   language?: TranscribeLanguage,
+  signal?: AbortSignal,
 ): Promise<TranscribeSpeechResult> {
   const fd = new FormData()
   fd.append('file', blob, 'recording.webm')
@@ -30,5 +31,6 @@ export async function transcribeSpeech(
     method: 'POST',
     body: fd,
     headers,
+    signal,
   })
 }

--- a/frontend/homepage/src/lib/transcript-quality.ts
+++ b/frontend/homepage/src/lib/transcript-quality.ts
@@ -1,0 +1,54 @@
+import type { SpeechUiLang } from './realtime-voice'
+
+const STOP_WORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'with',
+  'what',
+  'does',
+  'about',
+  'tell',
+  'his',
+  'her',
+  'him',
+  'hva',
+  'om',
+  'og',
+  'med',
+  'kan',
+  'du',
+  'han',
+  'hans',
+  'kevin',
+])
+
+/** Returns true when Whisper output looks too short or garbled to trust. */
+export function isTranscriptUncertain(text: string): boolean {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) {
+    return true
+  }
+
+  const meaningful = trimmed
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter((part) => part.length > 0 && !STOP_WORDS.has(part))
+    .join('')
+  if (meaningful.length < 3) {
+    return true
+  }
+
+  const letters = trimmed.match(/\p{L}/gu)?.length ?? 0
+  if (trimmed.length > 0 && letters / trimmed.length < 0.5) {
+    return true
+  }
+
+  return false
+}
+
+export function repeatRequestMessage(language: SpeechUiLang): string {
+  return language === 'no'
+    ? 'Beklager, jeg hørte deg ikke helt tydelig. Kan du si det på nytt?'
+    : "Sorry, I didn't catch that clearly. Could you please say it again?"
+}

--- a/frontend/homepage/src/lib/voice-answer.ts
+++ b/frontend/homepage/src/lib/voice-answer.ts
@@ -1,15 +1,38 @@
-import type { RealtimeLookupResponse, SpeechUiLang } from './realtime-voice'
+import type { RealtimeLookupConfidence, RealtimeLookupResponse, SpeechUiLang } from './realtime-voice'
+
+function noneMessage(language: SpeechUiLang): string {
+  return language === 'no'
+    ? 'Jeg har ikke informasjon om det. Prøv gjerne å spørre om Kevin sine studier, prosjekter eller erfaring.'
+    : "I don't have information about that. Try asking about Kevin's studies, projects, or experience."
+}
+
+function lowConfidencePrefix(language: SpeechUiLang): string {
+  return language === 'no'
+    ? 'Jeg er ikke helt sikker på hva du sa, men dette fant jeg: '
+    : "I'm not sure I understood correctly, but here's what I found: "
+}
+
+function lowConfidenceSuffix(language: SpeechUiLang): string {
+  return language === 'no'
+    ? ' Kan du prøve å si det på en annen måte?'
+    : ' Could you try rephrasing that?'
+}
 
 export function formatLookupForSpeech(response: RealtimeLookupResponse, language: SpeechUiLang): string {
+  const confidence: RealtimeLookupConfidence = response.confidence ?? (response.found ? 'high' : 'none')
   const snippets = response.snippets
     .map((s) => s.text.trim())
     .filter((s) => s.length > 0)
     .slice(0, 2)
 
-  if (snippets.length === 0 || response.found !== true) {
-    return language === 'no'
-      ? 'Beklager, jeg fant ikke noe sikkert svar akkurat nå. Prøv gjerne å spørre på en annen måte.'
-      : "Sorry, I couldn't find a reliable answer right now. Please try asking in a different way."
+  if (confidence === 'none' || snippets.length === 0 || response.found !== true) {
+    return noneMessage(language)
   }
-  return snippets.join(' ')
+
+  const body = snippets.join(' ')
+  if (confidence === 'low') {
+    return `${lowConfidencePrefix(language)}${body}${lowConfidenceSuffix(language)}`
+  }
+
+  return body
 }

--- a/frontend/homepage/src/lib/voice-answer.ts
+++ b/frontend/homepage/src/lib/voice-answer.ts
@@ -1,0 +1,15 @@
+import type { RealtimeLookupResponse, SpeechUiLang } from './realtime-voice'
+
+export function formatLookupForSpeech(response: RealtimeLookupResponse, language: SpeechUiLang): string {
+  const snippets = response.snippets
+    .map((s) => s.text.trim())
+    .filter((s) => s.length > 0)
+    .slice(0, 2)
+
+  if (snippets.length === 0 || response.found !== true) {
+    return language === 'no'
+      ? 'Beklager, jeg fant ikke noe sikkert svar akkurat nå. Prøv gjerne å spørre på en annen måte.'
+      : "Sorry, I couldn't find a reliable answer right now. Please try asking in a different way."
+  }
+  return snippets.join(' ')
+}

--- a/frontend/homepage/src/stores/__tests__/voice-mode.spec.ts
+++ b/frontend/homepage/src/stores/__tests__/voice-mode.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useVoiceModeStore } from '../voice-mode'
+
+describe('useVoiceModeStore', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('loads a stored voice mode', () => {
+    sessionStorage.setItem('voiceMode', 'live')
+    const store = useVoiceModeStore()
+    store.load()
+    expect(store.mode).toBe('live')
+  })
+
+  it('ignores invalid stored values', () => {
+    sessionStorage.setItem('voiceMode', 'invalid')
+    const store = useVoiceModeStore()
+    store.load()
+    expect(store.mode).toBe('standard')
+  })
+
+  it('persists setMode to sessionStorage', () => {
+    const store = useVoiceModeStore()
+    store.setMode('live')
+    expect(store.mode).toBe('live')
+    expect(sessionStorage.getItem('voiceMode')).toBe('live')
+  })
+
+  it('ignores sessionStorage failures when loading', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    const store = useVoiceModeStore()
+    store.load()
+    expect(store.mode).toBe('standard')
+    getItem.mockRestore()
+  })
+
+  it('ignores sessionStorage failures when saving', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    const store = useVoiceModeStore()
+    store.setMode('live')
+    expect(store.mode).toBe('live')
+    setItem.mockRestore()
+  })
+})

--- a/frontend/homepage/src/stores/__tests__/voice-model.spec.ts
+++ b/frontend/homepage/src/stores/__tests__/voice-model.spec.ts
@@ -15,6 +15,19 @@ describe('useVoiceModelStore', () => {
     vi.mocked(fetchRealtimeVoiceModels).mockReset()
   })
 
+  it('exposes the selected model through getters', async () => {
+    vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
+      { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
+    ])
+    const store = useVoiceModelStore()
+
+    await store.ensureModelsLoaded()
+
+    expect(store.selectedModel?.id).toBe('gpt-realtime-2')
+    expect(store.selectedProvider).toBe('OPENAI')
+    expect(store.hasModels).toBe(true)
+  })
+
   it('loads models and prefers the OpenAI default', async () => {
     vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
       { provider: 'ELEVENLABS', id: 'agent_1', label: 'ElevenLabs Agent', defaultOption: true },
@@ -54,5 +67,100 @@ describe('useVoiceModelStore', () => {
     store.setSelectedModelId('missing')
 
     expect(store.selectedModelId).toBe('OPENAI:gpt-realtime-2')
+  })
+
+  it('restores a legacy id-only stored model key', async () => {
+    sessionStorage.setItem('voiceSelectedModel', 'gpt-realtime-2')
+    vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
+      { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
+    ])
+    const store = useVoiceModelStore()
+
+    await store.ensureModelsLoaded()
+
+    expect(store.selectedModelId).toBe('OPENAI:gpt-realtime-2')
+  })
+
+  it('re-applies selection when models are cached but selection is empty', async () => {
+    vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
+      { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
+    ])
+    const store = useVoiceModelStore()
+    await store.ensureModelsLoaded()
+    store.selectedModelId = ''
+
+    await store.ensureModelsLoaded()
+
+    expect(store.selectedModelId).toBe('OPENAI:gpt-realtime-2')
+    expect(fetchRealtimeVoiceModels).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates concurrent model loads', async () => {
+    let resolveModels: (value: Awaited<ReturnType<typeof fetchRealtimeVoiceModels>>) => void
+    vi.mocked(fetchRealtimeVoiceModels).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveModels = resolve
+        }),
+    )
+    const store = useVoiceModelStore()
+    const first = store.ensureModelsLoaded()
+    const second = store.ensureModelsLoaded()
+
+    resolveModels!([
+      { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
+    ])
+    await Promise.all([first, second])
+    expect(fetchRealtimeVoiceModels).toHaveBeenCalledTimes(1)
+    expect(store.models).toHaveLength(1)
+  })
+
+  it('falls back to the first model when no OpenAI default exists', async () => {
+    vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
+      { provider: 'ELEVENLABS', id: 'agent_1', label: 'ElevenLabs Agent', defaultOption: false },
+    ])
+    const store = useVoiceModelStore()
+
+    await store.ensureModelsLoaded()
+
+    expect(store.selectedModelId).toBe('ELEVENLABS:agent_1')
+  })
+
+  it('skips persisting when no model is selected', () => {
+    const store = useVoiceModelStore()
+    store.selectedModelId = ''
+    store.persistModelId()
+    expect(sessionStorage.getItem('voiceSelectedModel')).toBeNull()
+  })
+
+  it('exposes null provider when nothing is selected', () => {
+    const store = useVoiceModelStore()
+    expect(store.selectedProvider).toBeNull()
+  })
+
+  it('ignores malformed stored model keys', async () => {
+    sessionStorage.setItem('voiceSelectedModel', ':')
+    vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
+      { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
+    ])
+    const store = useVoiceModelStore()
+
+    await store.ensureModelsLoaded()
+
+    expect(store.selectedModelId).toBe('OPENAI:gpt-realtime-2')
+  })
+
+  it('ignores sessionStorage failures when persisting selection', async () => {
+    vi.mocked(fetchRealtimeVoiceModels).mockResolvedValue([
+      { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
+    ])
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    const store = useVoiceModelStore()
+    await store.ensureModelsLoaded()
+    store.setSelectedModelId('OPENAI:gpt-realtime-2')
+    expect(store.selectedModelId).toBe('OPENAI:gpt-realtime-2')
+    setItem.mockRestore()
   })
 })

--- a/frontend/homepage/src/stores/voice-mode.ts
+++ b/frontend/homepage/src/stores/voice-mode.ts
@@ -1,0 +1,31 @@
+import { defineStore } from 'pinia'
+
+export type VoiceMode = 'standard' | 'live'
+
+const VOICE_MODE_STORAGE_KEY = 'voiceMode'
+
+export const useVoiceModeStore = defineStore('voiceMode', {
+  state: () => ({
+    mode: 'standard' as VoiceMode,
+  }),
+  actions: {
+    load() {
+      try {
+        const raw = sessionStorage.getItem(VOICE_MODE_STORAGE_KEY)
+        if (raw === 'standard' || raw === 'live') {
+          this.mode = raw
+        }
+      } catch {
+        // ignore
+      }
+    },
+    setMode(mode: VoiceMode) {
+      this.mode = mode
+      try {
+        sessionStorage.setItem(VOICE_MODE_STORAGE_KEY, mode)
+      } catch {
+        // ignore
+      }
+    },
+  },
+})

--- a/frontend/homepage/src/views/HomeView.vue
+++ b/frontend/homepage/src/views/HomeView.vue
@@ -4,7 +4,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useLangStore } from '../stores/lang'
 import { Button } from '@/components/ui/button'
 import { Info, MessageSquare, ChevronRight, Mic, Headphones } from 'lucide-vue-next'
-import { fetchRealtimeVoiceEnabled } from '@/lib/realtime-voice'
+import { fetchRealtimeVoiceStatus } from '@/lib/realtime-voice'
 
 const router = useRouter()
 
@@ -44,10 +44,11 @@ const futureWorkHomeLink = computed(() => {
 })
 
 /** Null until loaded from GET /realtime/status */
-const voiceFeatureEnabled = ref<boolean | null>(null)
+const standardEnabled = ref<boolean | null>(null)
+const liveEnabled = ref<boolean | null>(null)
 
 const voiceCtaAria = computed(() =>
-  language.value === 'no' ? 'Gå til live stemmechat' : 'Go to live voice chat',
+  language.value === 'no' ? 'Gå til robust stemmemodus' : 'Go to robust voice mode',
 )
 
 function goToVoiceChat() {
@@ -56,18 +57,23 @@ function goToVoiceChat() {
 
 const voiceStatus = computed(() => {
   if (language.value === 'no') {
-    if (voiceFeatureEnabled.value === true) return 'Live stemme er tilgjengelig'
-    if (voiceFeatureEnabled.value === false) return 'Stemme er midlertidig av'
+    if (standardEnabled.value === true && liveEnabled.value === true) return 'Standard og live stemme er tilgjengelig'
+    if (standardEnabled.value === true) return 'Standard stemme er tilgjengelig'
+    if (standardEnabled.value === false && liveEnabled.value === true) return 'Kun live stemme er tilgjengelig'
+    if (standardEnabled.value === false && liveEnabled.value === false) return 'Stemme er midlertidig av'
     return 'Sjekker stemmestatus'
   }
-  if (voiceFeatureEnabled.value === true) return 'Live voice is available'
-  if (voiceFeatureEnabled.value === false) return 'Voice is temporarily off'
+  if (standardEnabled.value === true && liveEnabled.value === true) return 'Standard and live voice are available'
+  if (standardEnabled.value === true) return 'Standard voice is available'
+  if (standardEnabled.value === false && liveEnabled.value === true) return 'Live voice only is available'
+  if (standardEnabled.value === false && liveEnabled.value === false) return 'Voice is temporarily off'
   return 'Checking voice status'
 })
 
 onMounted(() => {
-  void fetchRealtimeVoiceEnabled().then((ok) => {
-    voiceFeatureEnabled.value = ok
+  void fetchRealtimeVoiceStatus().then((status) => {
+    standardEnabled.value = status.standardEnabled
+    liveEnabled.value = status.liveEnabled
   })
 })
 </script>
@@ -99,7 +105,7 @@ onMounted(() => {
           <div class="mb-5 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50/80 px-3 py-1.5 text-xs font-semibold text-blue-800">
             <span
               class="size-2 rounded-full"
-              :class="voiceFeatureEnabled === false ? 'bg-amber-500' : 'bg-emerald-500'"
+              :class="standardEnabled === false && liveEnabled === false ? 'bg-amber-500' : 'bg-emerald-500'"
               aria-hidden="true"
             ></span>
             {{ voiceStatus }}
@@ -113,8 +119,8 @@ onMounted(() => {
           <p class="mt-5 max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
             {{
               language === 'no'
-                ? 'Live stemme er den raskeste veien inn i porteføljen. Spør om studier, prosjekter, erfaring og AI-bygget med en gang.'
-                : 'Live voice is the fastest way into the portfolio. Ask about studies, projects, experience, and the AI build without typing first.'
+                ? 'Standard stemme er anbefalt: tregere, men mer robust. Live-modus finnes fortsatt for raskere samtaler, men er mindre stabil.'
+                : 'Standard voice is recommended: slower, but more robust. Live mode still exists for faster conversations, but is less stable.'
             }}
           </p>
           <div class="mt-7 flex flex-col gap-3 sm:flex-row">
@@ -125,14 +131,18 @@ onMounted(() => {
               @click="goToVoiceChat"
             >
               <Headphones class="me-2 size-5" aria-hidden="true" />
-              {{ language === 'no' ? 'Start stemme' : 'Start voice' }}
+              {{ language === 'no' ? 'Start standard stemme' : 'Start standard voice' }}
             </Button>
             <Button
               as-child
               variant="outline"
               class="h-14 w-full justify-center rounded-2xl border-blue-200 bg-white/85 px-5 text-sm font-semibold text-slate-800 hover:bg-blue-50 sm:w-auto sm:px-7 sm:text-base"
             >
-              <RouterLink to="/chat" class="inline-flex items-center">
+              <RouterLink v-if="liveEnabled === true" to="/voice?mode=live" class="inline-flex items-center">
+                <Headphones class="me-2 size-5" aria-hidden="true" />
+                {{ language === 'no' ? 'Prøv live (ustabil)' : 'Try live (unstable)' }}
+              </RouterLink>
+              <RouterLink v-else to="/chat" class="inline-flex items-center">
                 <MessageSquare class="me-2 size-5" aria-hidden="true" />
                 {{ language === 'no' ? 'Bruk tekstchat' : 'Use text chat' }}
               </RouterLink>
@@ -157,8 +167,8 @@ onMounted(() => {
               <p>
                 {{
                   language === 'no'
-                    ? 'Stemme kan bruke et lite offentlig faktaoppslag. Dypere RAG-svar ligger fortsatt i tekstchat.'
-                    : 'Voice can use a small public fact lookup. Deeper RAG answers still live in text chat.'
+                    ? 'Standard stemmemodus bruker språkvalg på forhånd for bedre kvalitet. Live-modus er raskere, men mer ustabil.'
+                    : 'Standard voice asks for language up front for higher quality. Live mode is faster, but more unstable.'
                 }}
               </p>
             </div>

--- a/frontend/homepage/src/views/VoiceView.vue
+++ b/frontend/homepage/src/views/VoiceView.vue
@@ -1,58 +1,54 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { RouterLink } from 'vue-router'
-import { Mic, MicOff, Loader2, Info, MessageSquare } from 'lucide-vue-next'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
+import { MessageSquare } from 'lucide-vue-next'
 import { useLangStore } from '@/stores/lang'
 import { useVoiceModelStore } from '@/stores/voice-model'
-import { Button } from '@/components/ui/button'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import AiStatusDialog from '@/components/AiStatusDialog.vue'
-import { useRealtimeVoice } from '@/composables/useRealtimeVoice'
+import { useVoiceModeStore, type VoiceMode } from '@/stores/voice-mode'
+import { captureProductAnalyticsEvent } from '@/lib/analytics'
+import { POSTHOG_VOICE_EVENTS } from '@/lib/posthog-sdk'
 import {
   fetchRealtimeVoiceStatus,
   type RealtimeReasoningEffort,
   type RealtimeVoiceChoice,
 } from '@/lib/realtime-voice'
+import VoiceModeSwitcher from '@/components/voice/VoiceModeSwitcher.vue'
+import StandardVoicePanel from '@/components/voice/StandardVoicePanel.vue'
+import RealtimeVoicePanel from '@/components/voice/RealtimeVoicePanel.vue'
 
 const langStore = useLangStore()
 const voiceModelStore = useVoiceModelStore()
+const voiceModeStore = useVoiceModeStore()
 const language = computed(() => langStore.language)
+const route = useRoute()
+const router = useRouter()
 
-const voiceAvailable = ref<boolean | null>(null)
+const liveAvailable = ref<boolean | null>(null)
+const standardAvailable = ref<boolean | null>(null)
 const voiceOptions = ref<RealtimeVoiceChoice[]>(['marin', 'cedar'])
 const reasoningOptions = ref<RealtimeReasoningEffort[]>(['low', 'medium', 'high'])
-const selectedVoice = ref<RealtimeVoiceChoice>('marin')
-const selectedReasoningEffort = ref<RealtimeReasoningEffort>('low')
-const aiErrorDialogOpen = ref(false)
-
-const selectedRealtimeOptions = computed(() => ({
-  voice: selectedVoice.value,
-  reasoningEffort: selectedReasoningEffort.value,
-}))
-const selectedVoiceModel = computed(() => voiceModelStore.selectedModel)
-const selectedVoiceProvider = computed(() => selectedVoiceModel.value?.provider ?? 'OPENAI')
-
-const {
-  connectionState,
-  errorMessage,
-  sessionNotice,
-  assistantTranscript,
-  userTranscript,
-  connect,
-  disconnect,
-  maxSessionMs,
-} = useRealtimeVoice(language, selectedRealtimeOptions, selectedVoiceModel)
+const defaultVoice = ref<RealtimeVoiceChoice>('marin')
+const defaultReasoningEffort = ref<RealtimeReasoningEffort>('low')
+const selectedMode = computed<VoiceMode>({
+  get: () => voiceModeStore.mode,
+  set: (value) => voiceModeStore.setMode(value),
+})
 
 onMounted(async () => {
+  voiceModeStore.load()
+  if (route.query.mode === 'live') {
+    voiceModeStore.setMode('live')
+  }
   const [status] = await Promise.all([
     fetchRealtimeVoiceStatus(),
     voiceModelStore.ensureModelsLoaded(),
   ])
-  voiceAvailable.value = status.enabled && voiceModelStore.hasModels
+  liveAvailable.value = status.liveEnabled && voiceModelStore.hasModels
+  standardAvailable.value = status.standardEnabled
   voiceOptions.value = status.voices
   reasoningOptions.value = status.reasoningEfforts
-  selectedVoice.value = status.voice
-  selectedReasoningEffort.value = status.reasoningEffort
+  defaultVoice.value = status.voice
+  defaultReasoningEffort.value = status.reasoningEffort
 })
 
 const copy = computed(() => {
@@ -60,95 +56,28 @@ const copy = computed(() => {
   return {
     title: en ? "Talk with Kevin's AI" : 'Snakk med Kevin sin AI',
     chatAlt: en ? 'Use text chat instead' : 'Bruk tekstchat',
-    unavailable: en
-      ? 'Voice chat is not enabled on the server right now.'
-      : 'Stemmechat er ikke slått på hos serveren akkurat nå.',
-    connect: en ? 'Start voice' : 'Start stemme',
-    disconnect: en ? 'End session' : 'Avslutt',
-    connecting: en ? 'Connecting…' : 'Kobler til…',
-    live: en ? 'Live' : 'Aktiv',
-    modelLabel: en ? 'Provider/model' : 'Leverandør/modell',
-    voiceLabel: en ? 'Voice' : 'Stemme',
-    reasoningLabel: en ? 'Reasoning' : 'Resonnering',
-    you: en ? 'You (transcript)' : 'Du (transkripsjon)',
-    assistant: en ? 'Assistant (transcript)' : 'Assistent (transkripsjon)',
-    disclaimerTitle: en ? 'Before you use voice' : 'Før du bruker stemme',
-    disclaimerBody: en
-      ? `You are talking to an AI, not Kevin himself. Replies can be wrong. Audio is processed by ${selectedVoiceProvider.value === 'ELEVENLABS' ? 'ElevenLabs' : 'OpenAI'} in real time (this page uses WebRTC). Each session ends automatically after about 3 minutes.`
-      : `Du snakker med en KI, ikke Kevin selv. Svar kan være feil. Lyd behandles av ${selectedVoiceProvider.value === 'ELEVENLABS' ? 'ElevenLabs' : 'OpenAI'} i sanntid (denne siden bruker WebRTC). Hver økt avsluttes automatisk etter ca. 3 minutter.`,
+    modeHint: en
+      ? 'Choose between robust standard voice and experimental live mode.'
+      : 'Velg mellom robust standard stemme og eksperimentell live-modus.',
   }
 })
 
-const voiceLabels: Record<RealtimeVoiceChoice, string> = {
-  marin: 'Marin',
-  cedar: 'Cedar',
-}
-
-const reasoningLabels = computed<Record<RealtimeReasoningEffort, string>>(() => {
-  const en = language.value === 'en'
-  return {
-    low: en ? 'Fast' : 'Rask',
-    medium: en ? 'Balanced' : 'Balansert',
-    high: en ? 'Thorough' : 'Grundig',
+watch(
+  () => selectedMode.value,
+  (mode) => {
+    captureProductAnalyticsEvent(POSTHOG_VOICE_EVENTS.MODE_SELECTED, { mode })
+    const nextQuery = { ...route.query }
+    if (mode === 'live') nextQuery.mode = 'live'
+    else delete nextQuery.mode
+    void router.replace({ query: nextQuery })
   }
-})
-
-function makeVoiceModelValue(provider: string, id: string) {
-  return `${provider}:${id}`
-}
-
-const sessionControlsDisabled = computed(
-  () => connectionState.value === 'connecting' || connectionState.value === 'connected',
 )
-
-const statusLabel = computed(() => {
-  if (connectionState.value === 'connecting') return copy.value.connecting
-  if (connectionState.value === 'connected') return copy.value.live
-  return ''
-})
-
-const errorDialogCopy = computed(() => {
-  const en = language.value === 'en'
-  return {
-    title: en ? 'Voice could not start' : 'Stemme kunne ikke starte',
-    description: en
-      ? 'The live AI service needs a fresh session before it can continue.'
-      : 'Live AI-tjenesten trenger en ny økt før den kan fortsette.',
-    retry: en ? 'Try again' : 'Prøv igjen',
-  }
-})
-
-watch(errorMessage, (message) => {
-  aiErrorDialogOpen.value = message.trim() !== ''
-})
-
-function retryVoice() {
-  aiErrorDialogOpen.value = false
-  void connect()
-}
-
-function setVoiceModelFromEvent(event: Event) {
-  const target = event.target
-  if (target instanceof HTMLSelectElement) {
-    voiceModelStore.setSelectedModelId(target.value)
-  }
-}
 </script>
 
 <template>
   <main
     class="relative flex min-h-0 flex-1 flex-col overflow-y-auto bg-gradient-to-br from-slate-100 via-blue-50 to-slate-100 pt-20"
   >
-    <AiStatusDialog
-      v-model:open="aiErrorDialogOpen"
-      :title="errorDialogCopy.title"
-      :description="errorDialogCopy.description"
-      :message="errorMessage"
-      :retry-label="errorDialogCopy.retry"
-      show-retry
-      @retry="retryVoice"
-    />
-
     <div class="absolute inset-0 pointer-events-none">
       <div
         class="absolute top-0 left-0 h-full w-full"
@@ -172,163 +101,23 @@ function setVoiceModelFromEvent(event: Event) {
           {{ copy.chatAlt }}
         </RouterLink>
       </div>
+      <p class="mb-4 text-sm text-slate-600">{{ copy.modeHint }}</p>
+      <VoiceModeSwitcher v-model="selectedMode" :language="language" />
 
-      <Alert
-        class="mb-6 border-blue-200/80 bg-blue-50/90 text-slate-800 shadow-sm backdrop-blur-sm [&>svg]:text-blue-600"
-      >
-        <Info class="size-4 shrink-0" aria-hidden="true" />
-        <AlertTitle>{{ copy.disclaimerTitle }}</AlertTitle>
-        <AlertDescription>{{ copy.disclaimerBody }}</AlertDescription>
-      </Alert>
-
-      <div
-        v-if="voiceAvailable === false"
-        class="rounded-2xl border border-amber-200 bg-amber-50/90 px-4 py-3 text-center text-sm text-amber-900"
-      >
-        {{ copy.unavailable }}
-      </div>
-
-      <template v-else-if="voiceAvailable === true">
-        <div class="flex flex-col items-center gap-6">
-          <div
-            class="relative flex h-40 w-40 items-center justify-center rounded-full bg-gradient-to-br from-blue-600 to-indigo-700 shadow-xl shadow-blue-500/25"
-            :class="{
-              'ring-4 ring-blue-400/50 animate-pulse': connectionState === 'connected',
-            }"
-          >
-            <Loader2
-              v-if="connectionState === 'connecting'"
-              class="size-14 text-white animate-spin"
-              aria-hidden="true"
-            />
-            <Mic
-              v-else-if="connectionState === 'connected'"
-              class="size-14 text-white"
-              aria-hidden="true"
-            />
-            <Mic v-else class="size-14 text-white opacity-90" aria-hidden="true" />
-            <span class="sr-only">{{ statusLabel }}</span>
-          </div>
-
-          <p v-if="connectionState === 'connected'" class="text-sm font-medium text-green-700">
-            {{ copy.live }} · ~{{ Math.round(maxSessionMs / 60_000) }} min max
-          </p>
-
-          <label class="w-full max-w-md text-left text-xs font-semibold uppercase text-slate-600">
-            {{ copy.modelLabel }}
-            <select
-              :value="voiceModelStore.selectedModelId"
-              data-testid="voice-model-select"
-              class="mt-1 h-10 w-full rounded-lg border border-blue-100 bg-white/90 px-3 text-sm font-medium normal-case text-slate-800 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
-              :disabled="sessionControlsDisabled"
-              @change="setVoiceModelFromEvent"
-            >
-              <option
-                v-for="model in voiceModelStore.models"
-                :key="model.provider + ':' + model.id"
-                :value="makeVoiceModelValue(model.provider, model.id)"
-              >
-                {{ model.label }}
-              </option>
-            </select>
-          </label>
-
-          <div
-            v-if="selectedVoiceProvider === 'OPENAI'"
-            class="grid w-full max-w-md grid-cols-1 gap-3 sm:grid-cols-2"
-          >
-            <label class="text-left text-xs font-semibold uppercase text-slate-600">
-              {{ copy.voiceLabel }}
-              <select
-                v-model="selectedVoice"
-                data-testid="voice-select"
-                class="mt-1 h-10 w-full rounded-lg border border-blue-100 bg-white/90 px-3 text-sm font-medium normal-case text-slate-800 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
-                :disabled="sessionControlsDisabled"
-              >
-                <option v-for="voice in voiceOptions" :key="voice" :value="voice">
-                  {{ voiceLabels[voice] }}
-                </option>
-              </select>
-            </label>
-
-            <label class="text-left text-xs font-semibold uppercase text-slate-600">
-              {{ copy.reasoningLabel }}
-              <select
-                v-model="selectedReasoningEffort"
-                data-testid="reasoning-select"
-                class="mt-1 h-10 w-full rounded-lg border border-blue-100 bg-white/90 px-3 text-sm font-medium normal-case text-slate-800 shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
-                :disabled="sessionControlsDisabled"
-              >
-                <option v-for="effort in reasoningOptions" :key="effort" :value="effort">
-                  {{ reasoningLabels[effort] }}
-                </option>
-              </select>
-            </label>
-          </div>
-
-          <div class="flex flex-wrap justify-center gap-3">
-            <Button
-              v-if="connectionState === 'idle' || connectionState === 'error'"
-              type="button"
-              class="rounded-2xl bg-gradient-to-r from-blue-600 to-blue-700 px-8 py-6 text-base font-semibold"
-              @click="connect"
-            >
-              {{ copy.connect }}
-            </Button>
-            <Button
-              v-if="connectionState === 'connecting'"
-              type="button"
-              variant="secondary"
-              disabled
-            >
-              {{ copy.connecting }}
-            </Button>
-            <Button
-              v-if="connectionState === 'connected'"
-              type="button"
-              variant="outline"
-              class="rounded-2xl border-red-200 text-red-700 hover:bg-red-50"
-              @click="disconnect"
-            >
-              <MicOff class="me-2 inline size-4" aria-hidden="true" />
-              {{ copy.disconnect }}
-            </Button>
-          </div>
-        </div>
-
-        <Alert
-          v-if="sessionNotice"
-          class="mt-6 border-blue-200 bg-blue-50 text-slate-800"
-        >
-          <AlertDescription>{{ sessionNotice }}</AlertDescription>
-        </Alert>
-
-        <div
-          v-if="connectionState === 'connected' || userTranscript || assistantTranscript"
-          class="mt-8 space-y-4 rounded-2xl border border-blue-100 bg-white/85 p-4 shadow-sm backdrop-blur-md"
-        >
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              {{ copy.you }}
-            </p>
-            <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">
-              {{ userTranscript || '…' }}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              {{ copy.assistant }}
-            </p>
-            <p class="mt-1 whitespace-pre-wrap text-sm text-slate-800">
-              {{ assistantTranscript || '…' }}
-            </p>
-          </div>
-        </div>
-      </template>
-
-      <div v-else class="flex justify-center py-12">
-        <Loader2 class="size-8 animate-spin text-blue-600" aria-hidden="true" />
-      </div>
+      <StandardVoicePanel
+        v-if="selectedMode === 'standard'"
+        :language="language"
+        :available="standardAvailable"
+      />
+      <RealtimeVoicePanel
+        v-else
+        :language="language"
+        :available="liveAvailable"
+        :voice-options="voiceOptions"
+        :reasoning-options="reasoningOptions"
+        :default-voice="defaultVoice"
+        :default-reasoning-effort="defaultReasoningEffort"
+      />
     </div>
   </main>
 </template>

--- a/frontend/homepage/src/views/__tests__/ChatView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/ChatView.spec.ts
@@ -639,7 +639,11 @@ describe('ChatView', () => {
 
       expect(wrapper.find('input[type="text"]').exists()).toBe(true)
       expect(wrapper.find('[role="img"]').exists()).toBe(false)
-      expect(vi.mocked(transcribeSpeech)).toHaveBeenCalledWith(expect.any(Blob), 'en')
+      expect(vi.mocked(transcribeSpeech)).toHaveBeenCalledWith(
+        expect.any(Blob),
+        'en',
+        expect.any(AbortSignal),
+      )
     })
   })
 })

--- a/frontend/homepage/src/views/__tests__/HomeView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/HomeView.spec.ts
@@ -6,7 +6,15 @@ import HomeView from '../HomeView.vue'
 import { useLangStore } from '@/stores/lang'
 
 vi.mock('@/lib/realtime-voice', () => ({
-	fetchRealtimeVoiceEnabled: vi.fn().mockResolvedValue(false),
+	fetchRealtimeVoiceStatus: vi.fn().mockResolvedValue({
+		enabled: false,
+		standardEnabled: false,
+		liveEnabled: false,
+		voices: ['marin', 'cedar'],
+		reasoningEfforts: ['low', 'medium', 'high'],
+		voice: 'marin',
+		reasoningEffort: 'low',
+	}),
 }))
 
 vi.mock('@/stores/auth', () => ({
@@ -115,7 +123,7 @@ describe('HomeView', () => {
 		})
 		await flushPromises()
 
-		await wrapper.find('[aria-label="Go to live voice chat"]').trigger('click')
+		await wrapper.find('[aria-label="Go to robust voice mode"]').trigger('click')
 		expect(pushSpy).toHaveBeenCalledWith({ name: 'voice' })
 	})
 
@@ -134,7 +142,7 @@ describe('HomeView', () => {
 		})
 		await flushPromises()
 
-		await wrapper.find('[aria-label="Gå til live stemmechat"]').trigger('click')
+		await wrapper.find('[aria-label="Gå til robust stemmemodus"]').trigger('click')
 		expect(pushSpy).toHaveBeenCalledWith({ name: 'voice' })
 	})
 })

--- a/frontend/homepage/src/views/__tests__/VoiceView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/VoiceView.spec.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 import type { Component } from 'vue'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
@@ -8,93 +7,41 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import VoiceView from '../VoiceView.vue'
 import { useLangStore } from '@/stores/lang'
 
-const fetchRealtimeVoiceEnabledMock = vi.hoisted(() => vi.fn())
+const fetchRealtimeVoiceStatusMock = vi.hoisted(() => vi.fn())
 const fetchRealtimeVoiceModelsMock = vi.hoisted(() => vi.fn())
-const mockedUseRealtimeVoiceImpl = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/realtime-voice', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/realtime-voice')>()
   return {
     ...actual,
-    fetchRealtimeVoiceStatus: (...args: unknown[]) => fetchRealtimeVoiceEnabledMock(...args),
+    fetchRealtimeVoiceStatus: (...args: unknown[]) => fetchRealtimeVoiceStatusMock(...args),
     fetchRealtimeVoiceModels: (...args: unknown[]) => fetchRealtimeVoiceModelsMock(...args),
   }
 })
 
-vi.mock('@/composables/useRealtimeVoice', () => ({
-  useRealtimeVoice: (...args: unknown[]) => mockedUseRealtimeVoiceImpl(...args),
-}))
-
-vi.mock('@/lib/analytics', () => ({
-  captureProductAnalyticsEvent: vi.fn(),
-  captureClientException: vi.fn(),
-}))
-
 describe('VoiceView.vue', () => {
   async function factory(opts: {
     lang: 'en' | 'no'
-    fetchResult: boolean | 'pending'
+    route?: string
+    standardEnabled: boolean
+    liveEnabled: boolean
   }) {
     vi.clearAllMocks()
-
-    fetchRealtimeVoiceEnabledMock.mockReset()
+    fetchRealtimeVoiceStatusMock.mockReset()
     fetchRealtimeVoiceModelsMock.mockReset()
     fetchRealtimeVoiceModelsMock.mockResolvedValue([
       { provider: 'OPENAI', id: 'gpt-realtime-2', label: 'OpenAI GPT-Realtime-2', defaultOption: true },
       { provider: 'ELEVENLABS', id: 'agent_1', label: 'ElevenLabs Agent', defaultOption: false },
     ])
-
-    let resolveAvail: ((v: boolean) => void) | undefined
-
-    if (opts.fetchResult === 'pending') {
-      fetchRealtimeVoiceEnabledMock.mockImplementation(
-        () =>
-          new Promise<{
-            enabled: boolean
-            voices: ['marin', 'cedar']
-            reasoningEfforts: ['low', 'medium', 'high']
-            voice: 'cedar'
-            reasoningEffort: 'medium'
-          }>((resolve) => {
-            resolveAvail = (v: boolean) =>
-              resolve({
-                enabled: v,
-                voices: ['marin', 'cedar'],
-                reasoningEfforts: ['low', 'medium', 'high'],
-                voice: 'cedar',
-                reasoningEffort: 'medium',
-              })
-          }),
-      )
-    } else {
-      fetchRealtimeVoiceEnabledMock.mockResolvedValue({
-        enabled: opts.fetchResult,
-        voices: ['marin', 'cedar'],
-        reasoningEfforts: ['low', 'medium', 'high'],
-        voice: 'cedar',
-        reasoningEffort: 'medium',
-      })
-    }
-
-    const stubConnect = vi.fn()
-    const stubDisconnect = vi.fn()
-
-    const connectionState = ref<'idle' | 'connecting' | 'connected' | 'error'>('idle')
-    const errorMessage = ref('')
-    const sessionNotice = ref('')
-    const assistantTranscript = ref('')
-    const userTranscript = ref('')
-
-    mockedUseRealtimeVoiceImpl.mockImplementation(() => ({
-      connectionState,
-      errorMessage,
-      sessionNotice,
-      assistantTranscript,
-      userTranscript,
-      connect: stubConnect,
-      disconnect: stubDisconnect,
-      maxSessionMs: ref(180_000),
-    }))
+    fetchRealtimeVoiceStatusMock.mockResolvedValue({
+      enabled: opts.standardEnabled || opts.liveEnabled,
+      standardEnabled: opts.standardEnabled,
+      liveEnabled: opts.liveEnabled,
+      voices: ['marin', 'cedar'],
+      reasoningEfforts: ['low', 'medium', 'high'],
+      voice: 'cedar',
+      reasoningEffort: 'medium',
+    })
 
     const HomeStub = { template: '<div />' }
 
@@ -114,7 +61,7 @@ describe('VoiceView.vue', () => {
       ],
     })
 
-    await router.push('/voice')
+    await router.push(opts.route ?? '/voice')
     await router.isReady()
 
     const stubs = {
@@ -129,15 +76,14 @@ describe('VoiceView.vue', () => {
       Alert: { template: '<div class="__alert-portfolio"><slot /></div>' },
       AlertTitle: { template: '<div><slot /></div>' },
       AlertDescription: { template: '<div><slot /></div>' },
-      Info: true,
-      Mic: true,
-      MicOff: true,
-      Loader2: true,
       MessageSquare: true,
-      AiStatusDialog: {
-        props: ['open', 'title', 'message'],
-        template: '<div v-if="open" role="dialog"><h2>{{ title }}</h2><p>{{ message }}</p><button @click="$emit(\'update:open\', false)">OK</button></div>',
+      VoiceModeSwitcher: {
+        props: ['modelValue'],
+        emits: ['update:modelValue'],
+        template: '<div><button data-testid="switch-standard" @click="$emit(\'update:modelValue\', \'standard\')">standard</button><button data-testid="switch-live" @click="$emit(\'update:modelValue\', \'live\')">live</button><span data-testid="mode">{{ modelValue }}</span></div>',
       },
+      StandardVoicePanel: { template: '<div data-testid="standard-panel">standard panel</div>' },
+      RealtimeVoicePanel: { template: '<div data-testid="live-panel">live panel</div>' },
     }
 
     const wrapper = mount(VoiceView, {
@@ -150,16 +96,7 @@ describe('VoiceView.vue', () => {
 
     return {
       wrapper,
-      resolveAvail,
-      stubConnect,
-      stubDisconnect,
-      refs: {
-        connectionState,
-        errorMessage,
-        sessionNotice,
-        assistantTranscript,
-        userTranscript,
-      },
+      router,
     }
   }
 
@@ -169,253 +106,30 @@ describe('VoiceView.vue', () => {
     vi.clearAllMocks()
   })
 
-  it('shows a spinner overlay while realtime availability resolves', async () => {
+  it('defaults to standard mode and renders standard panel', async () => {
     const { wrapper } = await factory({
       lang: 'en',
-      fetchResult: 'pending',
+      standardEnabled: true,
+      liveEnabled: true,
     })
 
-    expect(fetchRealtimeVoiceEnabledMock).toHaveBeenCalledTimes(1)
     await flushPromises()
-    await wrapper.vm.$nextTick()
-
-    await flushPromises()
+    expect(fetchRealtimeVoiceStatusMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('[data-testid="standard-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="live-panel"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
-  it('shows the unavailable banner when realtime is disabled on the backend', async () => {
+  it('uses live mode when route query asks for it', async () => {
     const { wrapper } = await factory({
       lang: 'en',
-      fetchResult: false,
+      route: '/voice?mode=live',
+      standardEnabled: true,
+      liveEnabled: true,
     })
-
     await flushPromises()
-
-    expect(document.body.textContent).toContain('Voice chat is not enabled on the server right now.')
-
-    wrapper.unmount()
-  })
-
-  it('shows localized unavailable copy when the UI language is Norwegian', async () => {
-    const { wrapper } = await factory({
-      lang: 'no',
-      fetchResult: false,
-    })
-
-    await flushPromises()
-
-    expect(document.body.textContent).toContain('Stemmechat er ikke slått på hos serveren akkurat nå.')
-
-    wrapper.unmount()
-  })
-
-  it('shows the Norwegian hero title when realtime is enabled and language is Norwegian', async () => {
-    const { wrapper } = await factory({
-      lang: 'no',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    expect(document.body.textContent).toContain('Snakk med Kevin sin AI')
-
-    wrapper.unmount()
-  })
-
-  it('renders voice controls with backend defaults and localized labels', async () => {
-    const { wrapper } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    const voiceSelect = wrapper.get('[data-testid="voice-select"]').element as HTMLSelectElement
-    const reasoningSelect = wrapper.get('[data-testid="reasoning-select"]').element as HTMLSelectElement
-
-    expect(document.body.textContent).toContain('Voice')
-    expect(document.body.textContent).toContain('Reasoning')
-    expect(document.body.textContent).toContain('Marin')
-    expect(document.body.textContent).toContain('Cedar')
-    expect(document.body.textContent).toContain('Fast')
-    expect(document.body.textContent).toContain('Balanced')
-    expect(document.body.textContent).toContain('Thorough')
-    expect(voiceSelect.value).toBe('cedar')
-    expect(reasoningSelect.value).toBe('medium')
-
-    wrapper.unmount()
-  })
-
-  it('renders and persists the visitor voice model selection', async () => {
-    const { wrapper } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    const select = wrapper.get('[data-testid="voice-model-select"]').element as HTMLSelectElement
-    expect(document.body.textContent).toContain('Provider/model')
-    expect(document.body.textContent).toContain('OpenAI GPT-Realtime-2')
-    expect(document.body.textContent).toContain('ElevenLabs Agent')
-    expect(select.value).toBe('OPENAI:gpt-realtime-2')
-
-    select.value = 'ELEVENLABS:agent_1'
-    await wrapper.get('[data-testid="voice-model-select"]').trigger('change')
-
-    expect(sessionStorage.getItem('voiceSelectedModel')).toBe('ELEVENLABS:agent_1')
-
-    wrapper.unmount()
-  })
-
-  it('disables voice controls while realtime is connected', async () => {
-    const { wrapper, refs } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    refs.connectionState.value = 'connected'
-    await wrapper.vm.$nextTick()
-
-    expect((wrapper.get('[data-testid="voice-select"]').element as HTMLSelectElement).disabled).toBe(true)
-    expect((wrapper.get('[data-testid="reasoning-select"]').element as HTMLSelectElement).disabled).toBe(true)
-
-    wrapper.unmount()
-  })
-
-  it('shows the Norwegian reasoning label when language is Norwegian', async () => {
-    const { wrapper } = await factory({
-      lang: 'no',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    expect(document.body.textContent).toContain('Resonnering')
-
-    wrapper.unmount()
-  })
-
-  it('surfaces realtime errors through the AI status dialog', async () => {
-    const { wrapper, refs } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    refs.errorMessage.value = 'Microphone unavailable'
-    await wrapper.vm.$nextTick()
-
-    expect(document.body.querySelector('[role="dialog"]')).toBeTruthy()
-    expect(document.body.textContent).toContain('Voice could not start')
-    expect(document.body.textContent).toContain('Microphone unavailable')
-
-    wrapper.unmount()
-  })
-
-  it('shows a session notice banner when realtime composables publish one', async () => {
-    const { wrapper, refs } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    refs.sessionNotice.value = 'Time limit placeholder'
-    await wrapper.vm.$nextTick()
-
-    expect(document.body.textContent).toContain('Time limit placeholder')
-
-    wrapper.unmount()
-  })
-
-  it('renders bilingual transcript labels alongside stored transcript text', async () => {
-    const { wrapper, refs } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    refs.connectionState.value = 'connected'
-    refs.userTranscript.value = 'speaker text'
-    refs.assistantTranscript.value = 'model text'
-    await wrapper.vm.$nextTick()
-
-    const bodyText = document.body.textContent ?? ''
-    expect(bodyText).toContain('You (transcript)')
-    expect(bodyText).toContain('speaker text')
-    expect(bodyText).toContain('Assistant (transcript)')
-    expect(bodyText).toContain('model text')
-
-    wrapper.unmount()
-  })
-
-  it('uses Norwegian transcript labels while language is Norwegian', async () => {
-    const { wrapper, refs } = await factory({
-      lang: 'no',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    refs.connectionState.value = 'connected'
-    refs.userTranscript.value = 'bruker'
-    refs.assistantTranscript.value = 'assistent'
-
-    await wrapper.vm.$nextTick()
-
-    expect(document.body.textContent).toContain('Du (transkripsjon)')
-    expect(document.body.textContent).toContain('Assistent (transkripsjon)')
-
-    wrapper.unmount()
-  })
-
-  it('wires the connect control to mocked composables', async () => {
-    const { wrapper, stubConnect } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    const idleConnect = [...document.body.querySelectorAll('button')]
-      .map((btn) => btn.textContent?.trim())
-      .find((txt) => txt?.includes('Start voice'))
-
-    expect(idleConnect).toBeTruthy()
-
-    const button = [...document.body.querySelectorAll('button')]
-      .find((el) => el.textContent?.includes('Start voice'))
-    ;(button as HTMLButtonElement).click()
-
-    expect(stubConnect).toHaveBeenCalled()
-
-    wrapper.unmount()
-  })
-
-  it('shows disconnected UI when realtime session is actively connected', async () => {
-    const { wrapper, refs, stubDisconnect } = await factory({
-      lang: 'en',
-      fetchResult: true,
-    })
-
-    await flushPromises()
-
-    refs.connectionState.value = 'connected'
-    await wrapper.vm.$nextTick()
-
-    const button = [...document.body.querySelectorAll('button')]
-      .find((el) => el.textContent?.includes('End session'))
-
-    expect(button).toBeTruthy()
-
-    ;(button as HTMLButtonElement).click()
-    expect(stubDisconnect).toHaveBeenCalled()
-
+    expect(wrapper.find('[data-testid="live-panel"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="standard-panel"]').exists()).toBe(false)
     wrapper.unmount()
   })
 })

--- a/frontend/homepage/src/views/__tests__/VoiceView.spec.ts
+++ b/frontend/homepage/src/views/__tests__/VoiceView.spec.ts
@@ -19,6 +19,10 @@ vi.mock('@/lib/realtime-voice', async (importOriginal) => {
   }
 })
 
+vi.mock('@/lib/analytics', () => ({
+  captureProductAnalyticsEvent: vi.fn(),
+}))
+
 describe('VoiceView.vue', () => {
   async function factory(opts: {
     lang: 'en' | 'no'
@@ -130,6 +134,47 @@ describe('VoiceView.vue', () => {
     await flushPromises()
     expect(wrapper.find('[data-testid="live-panel"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="standard-panel"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders Norwegian copy', async () => {
+    const { wrapper } = await factory({
+      lang: 'no',
+      standardEnabled: true,
+      liveEnabled: false,
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Snakk med Kevin sin AI')
+    expect(wrapper.text()).toContain('Bruk tekstchat')
+    wrapper.unmount()
+  })
+
+  it('updates route query when switching to live mode', async () => {
+    const { wrapper, router } = await factory({
+      lang: 'en',
+      standardEnabled: true,
+      liveEnabled: true,
+    })
+    await flushPromises()
+    await wrapper.find('[data-testid="switch-live"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.query.mode).toBe('live')
+    expect(wrapper.find('[data-testid="live-panel"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('clears route query when switching back to standard mode', async () => {
+    const { wrapper, router } = await factory({
+      lang: 'en',
+      route: '/voice?mode=live',
+      standardEnabled: true,
+      liveEnabled: true,
+    })
+    await flushPromises()
+    await wrapper.find('[data-testid="switch-standard"]').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.query.mode).toBeUndefined()
+    expect(wrapper.find('[data-testid="standard-panel"]').exists()).toBe(true)
     wrapper.unmount()
   })
 })

--- a/frontend/homepage/vite.config.ts
+++ b/frontend/homepage/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8080',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },


### PR DESCRIPTION
## Summary
- Adds backend `POST /synthesize` for OpenAI TTS (`tts-1`) with budget tracking and rate limiting alongside existing transcription.
- Extends `/realtime/status` to report `standardEnabled` and `liveEnabled` separately so turn-based voice works without live WebRTC providers.
- Introduces frontend standard voice flow (transcribe → lookup → synthesize) with mode switcher, dedicated panels, and updated home/voice entry points.

## Commits
- `feat(backend): add OpenAI speech synthesis endpoint`
- `feat(backend): split standard and live voice availability in status`
- `feat(frontend): add standard voice mode with mode switcher`
- `test(e2e): add Cypress coverage for standard voice flow`
- `test(frontend): cover standard voice flow and fix panel typing`

## Test plan
- [x] Backend unit tests: `SpeechSynthesisControllerTest`, `SpeechSynthesisServiceTest`, `RealtimeControllerTest`
- [x] Frontend: `npm run type-check`, `npm run lint:ci`, `npm run test:unit:coverage`
- [ ] CI: GitGuardian scan, Tests (backend, frontend, frontend-e2e)