### PR TITLE
feat(admin): voice interview with transcript clean and RAG ingest

### DIFF
--- a/backend/src/main/java/com/kevinmazali/portfolio/config/WebConfig.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/WebConfig.java
@@ -63,6 +63,8 @@ public class WebConfig {
     private final Map<String, Bucket> datasetGenerateBuckets = new ConcurrentHashMap<>();
     private final Map<String, Bucket> realtimeSessionBuckets = new ConcurrentHashMap<>();
     private final Map<String, Bucket> realtimeLookupBuckets = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> interviewRealtimeBuckets = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> interviewTurnBuckets = new ConcurrentHashMap<>();
 
     private Bucket newAskBucketAuthenticated() {
         AskRateLimitProperties p = askRateLimitProperties;
@@ -375,6 +377,92 @@ public class WebConfig {
         registration.addUrlPatterns("/realtime/lookup");
         registration.setName("realtimeLookupRateLimitFilter");
         registration.setOrder(6);
+        return registration;
+    }
+
+    private Bucket newInterviewRealtimeBucket() {
+        Bandwidth limit = Bandwidth.builder()
+            .capacity(5)
+            .refillGreedy(5, Duration.ofHours(1))
+            .build();
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private String interviewRealtimeKey(HttpServletRequest req) {
+        String user = req.getUserPrincipal() != null ? req.getUserPrincipal().getName() : "unknown";
+        return "interview-rt:" + user;
+    }
+
+    private Bucket newInterviewTurnBucket() {
+        Bandwidth limit = Bandwidth.builder()
+            .capacity(30)
+            .refillGreedy(30, Duration.ofMinutes(1))
+            .build();
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private String interviewTurnKey(HttpServletRequest req) {
+        String user = req.getUserPrincipal() != null ? req.getUserPrincipal().getName() : "unknown";
+        return "interview-turn:" + user;
+    }
+
+    @Bean
+    public org.springframework.boot.web.servlet.FilterRegistrationBean<Filter> interviewRealtimeRateLimitFilter() {
+        var registration = new org.springframework.boot.web.servlet.FilterRegistrationBean<Filter>();
+        registration.setFilter(new OncePerRequestFilter() {
+            @Override
+            protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+                throws ServletException, IOException {
+                String uri = request.getRequestURI();
+                if (!"POST".equalsIgnoreCase(request.getMethod())
+                    || uri == null
+                    || !uri.contains("/admin/tools/interview/sessions/")
+                    || !uri.endsWith("/realtime/session")) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+                Bucket bucket = interviewRealtimeBuckets.computeIfAbsent(interviewRealtimeKey(request), k -> newInterviewRealtimeBucket());
+                ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+                if (probe.isConsumed()) {
+                    filterChain.doFilter(request, response);
+                } else {
+                    write429(response, probe, "Too many interview voice sessions. Please wait before trying again.");
+                }
+            }
+        });
+        registration.addUrlPatterns("/admin/tools/interview/sessions/*");
+        registration.setName("interviewRealtimeRateLimitFilter");
+        registration.setOrder(7);
+        return registration;
+    }
+
+    @Bean
+    public org.springframework.boot.web.servlet.FilterRegistrationBean<Filter> interviewTurnRateLimitFilter() {
+        var registration = new org.springframework.boot.web.servlet.FilterRegistrationBean<Filter>();
+        registration.setFilter(new OncePerRequestFilter() {
+            @Override
+            protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+                throws ServletException, IOException {
+                String uri = request.getRequestURI();
+                if (!"POST".equalsIgnoreCase(request.getMethod())
+                    || uri == null
+                    || !uri.contains("/admin/tools/interview/sessions/")
+                    || !uri.endsWith("/turns")) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+                Bucket bucket = interviewTurnBuckets.computeIfAbsent(interviewTurnKey(request), k -> newInterviewTurnBucket());
+                ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+                if (probe.isConsumed()) {
+                    filterChain.doFilter(request, response);
+                } else {
+                    write429(response, probe, "Too many transcript saves. Please wait before trying again.");
+                }
+            }
+        });
+        registration.addUrlPatterns("/admin/tools/interview/sessions/*");
+        registration.setName("interviewTurnRateLimitFilter");
+        registration.setOrder(8);
         return registration;
     }
 }

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/InterviewController.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/InterviewController.java
@@ -1,0 +1,162 @@
+package com.kevinmazali.portfolio.controller;
+
+import com.kevinmazali.portfolio.config.OpenApiConfig;
+import com.kevinmazali.portfolio.exception.RealtimeSessionException;
+import com.kevinmazali.portfolio.model.ApiError;
+import com.kevinmazali.portfolio.model.IngestionResult;
+import com.kevinmazali.portfolio.model.interview.CreateInterviewSessionRequest;
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewTextDocumentRequest;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnBatchRequest;
+import com.kevinmazali.portfolio.service.InterviewDocumentService;
+import com.kevinmazali.portfolio.service.InterviewRealtimeSessionService;
+import com.kevinmazali.portfolio.service.InterviewSessionService;
+import com.kevinmazali.portfolio.service.RequestLogService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin/tools/interview")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+@Tag(name = "Admin interview", description = "Voice interview practice with document context (ADMIN)")
+@SecurityRequirement(name = OpenApiConfig.BASIC_AUTH_SCHEME)
+public class InterviewController {
+
+  private final InterviewDocumentService interviewDocumentService;
+  private final InterviewSessionService interviewSessionService;
+  private final InterviewRealtimeSessionService interviewRealtimeSessionService;
+  private final RequestLogService requestLogService;
+
+  @Operation(summary = "Upload interview source document")
+  @PostMapping(value = "/documents", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<InterviewDocumentResponse> uploadDocument(
+      @RequestParam("file") MultipartFile file, Principal principal) throws IOException {
+    String createdBy = principal != null ? principal.getName() : null;
+    return ResponseEntity.ok(interviewDocumentService.storeMultipart(file, createdBy));
+  }
+
+  @Operation(summary = "Create interview source document from pasted text")
+  @PostMapping(value = "/documents/text", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<InterviewDocumentResponse> createTextDocument(
+      @RequestBody InterviewTextDocumentRequest request, Principal principal) {
+    String createdBy = principal != null ? principal.getName() : null;
+    return ResponseEntity.ok(
+        interviewDocumentService.storeText(request.text(), request.filename(), createdBy));
+  }
+
+  @Operation(summary = "Get interview source document metadata")
+  @GetMapping("/documents/{id}")
+  public ResponseEntity<InterviewDocumentResponse> getDocument(@PathVariable String id) {
+    return ResponseEntity.ok(interviewDocumentService.getDocument(id));
+  }
+
+  @Operation(summary = "Create interview session")
+  @PostMapping("/sessions")
+  public ResponseEntity<InterviewSessionResponse> createSession(
+      @RequestBody CreateInterviewSessionRequest request) {
+    return ResponseEntity.ok(interviewSessionService.createSession(request));
+  }
+
+  @Operation(summary = "List interview sessions")
+  @GetMapping("/sessions")
+  public ResponseEntity<List<InterviewSessionResponse>> listSessions() {
+    return ResponseEntity.ok(interviewSessionService.listSessions());
+  }
+
+  @Operation(summary = "Get interview session with turns")
+  @GetMapping("/sessions/{id}")
+  public ResponseEntity<InterviewSessionResponse> getSession(@PathVariable String id) {
+    return ResponseEntity.ok(interviewSessionService.getSession(id));
+  }
+
+  @Operation(summary = "Append transcript turns")
+  @PostMapping("/sessions/{id}/turns")
+  public ResponseEntity<Void> appendTurns(
+      @PathVariable String id, @RequestBody InterviewTurnBatchRequest request) {
+    interviewSessionService.appendTurns(id, request);
+    return ResponseEntity.ok().build();
+  }
+
+  @Operation(summary = "Finalize interview session and save raw transcript")
+  @PostMapping("/sessions/{id}/finalize")
+  public ResponseEntity<InterviewTranscriptResponse> finalizeSession(@PathVariable String id) {
+    return ResponseEntity.ok(interviewSessionService.finalizeSession(id));
+  }
+
+  @Operation(summary = "Create admin interview Realtime WebRTC session")
+  @PostMapping(value = "/sessions/{id}/realtime/session", consumes = {"application/sdp", "text/plain"})
+  public ResponseEntity<?> createRealtimeSession(
+      @PathVariable String id,
+      @RequestBody String sdp,
+      @RequestHeader(value = "X-Chat-Language", required = false) String chatLanguage,
+      @RequestHeader(value = "X-Realtime-Model", required = false) String model,
+      @RequestHeader(value = "X-Realtime-Voice", required = false) String voice,
+      @RequestHeader(value = "X-Realtime-Reasoning-Effort", required = false) String reasoningEffort) {
+    requestLogService.save("/admin/tools/interview/sessions/" + id + "/realtime/session", "POST", "sdp-bytes", null);
+    try {
+      String answer =
+          interviewRealtimeSessionService.createInterviewCall(
+              id, sdp, chatLanguage, model, voice, reasoningEffort);
+      return ResponseEntity.ok().contentType(MediaType.parseMediaType("application/sdp")).body(answer);
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().body(new ApiError(e.getMessage(), "BAD_REQUEST"));
+    } catch (RealtimeSessionException e) {
+      log.warn(
+          "interview realtime session: code={} status={} message={}",
+          e.getErrorCode(),
+          e.getHttpStatus().value(),
+          e.getMessage());
+      return ResponseEntity.status(e.getHttpStatus())
+          .body(new ApiError(e.getMessage(), e.getErrorCode().name()));
+    }
+  }
+
+  @Operation(summary = "Get transcript")
+  @GetMapping("/transcripts/{id}")
+  public ResponseEntity<InterviewTranscriptResponse> getTranscript(@PathVariable String id) {
+    return ResponseEntity.ok(interviewSessionService.getTranscript(id));
+  }
+
+  @Operation(summary = "Clean transcript for knowledge-base ingest")
+  @PostMapping("/transcripts/{id}/clean")
+  public ResponseEntity<InterviewTranscriptResponse> cleanTranscript(@PathVariable String id) {
+    return ResponseEntity.ok(interviewSessionService.cleanTranscript(id));
+  }
+
+  @Operation(summary = "Ingest cleaned transcript into vector store")
+  @PostMapping("/transcripts/{id}/ingest")
+  public ResponseEntity<IngestionResult> ingestTranscript(
+      @PathVariable String id, @RequestParam(value = "force", defaultValue = "false") boolean force) {
+    return ResponseEntity.ok(interviewSessionService.ingestTranscript(id, force));
+  }
+
+  @Operation(summary = "Soft-delete interview session")
+  @DeleteMapping("/sessions/{id}")
+  public ResponseEntity<Void> deleteSession(@PathVariable String id) {
+    interviewSessionService.deleteSession(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/CreateInterviewSessionRequest.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/CreateInterviewSessionRequest.java
@@ -1,0 +1,3 @@
+package com.kevinmazali.portfolio.model.interview;
+
+public record CreateInterviewSessionRequest(String documentId, String language, String voice) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewDocumentEntity.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewDocumentEntity.java
@@ -1,0 +1,44 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "interview_documents")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewDocumentEntity {
+
+  @Id
+  @Column(length = 64)
+  private String id;
+
+  @Column(name = "original_filename", nullable = false, length = 512)
+  private String originalFilename;
+
+  @Column(name = "mime_type", length = 128)
+  private String mimeType;
+
+  @Column(name = "parsed_text", nullable = false, columnDefinition = "TEXT")
+  private String parsedText;
+
+  @Column(name = "char_count", nullable = false)
+  private int charCount;
+
+  @Column(name = "created_by", length = 128)
+  private String createdBy;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewDocumentResponse.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewDocumentResponse.java
@@ -1,0 +1,11 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import java.time.Instant;
+
+public record InterviewDocumentResponse(
+    String id,
+    String originalFilename,
+    String mimeType,
+    int charCount,
+    String createdBy,
+    Instant createdAt) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewSessionEntity.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewSessionEntity.java
@@ -1,0 +1,47 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "interview_sessions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewSessionEntity {
+
+  @Id
+  @Column(length = 64)
+  private String id;
+
+  @Column(name = "document_id", nullable = false, length = 64)
+  private String documentId;
+
+  @Column(nullable = false, length = 8)
+  private String language;
+
+  @Column(nullable = false, length = 32)
+  private String status;
+
+  @Column(length = 32)
+  private String voice;
+
+  @Column(name = "started_at", nullable = false)
+  private Instant startedAt;
+
+  @Column(name = "ended_at")
+  private Instant endedAt;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewSessionResponse.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewSessionResponse.java
@@ -1,0 +1,17 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import java.time.Instant;
+import java.util.List;
+
+public record InterviewSessionResponse(
+    String id,
+    String documentId,
+    String language,
+    String status,
+    String voice,
+    Instant startedAt,
+    Instant endedAt,
+    String transcriptId,
+    String cleanStatus,
+    String ingestedDocumentId,
+    List<InterviewTurnDto> turns) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTextDocumentRequest.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTextDocumentRequest.java
@@ -1,0 +1,3 @@
+package com.kevinmazali.portfolio.model.interview;
+
+public record InterviewTextDocumentRequest(String text, String filename) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTranscriptEntity.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTranscriptEntity.java
@@ -1,0 +1,47 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "interview_transcripts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewTranscriptEntity {
+
+  @Id
+  @Column(length = 64)
+  private String id;
+
+  @Column(name = "session_id", nullable = false, length = 64)
+  private String sessionId;
+
+  @Column(name = "raw_text", columnDefinition = "TEXT")
+  private String rawText;
+
+  @Column(name = "cleaned_text", columnDefinition = "TEXT")
+  private String cleanedText;
+
+  @Column(name = "clean_status", nullable = false, length = 32)
+  private String cleanStatus;
+
+  @Column(name = "ingested_document_id", length = 64)
+  private String ingestedDocumentId;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "cleaned_at")
+  private Instant cleanedAt;
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTranscriptResponse.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTranscriptResponse.java
@@ -1,0 +1,13 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import java.time.Instant;
+
+public record InterviewTranscriptResponse(
+    String id,
+    String sessionId,
+    String rawText,
+    String cleanedText,
+    String cleanStatus,
+    String ingestedDocumentId,
+    Instant createdAt,
+    Instant cleanedAt) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTranscriptTurnEntity.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTranscriptTurnEntity.java
@@ -1,0 +1,43 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "interview_transcript_turns")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewTranscriptTurnEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false, length = 64)
+  private String sessionId;
+
+  @Column(nullable = false, length = 32)
+  private String role;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String text;
+
+  @Column(name = "sequence_no", nullable = false)
+  private int sequenceNo;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTurnBatchRequest.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTurnBatchRequest.java
@@ -1,0 +1,5 @@
+package com.kevinmazali.portfolio.model.interview;
+
+import java.util.List;
+
+public record InterviewTurnBatchRequest(List<InterviewTurnDto> turns) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTurnDto.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/model/interview/InterviewTurnDto.java
@@ -1,0 +1,3 @@
+package com.kevinmazali.portfolio.model.interview;
+
+public record InterviewTurnDto(String role, String text, int sequenceNo) {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewDocumentRepository.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewDocumentRepository.java
@@ -1,0 +1,6 @@
+package com.kevinmazali.portfolio.repository;
+
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewDocumentRepository extends JpaRepository<InterviewDocumentEntity, String> {}

--- a/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewSessionRepository.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewSessionRepository.java
@@ -1,0 +1,10 @@
+package com.kevinmazali.portfolio.repository;
+
+import com.kevinmazali.portfolio.model.interview.InterviewSessionEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewSessionRepository extends JpaRepository<InterviewSessionEntity, String> {
+
+  List<InterviewSessionEntity> findByDeletedAtIsNullOrderByStartedAtDesc();
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewTranscriptRepository.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewTranscriptRepository.java
@@ -1,0 +1,10 @@
+package com.kevinmazali.portfolio.repository;
+
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewTranscriptRepository extends JpaRepository<InterviewTranscriptEntity, String> {
+
+  Optional<InterviewTranscriptEntity> findBySessionId(String sessionId);
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewTranscriptTurnRepository.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/repository/InterviewTranscriptTurnRepository.java
@@ -1,0 +1,12 @@
+package com.kevinmazali.portfolio.repository;
+
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptTurnEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewTranscriptTurnRepository extends JpaRepository<InterviewTranscriptTurnEntity, Long> {
+
+  List<InterviewTranscriptTurnEntity> findBySessionIdOrderBySequenceNoAsc(String sessionId);
+
+  void deleteBySessionId(String sessionId);
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/DocumentIngestionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/DocumentIngestionService.java
@@ -317,6 +317,30 @@ public class DocumentIngestionService implements ApplicationRunner {
     return filename.substring(i + 1).toLowerCase(Locale.ROOT);
   }
 
+  /**
+   * Ingest plain text/markdown content (e.g. cleaned interview transcripts) into pgvector.
+   */
+  public IngestionResult ingestTextContent(String text, String displayFilename, boolean force) throws IOException {
+    if (text == null || text.isBlank()) {
+      return new IngestionResult("", displayFilename, 0, false, "Empty text");
+    }
+    byte[] bytes = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    if (bytes.length > documentIngestProperties.getMaxParseBytes()) {
+      throw new IOException("Text exceeds maximum parse size of " + documentIngestProperties.getMaxParseBytes() + " bytes");
+    }
+    String contentHash = sha256Hex(bytes);
+    String logicalName =
+        (displayFilename != null && !displayFilename.isBlank()) ? displayFilename.trim() : "text-upload.md";
+    ByteArrayResource resource =
+        new ByteArrayResource(bytes) {
+          @Override
+          public String getFilename() {
+            return logicalName;
+          }
+        };
+    return ingestFromResource(resource, contentHash, logicalName, force);
+  }
+
   public IngestionResult ingestMultipart(MultipartFile file, String titleOverride, boolean force) throws IOException {
     if (file == null || file.isEmpty()) {
       return new IngestionResult("", "", 0, false, "Empty file");

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewDocumentService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewDocumentService.java
@@ -1,0 +1,160 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.DocumentIngestProperties;
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentResponse;
+import com.kevinmazali.portfolio.repository.InterviewDocumentRepository;
+import com.kevinmazali.portfolio.util.InputValidator;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.reader.tika.TikaDocumentReader;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterviewDocumentService {
+
+  static final Set<String> ALLOWED_EXT =
+      Set.of("pdf", "docx", "doc", "txt", "md", "png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "svg");
+
+  static final int MAX_CONTEXT_CHARS = 14_000;
+
+  private final InterviewDocumentRepository documentRepository;
+  private final DocumentIngestProperties documentIngestProperties;
+
+  public InterviewDocumentResponse storeMultipart(MultipartFile file, String createdBy) throws IOException {
+    if (file == null || file.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Empty file");
+    }
+    String originalName = Optional.ofNullable(file.getOriginalFilename()).orElse("upload.bin");
+    String ext = extensionFromFilename(originalName);
+    if (!ALLOWED_EXT.contains(ext)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported file type: " + ext);
+    }
+    byte[] bytes = file.getBytes();
+    if (bytes.length > documentIngestProperties.getMaxParseBytes()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "File exceeds maximum parse size of " + documentIngestProperties.getMaxParseBytes() + " bytes");
+    }
+    ByteArrayResource resource =
+        new ByteArrayResource(bytes) {
+          @Override
+          public String getFilename() {
+            return originalName;
+          }
+        };
+    String parsed = parseResource(resource);
+    return saveDocument(originalName, file.getContentType(), parsed, createdBy);
+  }
+
+  public InterviewDocumentResponse storeText(String text, String filename, String createdBy) {
+    if (!StringUtils.hasText(text)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Text is required");
+    }
+    String safeName =
+        StringUtils.hasText(filename) ? InputValidator.sanitizeString(filename.trim()) : "pasted-text.md";
+    if (safeName.length() > 512) {
+      safeName = safeName.substring(0, 512);
+    }
+    return saveDocument(safeName, "text/plain", text.trim(), createdBy);
+  }
+
+  public InterviewDocumentResponse getDocument(String id) {
+    InterviewDocumentEntity entity =
+        documentRepository
+            .findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Document not found"));
+    return toResponse(entity);
+  }
+
+  public String contextForSession(String documentId) {
+    InterviewDocumentEntity entity =
+        documentRepository
+            .findById(documentId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Document not found"));
+    return truncateContext(entity.getParsedText());
+  }
+
+  static String truncateContext(String text) {
+    if (text == null) {
+      return "";
+    }
+    if (text.length() <= MAX_CONTEXT_CHARS) {
+      return text;
+    }
+    return text.substring(0, MAX_CONTEXT_CHARS) + "\n\n[truncated]";
+  }
+
+  private InterviewDocumentResponse saveDocument(
+      String originalFilename, String mimeType, String parsedText, String createdBy) {
+    if (!StringUtils.hasText(parsedText)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No text extracted from input");
+    }
+    String id = UUID.randomUUID().toString().replace("-", "");
+    InterviewDocumentEntity entity =
+        InterviewDocumentEntity.builder()
+            .id(id)
+            .originalFilename(originalFilename)
+            .mimeType(mimeType)
+            .parsedText(parsedText)
+            .charCount(parsedText.length())
+            .createdBy(createdBy)
+            .createdAt(Instant.now())
+            .build();
+    documentRepository.save(entity);
+    log.info("Stored interview document id={} filename={} chars={}", id, originalFilename, parsedText.length());
+    return toResponse(entity);
+  }
+
+  private String parseResource(Resource resource) throws IOException {
+    TikaDocumentReader reader = new TikaDocumentReader(resource);
+    List<Document> docs = reader.get();
+    if (docs == null || docs.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Document doc : docs) {
+      if (doc.getText() != null && !doc.getText().isBlank()) {
+        if (sb.length() > 0) {
+          sb.append("\n\n");
+        }
+        sb.append(doc.getText().trim());
+      }
+    }
+    return sb.toString();
+  }
+
+  private static String extensionFromFilename(String filename) {
+    int i = filename.lastIndexOf('.');
+    if (i < 0 || i == filename.length() - 1) {
+      return "";
+    }
+    return filename.substring(i + 1).toLowerCase(Locale.ROOT);
+  }
+
+  private static InterviewDocumentResponse toResponse(InterviewDocumentEntity entity) {
+    return new InterviewDocumentResponse(
+        entity.getId(),
+        entity.getOriginalFilename(),
+        entity.getMimeType(),
+        entity.getCharCount(),
+        entity.getCreatedBy(),
+        entity.getCreatedAt());
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionService.java
@@ -1,0 +1,275 @@
+package com.kevinmazali.portfolio.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.config.RealtimeProperties;
+import com.kevinmazali.portfolio.exception.RealtimeErrorCode;
+import com.kevinmazali.portfolio.exception.RealtimeSessionException;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionEntity;
+import com.kevinmazali.portfolio.repository.InterviewSessionRepository;
+import com.kevinmazali.portfolio.util.AiRequestContext;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+public class InterviewRealtimeSessionService {
+
+  private static final String OPENAI_REALTIME_CALLS = "https://api.openai.com/v1/realtime/calls";
+
+  private final RealtimeProperties realtimeProperties;
+  private final AiBudgetService aiBudgetService;
+  private final AiBudgetProperties budgetProperties;
+  private final AiCircuitBreaker aiCircuitBreaker;
+  private final OpenAiRealtimeHttpInvoker openAiRealtimeHttpInvoker;
+  private final RealtimeModelCatalog realtimeModelCatalog;
+  private final InterviewDocumentService interviewDocumentService;
+  private final InterviewSessionRepository sessionRepository;
+  private final String openAiApiKey;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private volatile String instructionsEn;
+  private volatile String instructionsNo;
+
+  public InterviewRealtimeSessionService(
+      RealtimeProperties realtimeProperties,
+      AiBudgetService aiBudgetService,
+      AiBudgetProperties budgetProperties,
+      AiCircuitBreaker aiCircuitBreaker,
+      OpenAiRealtimeHttpInvoker openAiRealtimeHttpInvoker,
+      RealtimeModelCatalog realtimeModelCatalog,
+      InterviewDocumentService interviewDocumentService,
+      InterviewSessionRepository sessionRepository,
+      @Value("${spring.ai.openai.api-key:}") String openAiApiKey) {
+    this.realtimeProperties = realtimeProperties;
+    this.aiBudgetService = aiBudgetService;
+    this.budgetProperties = budgetProperties;
+    this.aiCircuitBreaker = aiCircuitBreaker;
+    this.openAiRealtimeHttpInvoker = openAiRealtimeHttpInvoker;
+    this.realtimeModelCatalog = realtimeModelCatalog;
+    this.interviewDocumentService = interviewDocumentService;
+    this.sessionRepository = sessionRepository;
+    this.openAiApiKey = openAiApiKey;
+  }
+
+  @PostConstruct
+  void preloadInstructionPrompts() {
+    instructionsEn = loadPromptFile("prompts/interview-voice-en.txt");
+    instructionsNo = loadPromptFile("prompts/interview-voice-no.txt");
+  }
+
+  public String createInterviewCall(
+      String sessionId,
+      String sdp,
+      String chatLanguage,
+      String requestedModel,
+      String requestedVoice,
+      String requestedReasoningEffort) {
+    if (!realtimeProperties.isEnabled()) {
+      throw new RealtimeSessionException(
+          HttpStatus.SERVICE_UNAVAILABLE, RealtimeErrorCode.REALTIME_DISABLED, "Voice chat is disabled.");
+    }
+    if (!StringUtils.hasText(openAiApiKey)) {
+      throw new RealtimeSessionException(
+          HttpStatus.SERVICE_UNAVAILABLE, RealtimeErrorCode.API_KEY_MISSING, "OpenAI API key is not configured.");
+    }
+    if (!StringUtils.hasText(sdp)) {
+      throw new IllegalArgumentException("SDP body is required.");
+    }
+
+    InterviewSessionEntity session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new IllegalArgumentException("Interview session not found"));
+    if (session.getDeletedAt() != null || !InterviewSessionService.STATUS_ACTIVE.equals(session.getStatus())) {
+      throw new IllegalArgumentException("Interview session is not active");
+    }
+
+    String model = realtimeModelCatalog.resolveOpenAiModelId(requestedModel);
+    if (!realtimeModelCatalog.isOpenAiModelConfigured(model)) {
+      throw new RealtimeSessionException(
+          HttpStatus.BAD_REQUEST,
+          RealtimeErrorCode.VOICE_MODEL_NOT_CONFIGURED,
+          "OpenAI voice model is not configured.");
+    }
+
+    String budgetUserId = AiRequestContext.budgetUserIdentifier(budgetProperties);
+    boolean anonymous = false;
+    aiCircuitBreaker.assertClosed();
+    aiBudgetService.assertWithinBudget(budgetUserId, anonymous);
+
+    String lang = normalizeLang(chatLanguage != null ? chatLanguage : session.getLanguage());
+    String documentContext = interviewDocumentService.contextForSession(session.getDocumentId());
+    String instructions = instructionsForLanguage(lang).replace("{document_context}", documentContext);
+    String voice = realtimeProperties.resolveVoice(
+        StringUtils.hasText(requestedVoice) ? requestedVoice : session.getVoice());
+    String reasoningEffort = realtimeProperties.resolveReasoningEffort(requestedReasoningEffort);
+
+    String sessionJson;
+    try {
+      sessionJson = buildSessionJson(instructions, model, voice, reasoningEffort);
+    } catch (IOException e) {
+      throw new RealtimeSessionException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          RealtimeErrorCode.SESSION_CONFIG_FAILED,
+          "Could not build Realtime session config.",
+          e);
+    }
+
+    String boundary = "----PortfolioBoundary" + UUID.randomUUID();
+    byte[] body = buildMultipartBody(boundary, sdp, sessionJson);
+    String safetyId = AiRequestContext.openAiSafetyIdentifier(budgetUserId);
+
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(OPENAI_REALTIME_CALLS))
+            .timeout(Duration.ofSeconds(60))
+            .header("Authorization", "Bearer " + openAiApiKey)
+            .header("OpenAI-Safety-Identifier", safetyId)
+            .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+            .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+            .build();
+
+    try {
+      HttpResponse<String> response = openAiRealtimeHttpInvoker.invoke(request);
+      int status = response.statusCode();
+      if (status >= 200 && status < 300) {
+        aiBudgetService.recordUsage(
+            budgetUserId,
+            model,
+            realtimeProperties.getReservationInputTokens(),
+            realtimeProperties.getReservationOutputTokens(),
+            anonymous,
+            null,
+            "interview_realtime_session");
+        return response.body();
+      }
+      String responseBody = response.body();
+      RealtimeErrorCode code =
+          status >= 500 ? RealtimeErrorCode.OPENAI_SERVER_ERROR : RealtimeErrorCode.OPENAI_REJECTED;
+      String userMessage =
+          StringUtils.hasText(responseBody)
+              ? "OpenAI rejected the session: " + truncate(responseBody, 500)
+              : "OpenAI Realtime session failed (HTTP " + status + ").";
+      throw new RealtimeSessionException(HttpStatus.BAD_GATEWAY, code, userMessage);
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      throw new RealtimeSessionException(
+          HttpStatus.BAD_GATEWAY,
+          RealtimeErrorCode.OPENAI_UNREACHABLE,
+          "Could not reach OpenAI Realtime API: " + e.getMessage(),
+          e);
+    }
+  }
+
+  private String instructionsForLanguage(String lang) {
+    if ("no".equals(lang)) {
+      return instructionsNo != null ? instructionsNo : loadPromptFile("prompts/interview-voice-no.txt");
+    }
+    return instructionsEn != null ? instructionsEn : loadPromptFile("prompts/interview-voice-en.txt");
+  }
+
+  private String loadPromptFile(String path) {
+    try {
+      var res = new ClassPathResource(path);
+      return StreamUtils.copyToString(res.getInputStream(), StandardCharsets.UTF_8).trim();
+    } catch (IOException e) {
+      log.warn("Could not load interview prompt {}: {}", path, e.getMessage());
+      return "You are an interviewer. Use this document:\n{document_context}";
+    }
+  }
+
+  private String buildSessionJson(String instructions, String model, String voice, String reasoningEffort)
+      throws IOException {
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("type", "realtime");
+    root.put("model", model);
+    root.put("instructions", instructions);
+    root.put("max_output_tokens", realtimeProperties.getMaxResponseOutputTokens());
+    root.putArray("output_modalities").add("audio");
+
+    ObjectNode reasoning = objectMapper.createObjectNode();
+    reasoning.put("effort", reasoningEffort);
+    root.set("reasoning", reasoning);
+
+    ObjectNode audio = objectMapper.createObjectNode();
+    ObjectNode output = objectMapper.createObjectNode();
+    output.put("voice", voice);
+    audio.set("output", output);
+
+    ObjectNode input = objectMapper.createObjectNode();
+    ObjectNode transcription = objectMapper.createObjectNode();
+    transcription.put("model", "whisper-1");
+    input.set("transcription", transcription);
+
+    ObjectNode turnDetection = objectMapper.createObjectNode();
+    turnDetection.put("type", "semantic_vad");
+    turnDetection.put("eagerness", "auto");
+    turnDetection.put("create_response", true);
+    turnDetection.put("interrupt_response", true);
+    input.set("turn_detection", turnDetection);
+
+    audio.set("input", input);
+    root.set("audio", audio);
+
+    return objectMapper.writeValueAsString(root);
+  }
+
+  private static String normalizeLang(String raw) {
+    if (!StringUtils.hasText(raw)) {
+      return "en";
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    if ("no".equals(v) || "nb".equals(v) || "nn".equals(v)) {
+      return "no";
+    }
+    return "en";
+  }
+
+  private static String normalizeSdpLineEndings(String sdp) {
+    return sdp.replace("\r\n", "\n").replace('\r', '\n').replace("\n", "\r\n");
+  }
+
+  private static byte[] buildMultipartBody(String boundary, String sdp, String sessionJson) {
+    String sdpNorm = normalizeSdpLineEndings(sdp);
+    String sep = "--" + boundary + "\r\n";
+    StringBuilder sb = new StringBuilder();
+    sb.append(sep);
+    sb.append("Content-Disposition: form-data; name=\"sdp\"\r\n");
+    sb.append("Content-Type: application/sdp\r\n\r\n");
+    sb.append(sdpNorm);
+    sb.append("\r\n");
+    sb.append(sep);
+    sb.append("Content-Disposition: form-data; name=\"session\"\r\n");
+    sb.append("Content-Type: application/json\r\n\r\n");
+    sb.append(sessionJson);
+    sb.append("\r\n");
+    sb.append("--").append(boundary).append("--\r\n");
+    return sb.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static String truncate(String s, int max) {
+    if (s == null) {
+      return "";
+    }
+    return s.length() <= max ? s : s.substring(0, max) + "...";
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewSessionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewSessionService.java
@@ -1,0 +1,273 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.RealtimeProperties;
+import com.kevinmazali.portfolio.model.IngestionResult;
+import com.kevinmazali.portfolio.model.interview.CreateInterviewSessionRequest;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptTurnEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnBatchRequest;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnDto;
+import com.kevinmazali.portfolio.repository.InterviewDocumentRepository;
+import com.kevinmazali.portfolio.repository.InterviewSessionRepository;
+import com.kevinmazali.portfolio.repository.InterviewTranscriptRepository;
+import com.kevinmazali.portfolio.repository.InterviewTranscriptTurnRepository;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterviewSessionService {
+
+  public static final String STATUS_ACTIVE = "ACTIVE";
+  public static final String STATUS_FINALIZED = "FINALIZED";
+  public static final String STATUS_DELETED = "DELETED";
+  public static final String CLEAN_PENDING = "PENDING";
+  public static final String CLEAN_CLEANED = "CLEANED";
+  public static final String CLEAN_FAILED = "FAILED";
+
+  private final InterviewSessionRepository sessionRepository;
+  private final InterviewDocumentRepository documentRepository;
+  private final InterviewTranscriptTurnRepository turnRepository;
+  private final InterviewTranscriptRepository transcriptRepository;
+  private final InterviewTranscriptCleanerService transcriptCleanerService;
+  private final DocumentIngestionService documentIngestionService;
+  private final RealtimeProperties realtimeProperties;
+
+  @Transactional
+  public InterviewSessionResponse createSession(CreateInterviewSessionRequest request) {
+    if (request == null || !StringUtils.hasText(request.documentId())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "documentId is required");
+    }
+    if (!documentRepository.existsById(request.documentId())) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Document not found");
+    }
+    String lang = normalizeLang(request.language());
+    String voice = realtimeProperties.resolveVoice(request.voice());
+    String id = UUID.randomUUID().toString().replace("-", "");
+    InterviewSessionEntity session =
+        InterviewSessionEntity.builder()
+            .id(id)
+            .documentId(request.documentId())
+            .language(lang)
+            .status(STATUS_ACTIVE)
+            .voice(voice)
+            .startedAt(Instant.now())
+            .build();
+    sessionRepository.save(session);
+    return toResponse(session, List.of(), null);
+  }
+
+  public List<InterviewSessionResponse> listSessions() {
+    return sessionRepository.findByDeletedAtIsNullOrderByStartedAtDesc().stream()
+        .map(s -> toResponse(s, List.of(), transcriptRepository.findBySessionId(s.getId()).orElse(null)))
+        .toList();
+  }
+
+  public InterviewSessionResponse getSession(String sessionId) {
+    InterviewSessionEntity session = requireActiveSession(sessionId);
+    List<InterviewTurnDto> turns = loadTurns(sessionId);
+    InterviewTranscriptEntity transcript = transcriptRepository.findBySessionId(sessionId).orElse(null);
+    return toResponse(session, turns, transcript);
+  }
+
+  @Transactional
+  public void appendTurns(String sessionId, InterviewTurnBatchRequest request) {
+    requireActiveSession(sessionId);
+    if (request == null || request.turns() == null || request.turns().isEmpty()) {
+      return;
+    }
+    List<InterviewTranscriptTurnEntity> existing = turnRepository.findBySessionIdOrderBySequenceNoAsc(sessionId);
+    int maxSeq = existing.stream().mapToInt(InterviewTranscriptTurnEntity::getSequenceNo).max().orElse(-1);
+    Instant now = Instant.now();
+    List<InterviewTranscriptTurnEntity> toSave = new ArrayList<>();
+    for (InterviewTurnDto turn : request.turns()) {
+      if (!StringUtils.hasText(turn.text()) || !StringUtils.hasText(turn.role())) {
+        continue;
+      }
+      int seq = turn.sequenceNo() >= 0 ? turn.sequenceNo() : ++maxSeq;
+      maxSeq = Math.max(maxSeq, seq);
+      toSave.add(
+          InterviewTranscriptTurnEntity.builder()
+              .sessionId(sessionId)
+              .role(normalizeRole(turn.role()))
+              .text(turn.text().trim())
+              .sequenceNo(seq)
+              .createdAt(now)
+              .build());
+    }
+    if (!toSave.isEmpty()) {
+      turnRepository.saveAll(toSave);
+    }
+  }
+
+  @Transactional
+  public InterviewTranscriptResponse finalizeSession(String sessionId) {
+    InterviewSessionEntity session = requireActiveSession(sessionId);
+    List<InterviewTurnDto> turns = loadTurns(sessionId);
+    String raw = transcriptCleanerService.structureRawTranscript(turns);
+    String transcriptId = UUID.randomUUID().toString().replace("-", "");
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id(transcriptId)
+            .sessionId(sessionId)
+            .rawText(raw)
+            .cleanStatus(CLEAN_PENDING)
+            .createdAt(Instant.now())
+            .build();
+    transcriptRepository.save(transcript);
+    session.setStatus(STATUS_FINALIZED);
+    session.setEndedAt(Instant.now());
+    sessionRepository.save(session);
+    return toTranscriptResponse(transcript);
+  }
+
+  @Transactional
+  public InterviewTranscriptResponse cleanTranscript(String transcriptId) {
+    InterviewTranscriptEntity transcript = requireTranscript(transcriptId);
+    InterviewSessionEntity session =
+        sessionRepository
+            .findById(transcript.getSessionId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
+    try {
+      String cleaned = transcriptCleanerService.cleanForIngest(transcript.getRawText(), session.getLanguage());
+      transcript.setCleanedText(cleaned);
+      transcript.setCleanStatus(CLEAN_CLEANED);
+      transcript.setCleanedAt(Instant.now());
+      transcriptRepository.save(transcript);
+      return toTranscriptResponse(transcript);
+    } catch (Exception e) {
+      log.warn("Transcript clean failed id={}: {}", transcriptId, e.getMessage());
+      transcript.setCleanStatus(CLEAN_FAILED);
+      transcriptRepository.save(transcript);
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Transcript clean failed");
+    }
+  }
+
+  public InterviewTranscriptResponse getTranscript(String transcriptId) {
+    return toTranscriptResponse(requireTranscript(transcriptId));
+  }
+
+  @Transactional
+  public IngestionResult ingestTranscript(String transcriptId, boolean force) {
+    InterviewTranscriptEntity transcript = requireTranscript(transcriptId);
+    if (!CLEAN_CLEANED.equals(transcript.getCleanStatus()) || !StringUtils.hasText(transcript.getCleanedText())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Transcript must be cleaned before ingest");
+    }
+    if (StringUtils.hasText(transcript.getIngestedDocumentId()) && !force) {
+      return new IngestionResult(
+          transcript.getIngestedDocumentId(),
+          "interview-transcript",
+          0,
+          true,
+          "Already ingested. Use force to replace.");
+    }
+    String date = DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now().atZone(java.time.ZoneOffset.UTC));
+    String filename = "interview-" + date + "-cleaned.md";
+    try {
+      IngestionResult result =
+          documentIngestionService.ingestTextContent(transcript.getCleanedText(), filename, force);
+      transcript.setIngestedDocumentId(result.documentId());
+      transcriptRepository.save(transcript);
+      return result;
+    } catch (Exception e) {
+      log.warn("Interview transcript ingest failed id={}: {}", transcriptId, e.getMessage());
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Ingest failed: " + e.getMessage());
+    }
+  }
+
+  @Transactional
+  public void deleteSession(String sessionId) {
+    InterviewSessionEntity session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
+    session.setDeletedAt(Instant.now());
+    session.setStatus(STATUS_DELETED);
+    sessionRepository.save(session);
+  }
+
+  InterviewSessionEntity requireActiveSession(String sessionId) {
+    InterviewSessionEntity session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
+    if (session.getDeletedAt() != null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found");
+    }
+    return session;
+  }
+
+  private InterviewTranscriptEntity requireTranscript(String transcriptId) {
+    return transcriptRepository
+        .findById(transcriptId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Transcript not found"));
+  }
+
+  private List<InterviewTurnDto> loadTurns(String sessionId) {
+    return turnRepository.findBySessionIdOrderBySequenceNoAsc(sessionId).stream()
+        .map(t -> new InterviewTurnDto(t.getRole(), t.getText(), t.getSequenceNo()))
+        .toList();
+  }
+
+  private InterviewSessionResponse toResponse(
+      InterviewSessionEntity session, List<InterviewTurnDto> turns, InterviewTranscriptEntity transcript) {
+    return new InterviewSessionResponse(
+        session.getId(),
+        session.getDocumentId(),
+        session.getLanguage(),
+        session.getStatus(),
+        session.getVoice(),
+        session.getStartedAt(),
+        session.getEndedAt(),
+        transcript != null ? transcript.getId() : null,
+        transcript != null ? transcript.getCleanStatus() : null,
+        transcript != null ? transcript.getIngestedDocumentId() : null,
+        turns);
+  }
+
+  private static InterviewTranscriptResponse toTranscriptResponse(InterviewTranscriptEntity transcript) {
+    return new InterviewTranscriptResponse(
+        transcript.getId(),
+        transcript.getSessionId(),
+        transcript.getRawText(),
+        transcript.getCleanedText(),
+        transcript.getCleanStatus(),
+        transcript.getIngestedDocumentId(),
+        transcript.getCreatedAt(),
+        transcript.getCleanedAt());
+  }
+
+  private static String normalizeLang(String raw) {
+    if (!StringUtils.hasText(raw)) {
+      return "en";
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    if ("no".equals(v) || "nb".equals(v) || "nn".equals(v)) {
+      return "no";
+    }
+    return "en";
+  }
+
+  private static String normalizeRole(String role) {
+    String r = role.trim().toLowerCase(Locale.ROOT);
+    if ("assistant".equals(r) || "interviewer".equals(r)) {
+      return "interviewer";
+    }
+    return "user";
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerService.java
@@ -1,0 +1,163 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.model.SanitizeResult;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnDto;
+import com.kevinmazali.portfolio.util.AiRequestContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+public class InterviewTranscriptCleanerService {
+
+  private final NoiseCleaner noiseCleaner;
+  private final ObjectProvider<PiiSanitizerService> piiSanitizerProvider;
+  private final ObjectProvider<OpenAiChatModel> openAiChatModel;
+  private final AiBudgetService aiBudgetService;
+  private final AiBudgetProperties budgetProperties;
+  private final AiCircuitBreaker aiCircuitBreaker;
+
+  private volatile String cleanPromptEn;
+  private volatile String cleanPromptNo;
+
+  public InterviewTranscriptCleanerService(
+      NoiseCleaner noiseCleaner,
+      ObjectProvider<PiiSanitizerService> piiSanitizerProvider,
+      ObjectProvider<OpenAiChatModel> openAiChatModel,
+      AiBudgetService aiBudgetService,
+      AiBudgetProperties budgetProperties,
+      AiCircuitBreaker aiCircuitBreaker) {
+    this.noiseCleaner = noiseCleaner;
+    this.piiSanitizerProvider = piiSanitizerProvider;
+    this.openAiChatModel = openAiChatModel;
+    this.aiBudgetService = aiBudgetService;
+    this.budgetProperties = budgetProperties;
+    this.aiCircuitBreaker = aiCircuitBreaker;
+  }
+
+  public String structureRawTranscript(List<InterviewTurnDto> turns) {
+    if (turns == null || turns.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (InterviewTurnDto turn : turns) {
+      if (!StringUtils.hasText(turn.text())) {
+        continue;
+      }
+      String heading = roleHeading(turn.role());
+      sb.append("## ").append(heading).append("\n\n");
+      sb.append(turn.text().trim()).append("\n\n");
+    }
+    return sb.toString().trim();
+  }
+
+  public String cleanForIngest(String rawText, String language) {
+    if (!StringUtils.hasText(rawText)) {
+      return "";
+    }
+    String cleaned = noiseCleaner.cleanNoise(rawText).cleanedText();
+    PiiSanitizerService sanitizer = piiSanitizerProvider.getIfAvailable();
+    if (sanitizer != null) {
+      SanitizeResult result = sanitizer.sanitize(cleaned);
+      cleaned = result.sanitizedText();
+    }
+    return normalizeWithLlm(cleaned, language);
+  }
+
+  @Nullable
+  String normalizeWithLlm(String structuredText, String language) {
+    OpenAiChatModel model = openAiChatModel.getIfAvailable();
+    if (model == null || !StringUtils.hasText(structuredText)) {
+      return structuredText;
+    }
+    String lang = normalizeLang(language);
+    String template = cleanPromptForLanguage(lang);
+    String promptText = template.replace("{transcript}", structuredText);
+    String budgetUserId = AiRequestContext.budgetUserIdentifier(budgetProperties);
+    boolean anonymous = AiRequestContext.isAnonymousInteractiveUser();
+    try {
+      aiCircuitBreaker.assertClosed();
+      aiBudgetService.assertWithinBudget(budgetUserId, anonymous);
+      OpenAiChatOptions options =
+          OpenAiChatOptions.builder().model("gpt-4o-mini").maxTokens(2000).temperature(0.2).build();
+      ChatResponse response = model.call(new Prompt(promptText, options));
+      String output =
+          response.getResult() != null && response.getResult().getOutput() != null
+              ? response.getResult().getOutput().getText()
+              : null;
+      if (!StringUtils.hasText(output)) {
+        return structuredText;
+      }
+      aiBudgetService.recordUsage(
+          budgetUserId,
+          "gpt-4o-mini",
+          500,
+          1500,
+          anonymous,
+          null,
+          "interview_transcript_clean");
+      return output.trim();
+    } catch (Exception e) {
+      log.warn("Interview transcript LLM clean failed, using structured text: {}", e.getMessage());
+      return structuredText;
+    }
+  }
+
+  private String cleanPromptForLanguage(String lang) {
+    if ("no".equals(lang)) {
+      if (cleanPromptNo == null) {
+        cleanPromptNo = loadPrompt("prompts/interview-transcript-clean-no.txt");
+      }
+      return cleanPromptNo;
+    }
+    if (cleanPromptEn == null) {
+      cleanPromptEn = loadPrompt("prompts/interview-transcript-clean-en.txt");
+    }
+    return cleanPromptEn;
+  }
+
+  private static String roleHeading(String role) {
+    if (role == null) {
+      return "Unknown";
+    }
+    return switch (role.toLowerCase(Locale.ROOT)) {
+      case "interviewer", "assistant" -> "Interviewer";
+      case "user", "kevin" -> "Kevin";
+      default -> role;
+    };
+  }
+
+  private static String normalizeLang(String raw) {
+    if (!StringUtils.hasText(raw)) {
+      return "en";
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    if ("no".equals(v) || "nb".equals(v) || "nn".equals(v)) {
+      return "no";
+    }
+    return "en";
+  }
+
+  private static String loadPrompt(String path) {
+    try {
+      var res = new ClassPathResource(path);
+      return StreamUtils.copyToString(res.getInputStream(), StandardCharsets.UTF_8).trim();
+    } catch (IOException e) {
+      return "Clean this interview transcript into third-person facts about Kevin:\n\n{transcript}";
+    }
+  }
+}

--- a/backend/src/main/resources/db/migration/V15__interview_sessions.sql
+++ b/backend/src/main/resources/db/migration/V15__interview_sessions.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS interview_documents (
+    id VARCHAR(64) PRIMARY KEY,
+    original_filename VARCHAR(512) NOT NULL,
+    mime_type VARCHAR(128),
+    parsed_text TEXT NOT NULL,
+    char_count INTEGER NOT NULL,
+    created_by VARCHAR(128),
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_interview_documents_created_at ON interview_documents (created_at);
+
+CREATE TABLE IF NOT EXISTS interview_sessions (
+    id VARCHAR(64) PRIMARY KEY,
+    document_id VARCHAR(64) NOT NULL REFERENCES interview_documents (id) ON DELETE CASCADE,
+    language VARCHAR(8) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    voice VARCHAR(32),
+    started_at TIMESTAMPTZ NOT NULL,
+    ended_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_interview_sessions_status ON interview_sessions (status);
+CREATE INDEX IF NOT EXISTS idx_interview_sessions_started_at ON interview_sessions (started_at);
+
+CREATE TABLE IF NOT EXISTS interview_transcript_turns (
+    id BIGSERIAL PRIMARY KEY,
+    session_id VARCHAR(64) NOT NULL REFERENCES interview_sessions (id) ON DELETE CASCADE,
+    role VARCHAR(32) NOT NULL,
+    text TEXT NOT NULL,
+    sequence_no INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_interview_turns_session_seq ON interview_transcript_turns (session_id, sequence_no);
+
+CREATE TABLE IF NOT EXISTS interview_transcripts (
+    id VARCHAR(64) PRIMARY KEY,
+    session_id VARCHAR(64) NOT NULL UNIQUE REFERENCES interview_sessions (id) ON DELETE CASCADE,
+    raw_text TEXT,
+    cleaned_text TEXT,
+    clean_status VARCHAR(32) NOT NULL,
+    ingested_document_id VARCHAR(64),
+    created_at TIMESTAMPTZ NOT NULL,
+    cleaned_at TIMESTAMPTZ
+);

--- a/backend/src/main/resources/prompts/interview-transcript-clean-en.txt
+++ b/backend/src/main/resources/prompts/interview-transcript-clean-en.txt
@@ -1,0 +1,11 @@
+You convert a voice interview transcript into a concise factual document about Kevin for a portfolio knowledge base.
+
+Input is a Q&A transcript. Output plain markdown in third person about Kevin ("Kevin", "he", "his").
+- Keep only facts supported by the transcript or clearly stated by Kevin.
+- Remove filler words, disfluencies, and interviewer small talk.
+- Use short sections with headings (Background, Skills, Projects, Motivation, etc.) where appropriate.
+- Do not invent details. If uncertain, omit.
+- Maximum about 1200 words.
+
+Transcript:
+{transcript}

--- a/backend/src/main/resources/prompts/interview-transcript-clean-no.txt
+++ b/backend/src/main/resources/prompts/interview-transcript-clean-no.txt
@@ -1,0 +1,11 @@
+Du konverterer et transkript fra en stemmeintervju til et kort faktadokument om Kevin for en portfolio-kunnskapsbase.
+
+Inndata er et spørsmål-svar-transkript. Skriv ren markdown i tredjeperson om Kevin («Kevin», «han», «hans»).
+- Behold kun fakta som støttes av transkriptet eller som Kevin tydelig sier.
+- Fjern fyllord, disfluenser og småprat fra intervjueren.
+- Bruk korte seksjoner med overskrifter (Bakgrunn, Ferdigheter, Prosjekter, Motivasjon, osv.) der det passer.
+- Ikke finn på detaljer. Ved usikkerhet, utelat.
+- Maksimalt ca. 1200 ord.
+
+Transkript:
+{transcript}

--- a/backend/src/main/resources/prompts/interview-voice-en.txt
+++ b/backend/src/main/resources/prompts/interview-voice-en.txt
@@ -1,0 +1,14 @@
+You are a professional interviewer helping Kevin practice talking about himself for his portfolio and job interviews.
+
+Rules:
+- Use ONLY the source document below as your factual basis. Do not invent employers, dates, grades, or projects that are not supported by the document.
+- Ask one clear question at a time. Listen to Kevin's spoken answers, then ask a natural follow-up.
+- Cover background, motivation, skills, projects, and lessons learned when the document supports it.
+- If Kevin's answer is unclear or the transcription seems wrong, politely ask him to repeat or rephrase.
+- Keep your spoken questions concise and natural for voice.
+- Speak English when the session language is English.
+- When Kevin asks to wrap up, give a brief spoken summary of strengths and 1–2 areas to clarify next time.
+- You are an AI interviewer, not Kevin.
+
+Source document (may be truncated):
+{document_context}

--- a/backend/src/main/resources/prompts/interview-voice-no.txt
+++ b/backend/src/main/resources/prompts/interview-voice-no.txt
@@ -1,0 +1,14 @@
+Du er en profesjonell intervjuer som hjelper Kevin med å øve på å snakke om seg selv til portfolio og jobbintervjuer.
+
+Regler:
+- Bruk KUN kildedokumentet under som faktagrunnlag. Ikke finn på arbeidsgivere, datoer, karakterer eller prosjekter som ikke støttes av dokumentet.
+- Still ett tydelig spørsmål om gangen. Lytt til Kevins muntlige svar, og still et naturlig oppfølgingsspørsmål.
+- Dekk bakgrunn, motivasjon, ferdigheter, prosjekter og læringspunkter når dokumentet støtter det.
+- Hvis svaret er uklart eller transkripsjonen virker feil, be høflig om å gjenta eller omformulere.
+- Hold de muntlige spørsmålene korte og naturlige for tale.
+- Snakk norsk når sesjonsspråket er norsk.
+- Når Kevin ber om å avslutte, gi en kort muntlig oppsummering av styrker og 1–2 områder å tydeliggjøre neste gang.
+- Du er en AI-intervjuer, ikke Kevin.
+
+Kildedokument (kan være avkortet):
+{document_context}

--- a/backend/src/test/java/com/kevinmazali/portfolio/controller/InterviewControllerTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/controller/InterviewControllerTest.java
@@ -1,0 +1,122 @@
+package com.kevinmazali.portfolio.controller;
+
+import com.kevinmazali.portfolio.MvcTestSessionAuthConfig;
+import com.kevinmazali.portfolio.MvcTestUserDetailsConfig;
+import com.kevinmazali.portfolio.config.ApiErrorConfiguration;
+import com.kevinmazali.portfolio.config.SecurityConfig;
+import com.kevinmazali.portfolio.model.IngestionResult;
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptResponse;
+import com.kevinmazali.portfolio.service.InterviewDocumentService;
+import com.kevinmazali.portfolio.service.InterviewRealtimeSessionService;
+import com.kevinmazali.portfolio.service.InterviewSessionService;
+import com.kevinmazali.portfolio.service.RequestLogService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InterviewController.class)
+@Import({
+  SecurityConfig.class,
+  MvcTestSessionAuthConfig.class,
+  MvcTestUserDetailsConfig.class,
+  ApiErrorConfiguration.class
+})
+class InterviewControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private InterviewDocumentService interviewDocumentService;
+  @MockitoBean private InterviewSessionService interviewSessionService;
+  @MockitoBean private InterviewRealtimeSessionService interviewRealtimeSessionService;
+  @MockitoBean private RequestLogService requestLogService;
+
+  @Test
+  void uploadRequiresAdmin() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/admin/tools/interview/documents")
+                .file(new MockMultipartFile("file", "cv.pdf", "application/pdf", new byte[] {1, 2})))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void uploadDocumentOk() throws Exception {
+    when(interviewDocumentService.storeMultipart(any(), eq("admin")))
+        .thenReturn(
+            new InterviewDocumentResponse("doc1", "cv.pdf", "application/pdf", 100, "admin", Instant.now()));
+
+    mockMvc
+        .perform(
+            multipart("/admin/tools/interview/documents")
+                .file(new MockMultipartFile("file", "cv.pdf", "application/pdf", new byte[] {1, 2})))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value("doc1"));
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void createSessionOk() throws Exception {
+    when(interviewSessionService.createSession(any()))
+        .thenReturn(
+            new InterviewSessionResponse(
+                "sess1", "doc1", "no", "ACTIVE", "marin", Instant.now(), null, null, null, null, List.of()));
+
+    mockMvc
+        .perform(
+            post("/admin/tools/interview/sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"documentId\":\"doc1\",\"language\":\"no\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value("sess1"));
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void cleanTranscriptOk() throws Exception {
+    when(interviewSessionService.cleanTranscript("t1"))
+        .thenReturn(
+            new InterviewTranscriptResponse(
+                "t1", "sess1", "raw", "cleaned", "CLEANED", null, Instant.now(), Instant.now()));
+
+    mockMvc
+        .perform(post("/admin/tools/interview/transcripts/t1/clean"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.cleanStatus").value("CLEANED"));
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void ingestTranscriptOk() throws Exception {
+    when(interviewSessionService.ingestTranscript("t1", false))
+        .thenReturn(new IngestionResult("hash1", "interview.md", 3, false, "OK"));
+
+    mockMvc
+        .perform(post("/admin/tools/interview/transcripts/t1/ingest"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.skipped").value(false));
+
+    verify(interviewSessionService).ingestTranscript("t1", false);
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/security/SecurityConfigIT.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/security/SecurityConfigIT.java
@@ -98,6 +98,8 @@ class SecurityConfigIT {
           "/admin/tools/experiments/datasets",
           "/admin/tools/experiments/runs",
           "/admin/tools/ai/status",
+          "/admin/tools/interview/documents",
+          "/admin/tools/interview/sessions",
         }) {
       assertTrue(paths != null && paths.has(path), "Missing OpenAPI path: " + path);
     }

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewDocumentServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewDocumentServiceTest.java
@@ -1,0 +1,119 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.DocumentIngestProperties;
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentEntity;
+import com.kevinmazali.portfolio.repository.InterviewDocumentRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewDocumentServiceTest {
+
+  @Mock private InterviewDocumentRepository documentRepository;
+
+  private DocumentIngestProperties documentIngestProperties;
+  private InterviewDocumentService service;
+
+  @BeforeEach
+  void setUp() {
+    documentIngestProperties = new DocumentIngestProperties();
+    documentIngestProperties.setMaxParseBytes(1024 * 1024);
+    service = new InterviewDocumentService(documentRepository, documentIngestProperties);
+  }
+
+  @Test
+  void storeText_savesPlainTextDocument() {
+    when(documentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var response = service.storeText("  Hello NTNU  ", "notes.md", "admin");
+
+    assertThat(response.originalFilename()).isEqualTo("notes.md");
+    assertThat(response.charCount()).isEqualTo("Hello NTNU".length());
+
+    ArgumentCaptor<InterviewDocumentEntity> captor = ArgumentCaptor.forClass(InterviewDocumentEntity.class);
+    verify(documentRepository).save(captor.capture());
+    assertThat(captor.getValue().getParsedText()).isEqualTo("Hello NTNU");
+    assertThat(captor.getValue().getCreatedBy()).isEqualTo("admin");
+  }
+
+  @Test
+  void storeText_rejectsBlankInput() {
+    assertThatThrownBy(() -> service.storeText("   ", null, "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Text is required");
+  }
+
+  @Test
+  void storeMultipart_parsesTxtFile() throws Exception {
+    when(documentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    MockMultipartFile file =
+        new MockMultipartFile("file", "resume.txt", "text/plain", "Kevin studies at NTNU.".getBytes(StandardCharsets.UTF_8));
+
+    var response = service.storeMultipart(file, "admin");
+
+    assertThat(response.originalFilename()).isEqualTo("resume.txt");
+    assertThat(response.charCount()).isGreaterThan(0);
+  }
+
+  @Test
+  void storeMultipart_rejectsUnsupportedExtension() {
+    MockMultipartFile file = new MockMultipartFile("file", "virus.exe", "application/octet-stream", new byte[] {1});
+
+    assertThatThrownBy(() -> service.storeMultipart(file, "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Unsupported file type");
+  }
+
+  @Test
+  void contextForSession_returnsTruncatedText() {
+    String longText = "a".repeat(InterviewDocumentService.MAX_CONTEXT_CHARS + 100);
+    InterviewDocumentEntity entity =
+        InterviewDocumentEntity.builder()
+            .id("doc1")
+            .originalFilename("big.txt")
+            .parsedText(longText)
+            .charCount(longText.length())
+            .build();
+    when(documentRepository.findById("doc1")).thenReturn(Optional.of(entity));
+
+    String context = service.contextForSession("doc1");
+
+    assertThat(context).hasSize(InterviewDocumentService.MAX_CONTEXT_CHARS + "\n\n[truncated]".length());
+    assertThat(context).endsWith("[truncated]");
+  }
+
+  @Test
+  void truncateContext_handlesNullAndShortText() {
+    assertThat(InterviewDocumentService.truncateContext(null)).isEmpty();
+    assertThat(InterviewDocumentService.truncateContext("short")).isEqualTo("short");
+  }
+
+  @Test
+  void getDocument_mapsEntity() {
+    InterviewDocumentEntity entity =
+        InterviewDocumentEntity.builder()
+            .id("doc1")
+            .originalFilename("cv.pdf")
+            .mimeType("application/pdf")
+            .parsedText("text")
+            .charCount(4)
+            .build();
+    when(documentRepository.findById("doc1")).thenReturn(Optional.of(entity));
+
+    assertThat(service.getDocument("doc1").id()).isEqualTo("doc1");
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewDocumentServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewDocumentServiceTest.java
@@ -103,6 +103,34 @@ class InterviewDocumentServiceTest {
   }
 
   @Test
+  void storeMultipart_rejectsEmptyFile() {
+    MockMultipartFile file = new MockMultipartFile("file", "empty.txt", "text/plain", new byte[0]);
+
+    assertThatThrownBy(() -> service.storeMultipart(file, "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Empty file");
+  }
+
+  @Test
+  void storeMultipart_rejectsOversizedFile() {
+    documentIngestProperties.setMaxParseBytes(4);
+    MockMultipartFile file = new MockMultipartFile("file", "big.txt", "text/plain", "12345".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> service.storeMultipart(file, "admin"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("maximum parse size");
+  }
+
+  @Test
+  void getDocument_throwsWhenMissing() {
+    when(documentRepository.findById("missing")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getDocument("missing"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Document not found");
+  }
+
+  @Test
   void getDocument_mapsEntity() {
     InterviewDocumentEntity entity =
         InterviewDocumentEntity.builder()

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionServiceTest.java
@@ -1,0 +1,179 @@
+package com.kevinmazali.portfolio.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.config.RealtimeProperties;
+import com.kevinmazali.portfolio.exception.RealtimeErrorCode;
+import com.kevinmazali.portfolio.exception.RealtimeSessionException;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionEntity;
+import com.kevinmazali.portfolio.repository.InterviewSessionRepository;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class InterviewRealtimeSessionServiceTest {
+
+  @Mock private AiBudgetService aiBudgetService;
+  @Mock private AiCircuitBreaker aiCircuitBreaker;
+  @Mock private OpenAiRealtimeHttpInvoker openAiRealtimeHttpInvoker;
+  @Mock private RealtimeModelCatalog realtimeModelCatalog;
+  @Mock private InterviewDocumentService interviewDocumentService;
+  @Mock private InterviewSessionRepository sessionRepository;
+
+  private RealtimeProperties realtimeProperties;
+  private AiBudgetProperties budgetProperties;
+  private InterviewRealtimeSessionService service;
+
+  @BeforeEach
+  void setUp() {
+    realtimeProperties = new RealtimeProperties();
+    realtimeProperties.setEnabled(true);
+    realtimeProperties.setModel("gpt-realtime-2");
+    realtimeProperties.setVoice("marin");
+    realtimeProperties.setReasoningEffort("low");
+    realtimeProperties.setMaxResponseOutputTokens(512);
+    realtimeProperties.setReservationInputTokens(100);
+    realtimeProperties.setReservationOutputTokens(200);
+
+    budgetProperties = new AiBudgetProperties();
+    budgetProperties.setAnonIdentitySalt("test-salt");
+    budgetProperties.setEnabled(false);
+
+    doNothing().when(aiCircuitBreaker).assertClosed();
+    doNothing().when(aiBudgetService).assertWithinBudget(anyString(), anyBoolean());
+    when(realtimeModelCatalog.resolveOpenAiModelId(any())).thenReturn("gpt-realtime-2");
+    when(realtimeModelCatalog.isOpenAiModelConfigured(anyString())).thenReturn(true);
+
+    service =
+        new InterviewRealtimeSessionService(
+            realtimeProperties,
+            aiBudgetService,
+            budgetProperties,
+            aiCircuitBreaker,
+            openAiRealtimeHttpInvoker,
+            realtimeModelCatalog,
+            interviewDocumentService,
+            sessionRepository,
+            "sk-test-openai-key");
+    service.preloadInstructionPrompts();
+  }
+
+  @Test
+  void createInterviewCall_returnsSdpOnSuccess() throws Exception {
+    stubActiveSession("sess1", "doc1");
+    when(interviewDocumentService.contextForSession("doc1")).thenReturn("Document context");
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn("v=0\r\no=- interview answer");
+    when(openAiRealtimeHttpInvoker.invoke(any())).thenReturn(response);
+
+    assertThat(service.createInterviewCall("sess1", "v=0\r\no=offer", "no", null, "cedar", "high"))
+        .isEqualTo("v=0\r\no=- interview answer");
+
+    verify(aiBudgetService)
+        .recordUsage(anyString(), eq("gpt-realtime-2"), eq(100), eq(200), eq(false), isNull(), eq("interview_realtime_session"));
+  }
+
+  @Test
+  void createInterviewCall_rejectsWhenRealtimeDisabled() {
+    realtimeProperties.setEnabled(false);
+
+    assertThatThrownBy(() -> service.createInterviewCall("sess1", "v=0", "en", null, null, null))
+        .isInstanceOf(RealtimeSessionException.class)
+        .hasFieldOrPropertyWithValue("errorCode", RealtimeErrorCode.REALTIME_DISABLED);
+
+    verify(openAiRealtimeHttpInvoker, never()).invoke(any());
+  }
+
+  @Test
+  void createInterviewCall_rejectsMissingApiKey() {
+    InterviewRealtimeSessionService svc =
+        new InterviewRealtimeSessionService(
+            realtimeProperties,
+            aiBudgetService,
+            budgetProperties,
+            aiCircuitBreaker,
+            openAiRealtimeHttpInvoker,
+            realtimeModelCatalog,
+            interviewDocumentService,
+            sessionRepository,
+            "  ");
+
+    assertThatThrownBy(() -> svc.createInterviewCall("sess1", "v=0", "en", null, null, null))
+        .isInstanceOf(RealtimeSessionException.class)
+        .hasFieldOrPropertyWithValue("errorCode", RealtimeErrorCode.API_KEY_MISSING)
+        .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void createInterviewCall_rejectsInactiveSession() {
+    when(sessionRepository.findById("sess1"))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id("sess1")
+                    .documentId("doc1")
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_FINALIZED)
+                    .startedAt(Instant.now())
+                    .build()));
+
+    assertThatThrownBy(() -> service.createInterviewCall("sess1", "v=0", "en", null, null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not active");
+  }
+
+  @Test
+  void createInterviewCall_mapsOpenAi4xx() throws Exception {
+    stubActiveSession("sess1", "doc1");
+    when(interviewDocumentService.contextForSession("doc1")).thenReturn("ctx");
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(400);
+    when(response.body()).thenReturn("{\"error\":\"bad sdp\"}");
+    when(openAiRealtimeHttpInvoker.invoke(any())).thenReturn(response);
+
+    assertThatThrownBy(() -> service.createInterviewCall("sess1", "v=0", "en", null, null, null))
+        .isInstanceOf(RealtimeSessionException.class)
+        .hasFieldOrPropertyWithValue("errorCode", RealtimeErrorCode.OPENAI_REJECTED);
+
+    verify(aiBudgetService, never())
+        .recordUsage(anyString(), anyString(), anyInt(), anyInt(), anyBoolean(), isNull(), anyString());
+  }
+
+  private void stubActiveSession(String sessionId, String documentId) {
+    when(sessionRepository.findById(sessionId))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id(sessionId)
+                    .documentId(documentId)
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_ACTIVE)
+                    .voice("marin")
+                    .startedAt(Instant.now())
+                    .build()));
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionServiceTest.java
@@ -98,7 +98,7 @@ class InterviewRealtimeSessionServiceTest {
   }
 
   @Test
-  void createInterviewCall_rejectsWhenRealtimeDisabled() {
+  void createInterviewCall_rejectsWhenRealtimeDisabled() throws Exception {
     realtimeProperties.setEnabled(false);
 
     assertThatThrownBy(() -> service.createInterviewCall("sess1", "v=0", "en", null, null, null))
@@ -109,7 +109,7 @@ class InterviewRealtimeSessionServiceTest {
   }
 
   @Test
-  void createInterviewCall_rejectsMissingApiKey() {
+  void createInterviewCall_rejectsMissingApiKey() throws Exception {
     InterviewRealtimeSessionService svc =
         new InterviewRealtimeSessionService(
             realtimeProperties,

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
@@ -260,6 +260,7 @@ class InterviewSessionServiceTest {
             .build();
     when(sessionRepository.findByDeletedAtIsNullOrderByStartedAtDesc()).thenReturn(List.of(session));
     when(transcriptRepository.findBySessionId("sess1")).thenReturn(Optional.of(transcript));
+    when(transcriptRepository.findById("tr1")).thenReturn(Optional.of(transcript));
     when(sessionRepository.findById("sess1")).thenReturn(Optional.of(session));
     when(turnRepository.findBySessionIdOrderBySequenceNoAsc("sess1")).thenReturn(List.of());
 

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
@@ -1,0 +1,275 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.RealtimeProperties;
+import com.kevinmazali.portfolio.model.IngestionResult;
+import com.kevinmazali.portfolio.model.interview.CreateInterviewSessionRequest;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewSessionResponse;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewTranscriptTurnEntity;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnBatchRequest;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnDto;
+import com.kevinmazali.portfolio.repository.InterviewDocumentRepository;
+import com.kevinmazali.portfolio.repository.InterviewSessionRepository;
+import com.kevinmazali.portfolio.repository.InterviewTranscriptRepository;
+import com.kevinmazali.portfolio.repository.InterviewTranscriptTurnRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewSessionServiceTest {
+
+  @Mock private InterviewSessionRepository sessionRepository;
+  @Mock private InterviewDocumentRepository documentRepository;
+  @Mock private InterviewTranscriptTurnRepository turnRepository;
+  @Mock private InterviewTranscriptRepository transcriptRepository;
+  @Mock private InterviewTranscriptCleanerService transcriptCleanerService;
+  @Mock private DocumentIngestionService documentIngestionService;
+
+  private RealtimeProperties realtimeProperties;
+  private InterviewSessionService service;
+
+  @BeforeEach
+  void setUp() {
+    realtimeProperties = new RealtimeProperties();
+    realtimeProperties.setVoice("marin");
+    service =
+        new InterviewSessionService(
+            sessionRepository,
+            documentRepository,
+            turnRepository,
+            transcriptRepository,
+            transcriptCleanerService,
+            documentIngestionService,
+            realtimeProperties);
+  }
+
+  @Test
+  void createSession_requiresDocumentId() {
+    assertThatThrownBy(() -> service.createSession(null))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("documentId");
+  }
+
+  @Test
+  void createSession_requiresExistingDocument() {
+    when(documentRepository.existsById("missing")).thenReturn(false);
+
+    assertThatThrownBy(() -> service.createSession(new CreateInterviewSessionRequest("missing", "en", null)))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Document not found");
+  }
+
+  @Test
+  void createSession_normalizesLanguageAndSaves() {
+    when(documentRepository.existsById("doc1")).thenReturn(true);
+    when(sessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    InterviewSessionResponse response =
+        service.createSession(new CreateInterviewSessionRequest("doc1", "nb", "cedar"));
+
+    assertThat(response.documentId()).isEqualTo("doc1");
+    assertThat(response.language()).isEqualTo("no");
+    assertThat(response.status()).isEqualTo(InterviewSessionService.STATUS_ACTIVE);
+    assertThat(response.voice()).isEqualTo("cedar");
+
+    ArgumentCaptor<InterviewSessionEntity> captor = ArgumentCaptor.forClass(InterviewSessionEntity.class);
+    verify(sessionRepository).save(captor.capture());
+    assertThat(captor.getValue().getLanguage()).isEqualTo("no");
+  }
+
+  @Test
+  void appendTurns_skipsEmptyBatch() {
+    stubActiveSession("sess1");
+
+    service.appendTurns("sess1", new InterviewTurnBatchRequest(List.of()));
+
+    verify(turnRepository, never()).saveAll(any());
+  }
+
+  @Test
+  void appendTurns_persistsValidTurnsWithAutoSequence() {
+    stubActiveSession("sess1");
+    when(turnRepository.findBySessionIdOrderBySequenceNoAsc("sess1")).thenReturn(List.of());
+
+    service.appendTurns(
+        "sess1",
+        new InterviewTurnBatchRequest(
+            List.of(
+                new InterviewTurnDto("interviewer", "  Hello?  ", -1),
+                new InterviewTurnDto("", "ignored", 1),
+                new InterviewTurnDto("user", "Hi there", -1))));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<InterviewTranscriptTurnEntity>> captor = ArgumentCaptor.forClass(List.class);
+    verify(turnRepository).saveAll(captor.capture());
+    assertThat(captor.getValue()).hasSize(2);
+    assertThat(captor.getValue().get(0).getRole()).isEqualTo("interviewer");
+    assertThat(captor.getValue().get(0).getText()).isEqualTo("Hello?");
+    assertThat(captor.getValue().get(1).getRole()).isEqualTo("user");
+  }
+
+  @Test
+  void finalizeSession_createsTranscriptAndMarksFinalized() {
+    stubActiveSession("sess1");
+    when(turnRepository.findBySessionIdOrderBySequenceNoAsc("sess1"))
+        .thenReturn(
+            List.of(
+                InterviewTranscriptTurnEntity.builder()
+                    .sessionId("sess1")
+                    .role("user")
+                    .text("Answer")
+                    .sequenceNo(0)
+                    .build()));
+    when(transcriptCleanerService.structureRawTranscript(any())).thenReturn("raw transcript");
+    when(transcriptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(sessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var response = service.finalizeSession("sess1");
+
+    assertThat(response.cleanStatus()).isEqualTo(InterviewSessionService.CLEAN_PENDING);
+    assertThat(response.rawText()).isEqualTo("raw transcript");
+
+    ArgumentCaptor<InterviewSessionEntity> sessionCaptor = ArgumentCaptor.forClass(InterviewSessionEntity.class);
+    verify(sessionRepository).save(sessionCaptor.capture());
+    assertThat(sessionCaptor.getValue().getStatus()).isEqualTo(InterviewSessionService.STATUS_FINALIZED);
+    assertThat(sessionCaptor.getValue().getEndedAt()).isNotNull();
+  }
+
+  @Test
+  void cleanTranscript_setsCleanedTextOnSuccess() {
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id("tr1")
+            .sessionId("sess1")
+            .rawText("raw")
+            .cleanStatus(InterviewSessionService.CLEAN_PENDING)
+            .createdAt(Instant.now())
+            .build();
+    when(transcriptRepository.findById("tr1")).thenReturn(Optional.of(transcript));
+    when(sessionRepository.findById("sess1"))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id("sess1")
+                    .documentId("doc1")
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_FINALIZED)
+                    .startedAt(Instant.now())
+                    .build()));
+    when(transcriptCleanerService.cleanForIngest("raw", "en")).thenReturn("cleaned");
+    when(transcriptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var response = service.cleanTranscript("tr1");
+
+    assertThat(response.cleanedText()).isEqualTo("cleaned");
+    assertThat(response.cleanStatus()).isEqualTo(InterviewSessionService.CLEAN_CLEANED);
+  }
+
+  @Test
+  void ingestTranscript_requiresCleanedTranscript() {
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id("tr1")
+            .sessionId("sess1")
+            .cleanStatus(InterviewSessionService.CLEAN_PENDING)
+            .createdAt(Instant.now())
+            .build();
+    when(transcriptRepository.findById("tr1")).thenReturn(Optional.of(transcript));
+
+    assertThatThrownBy(() -> service.ingestTranscript("tr1", false))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("must be cleaned");
+  }
+
+  @Test
+  void ingestTranscript_returnsExistingWhenAlreadyIngested() {
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id("tr1")
+            .sessionId("sess1")
+            .cleanStatus(InterviewSessionService.CLEAN_CLEANED)
+            .cleanedText("cleaned")
+            .ingestedDocumentId("existing-doc")
+            .createdAt(Instant.now())
+            .build();
+    when(transcriptRepository.findById("tr1")).thenReturn(Optional.of(transcript));
+
+    IngestionResult result = service.ingestTranscript("tr1", false);
+
+    assertThat(result.documentId()).isEqualTo("existing-doc");
+    assertThat(result.message()).contains("Already ingested");
+    verify(documentIngestionService, never()).ingestTextContent(anyString(), anyString(), anyBoolean());
+  }
+
+  @Test
+  void ingestTranscript_ingestsCleanedText() {
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id("tr1")
+            .sessionId("sess1")
+            .cleanStatus(InterviewSessionService.CLEAN_CLEANED)
+            .cleanedText("cleaned markdown")
+            .createdAt(Instant.now())
+            .build();
+    when(transcriptRepository.findById("tr1")).thenReturn(Optional.of(transcript));
+    when(documentIngestionService.ingestTextContent(eq("cleaned markdown"), anyString(), eq(false)))
+        .thenReturn(new IngestionResult("ing1", "interview-transcript", 3, false, "ok"));
+    when(transcriptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    IngestionResult result = service.ingestTranscript("tr1", false);
+
+    assertThat(result.documentId()).isEqualTo("ing1");
+    assertThat(transcript.getIngestedDocumentId()).isEqualTo("ing1");
+  }
+
+  @Test
+  void deleteSession_softDeletes() {
+    InterviewSessionEntity session =
+        InterviewSessionEntity.builder()
+            .id("sess1")
+            .documentId("doc1")
+            .language("en")
+            .status(InterviewSessionService.STATUS_ACTIVE)
+            .startedAt(Instant.now())
+            .build();
+    when(sessionRepository.findById("sess1")).thenReturn(Optional.of(session));
+    when(sessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    service.deleteSession("sess1");
+
+    assertThat(session.getStatus()).isEqualTo(InterviewSessionService.STATUS_DELETED);
+    assertThat(session.getDeletedAt()).isNotNull();
+  }
+
+  private void stubActiveSession(String sessionId) {
+    when(sessionRepository.findById(sessionId))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id(sessionId)
+                    .documentId("doc1")
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_ACTIVE)
+                    .startedAt(Instant.now())
+                    .build()));
+  }
+}

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
@@ -201,7 +201,7 @@ class InterviewSessionServiceTest {
   }
 
   @Test
-  void ingestTranscript_returnsExistingWhenAlreadyIngested() {
+  void ingestTranscript_returnsExistingWhenAlreadyIngested() throws Exception {
     InterviewTranscriptEntity transcript =
         InterviewTranscriptEntity.builder()
             .id("tr1")
@@ -221,7 +221,7 @@ class InterviewSessionServiceTest {
   }
 
   @Test
-  void ingestTranscript_ingestsCleanedText() {
+  void ingestTranscript_ingestsCleanedText() throws Exception {
     InterviewTranscriptEntity transcript =
         InterviewTranscriptEntity.builder()
             .id("tr1")

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
@@ -242,6 +242,82 @@ class InterviewSessionServiceTest {
   }
 
   @Test
+  void listSessions_andGetSession_mapTranscriptMetadata() {
+    InterviewSessionEntity session =
+        InterviewSessionEntity.builder()
+            .id("sess1")
+            .documentId("doc1")
+            .language("en")
+            .status(InterviewSessionService.STATUS_FINALIZED)
+            .startedAt(Instant.now())
+            .build();
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id("tr1")
+            .sessionId("sess1")
+            .cleanStatus(InterviewSessionService.CLEAN_CLEANED)
+            .createdAt(Instant.now())
+            .build();
+    when(sessionRepository.findByDeletedAtIsNullOrderByStartedAtDesc()).thenReturn(List.of(session));
+    when(transcriptRepository.findBySessionId("sess1")).thenReturn(Optional.of(transcript));
+    when(sessionRepository.findById("sess1")).thenReturn(Optional.of(session));
+    when(turnRepository.findBySessionIdOrderBySequenceNoAsc("sess1")).thenReturn(List.of());
+
+    assertThat(service.listSessions()).hasSize(1);
+    assertThat(service.getSession("sess1").transcriptId()).isEqualTo("tr1");
+    assertThat(service.getTranscript("tr1").id()).isEqualTo("tr1");
+  }
+
+  @Test
+  void cleanTranscript_marksFailedOnCleanerError() {
+    InterviewTranscriptEntity transcript =
+        InterviewTranscriptEntity.builder()
+            .id("tr1")
+            .sessionId("sess1")
+            .rawText("raw")
+            .cleanStatus(InterviewSessionService.CLEAN_PENDING)
+            .createdAt(Instant.now())
+            .build();
+    when(transcriptRepository.findById("tr1")).thenReturn(Optional.of(transcript));
+    when(sessionRepository.findById("sess1"))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id("sess1")
+                    .documentId("doc1")
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_FINALIZED)
+                    .startedAt(Instant.now())
+                    .build()));
+    when(transcriptCleanerService.cleanForIngest("raw", "en")).thenThrow(new RuntimeException("boom"));
+    when(transcriptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    assertThatThrownBy(() -> service.cleanTranscript("tr1"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Transcript clean failed");
+    assertThat(transcript.getCleanStatus()).isEqualTo(InterviewSessionService.CLEAN_FAILED);
+  }
+
+  @Test
+  void requireActiveSession_rejectsDeleted() {
+    when(sessionRepository.findById("sess1"))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id("sess1")
+                    .documentId("doc1")
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_DELETED)
+                    .startedAt(Instant.now())
+                    .deletedAt(Instant.now())
+                    .build()));
+
+    assertThatThrownBy(() -> service.getSession("sess1"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Session not found");
+  }
+
+  @Test
   void deleteSession_softDeletes() {
     InterviewSessionEntity session =
         InterviewSessionEntity.builder()

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerServiceTest.java
@@ -1,0 +1,55 @@
+package com.kevinmazali.portfolio.service;
+
+import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.model.interview.InterviewTurnDto;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.ai.openai.OpenAiChatModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class InterviewTranscriptCleanerServiceTest {
+
+  @Test
+  void structureRawTranscriptFormatsQa() {
+    var service =
+        new InterviewTranscriptCleanerService(
+            new NoiseCleaner(),
+            mock(ObjectProvider.class),
+            mock(ObjectProvider.class),
+            mock(AiBudgetService.class),
+            new AiBudgetProperties(),
+            mock(AiCircuitBreaker.class));
+
+    String raw =
+        service.structureRawTranscript(
+            List.of(
+                new InterviewTurnDto("interviewer", "Tell me about your studies.", 0),
+                new InterviewTurnDto("user", "I study computer science at NTNU.", 1)));
+
+    assertThat(raw).contains("## Interviewer");
+    assertThat(raw).contains("## Kevin");
+    assertThat(raw).contains("computer science");
+  }
+
+  @Test
+  void cleanForIngestRunsNoiseCleanerWithoutLlm() {
+    var openAiProvider = mock(ObjectProvider.class);
+    org.mockito.Mockito.when(openAiProvider.getIfAvailable()).thenReturn(null);
+
+    var service =
+        new InterviewTranscriptCleanerService(
+            new NoiseCleaner(),
+            mock(ObjectProvider.class),
+            openAiProvider,
+            mock(AiBudgetService.class),
+            new AiBudgetProperties(),
+            mock(AiCircuitBreaker.class));
+
+    String cleaned = service.cleanForIngest("Kevin studies at NTNU.\n\nPage 1 of 1\n", "en");
+    assertThat(cleaned).contains("NTNU");
+    assertThat(cleaned).doesNotContain("Page 1 of 1");
+  }
+}

--- a/frontend/homepage/cypress/e2e/admin-interview-smoke.cy.ts
+++ b/frontend/homepage/cypress/e2e/admin-interview-smoke.cy.ts
@@ -1,0 +1,17 @@
+describe('Admin interview smoke', () => {
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.sessionStorage.setItem(
+        'auth',
+        JSON.stringify({ username: 'admin', role: 'ADMIN' }),
+      )
+    })
+  })
+
+  it('loads interview admin page and shows wizard', () => {
+    cy.visit('/admin/interview')
+    cy.contains('Stemmeintervju', { matchCase: false })
+    cy.contains('Kildedokument', { matchCase: false })
+    cy.contains('Last opp fil', { matchCase: false })
+  })
+})

--- a/frontend/homepage/openapi/openapi.json
+++ b/frontend/homepage/openapi/openapi.json
@@ -47,6 +47,10 @@
     {
       "name": "AI cost controls",
       "description": "AI cost controls"
+    },
+    {
+      "name": "Admin interview",
+      "description": "Voice interview practice with document context (ADMIN)"
     }
   ],
   "components": {
@@ -1037,6 +1041,156 @@
           "languageConsistencyExplanation": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "InterviewTranscriptResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionId": {
+            "type": "string"
+          },
+          "rawText": {
+            "type": "string"
+          },
+          "cleanedText": {
+            "type": "string"
+          },
+          "cleanStatus": {
+            "type": "string"
+          },
+          "ingestedDocumentId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cleanedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "InterviewSessionResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "voice": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transcriptId": {
+            "type": "string"
+          },
+          "cleanStatus": {
+            "type": "string"
+          },
+          "ingestedDocumentId": {
+            "type": "string"
+          },
+          "turns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InterviewTurnDto"
+            }
+          }
+        }
+      },
+      "CreateInterviewSessionRequest": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "voice": {
+            "type": "string"
+          }
+        }
+      },
+      "InterviewTurnBatchRequest": {
+        "type": "object",
+        "properties": {
+          "turns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InterviewTurnDto"
+            }
+          }
+        }
+      },
+      "InterviewDocumentResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "originalFilename": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "charCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "InterviewTextDocumentRequest": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          }
+        }
+      },
+      "InterviewTurnDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "sequenceNo": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       }
@@ -2546,6 +2700,523 @@
             "description": "No Content"
           }
         }
+      }
+    },
+    "/admin/tools/interview/transcripts/{id}/ingest": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Ingest cleaned transcript into vector store",
+        "operationId": "interviewTranscriptsIngest",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestionResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/transcripts/{id}/clean": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Clean transcript for knowledge-base ingest",
+        "operationId": "interviewTranscriptsClean",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewTranscriptResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/sessions": {
+      "get": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "List interview sessions",
+        "operationId": "interviewSessionsList",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InterviewSessionResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Create interview session",
+        "operationId": "createSession_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateInterviewSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewSessionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/sessions/{id}/turns": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Append transcript turns",
+        "operationId": "interviewSessionsAppendTurns",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InterviewTurnBatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/sessions/{id}/realtime/session": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Create admin interview Realtime WebRTC session",
+        "operationId": "interviewSessionsRealtimeSession",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Chat-Language",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Realtime-Model",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Realtime-Voice",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Realtime-Reasoning-Effort",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/sdp": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/sessions/{id}/finalize": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Finalize interview session and save raw transcript",
+        "operationId": "interviewSessionsFinalize",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewTranscriptResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/documents": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Upload interview source document",
+        "operationId": "interviewDocumentsUpload",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewDocumentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/documents/text": {
+      "post": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Create interview source document from pasted text",
+        "operationId": "interviewDocumentsCreateText",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InterviewTextDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewDocumentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/transcripts/{id}": {
+      "get": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Get transcript",
+        "operationId": "interviewTranscriptsGet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewTranscriptResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/sessions/{id}": {
+      "get": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Get interview session with turns",
+        "operationId": "interviewSessionsGet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewSessionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Soft-delete interview session",
+        "operationId": "interviewSessionsDelete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/tools/interview/documents/{id}": {
+      "get": {
+        "tags": [
+          "Admin interview"
+        ],
+        "summary": "Get interview source document metadata",
+        "operationId": "interviewDocumentsGet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/InterviewDocumentResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
       }
     }
   }

--- a/frontend/homepage/scripts/merge-interview-openapi.mjs
+++ b/frontend/homepage/scripts/merge-interview-openapi.mjs
@@ -1,0 +1,96 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dir = path.dirname(fileURLToPath(import.meta.url))
+const basePath = path.join(dir, '..', 'openapi', 'openapi.json')
+const exportPath = path.join(dir, '..', 'openapi', 'openapi-export-snapshot.json')
+
+const base = JSON.parse(fs.readFileSync(basePath, 'utf8'))
+const exported = JSON.parse(fs.readFileSync(exportPath, 'utf8'))
+
+const interviewPathPrefix = '/admin/tools/interview'
+
+const interviewPaths = Object.fromEntries(
+  Object.entries(exported.paths ?? {}).filter(([p]) => p.startsWith(interviewPathPrefix)),
+)
+
+function collectSchemaRefs(node, out) {
+  if (!node || typeof node !== 'object') return
+  if (typeof node.$ref === 'string' && node.$ref.startsWith('#/components/schemas/')) {
+    out.add(node.$ref.replace('#/components/schemas/', ''))
+  }
+  if (Array.isArray(node)) {
+    node.forEach((n) => collectSchemaRefs(n, out))
+    return
+  }
+  for (const v of Object.values(node)) collectSchemaRefs(v, out)
+}
+
+const exportedSchemas = exported.components?.schemas ?? {}
+const schemaNames = new Set()
+collectSchemaRefs(interviewPaths, schemaNames)
+
+const visited = new Set()
+const queue = [...schemaNames]
+while (queue.length > 0) {
+  const name = queue.shift()
+  if (visited.has(name)) continue
+  visited.add(name)
+  const extra = new Set()
+  collectSchemaRefs(exportedSchemas[name], extra)
+  for (const n of extra) {
+    schemaNames.add(n)
+    if (!visited.has(n)) queue.push(n)
+  }
+}
+
+base.components ??= { schemas: {} }
+base.components.schemas ??= {}
+
+for (const name of schemaNames) {
+  if (exportedSchemas[name]) {
+    base.components.schemas[name] = exportedSchemas[name]
+  }
+}
+
+base.paths = { ...base.paths, ...interviewPaths }
+
+base.tags ??= []
+if (!base.tags.some((t) => t.name === 'Admin interview')) {
+  base.tags.push({
+    name: 'Admin interview',
+    description: 'Voice interview practice with document context (ADMIN)',
+  })
+}
+
+const renameOps = {
+  uploadDocument: 'interviewDocumentsUpload',
+  createTextDocument: 'interviewDocumentsCreateText',
+  getDocument: 'interviewDocumentsGet',
+  createSession: 'interviewSessionsCreate',
+  listSessions: 'interviewSessionsList',
+  getSession: 'interviewSessionsGet',
+  appendTurns: 'interviewSessionsAppendTurns',
+  finalizeSession: 'interviewSessionsFinalize',
+  createRealtimeSession: 'interviewSessionsRealtimeSession',
+  getTranscript: 'interviewTranscriptsGet',
+  cleanTranscript: 'interviewTranscriptsClean',
+  ingestTranscript: 'interviewTranscriptsIngest',
+  deleteSession: 'interviewSessionsDelete',
+}
+
+for (const pathItem of Object.values(interviewPaths)) {
+  for (const op of Object.values(pathItem)) {
+    if (op && typeof op === 'object' && typeof op.operationId === 'string') {
+      const next = renameOps[op.operationId]
+      if (next) op.operationId = next
+      if (op.security == null) {
+        op.security = [{ basicAuth: [] }]
+      }
+    }
+  }
+}
+
+fs.writeFileSync(basePath, JSON.stringify(base, null, 2) + '\n')
+console.log(`Merged ${Object.keys(interviewPaths).length} interview paths and ${schemaNames.size} schemas`)

--- a/frontend/homepage/src/App.vue
+++ b/frontend/homepage/src/App.vue
@@ -19,6 +19,7 @@ const adminRouteNames = new Set([
   'admin-chunks',
   'admin-question-suggestions',
   'admin-prompts',
+  'admin-interview',
 ])
 const showPublicPageHeader = computed(() => !adminRouteNames.has(String(route.name ?? '')))
 

--- a/frontend/homepage/src/api/generated/portfolio.ts
+++ b/frontend/homepage/src/api/generated/portfolio.ts
@@ -431,6 +431,61 @@ export interface TranscribeResponse {
   text?: string;
 }
 
+export interface InterviewTranscriptResponse {
+  id?: string;
+  sessionId?: string;
+  rawText?: string;
+  cleanedText?: string;
+  cleanStatus?: string;
+  ingestedDocumentId?: string;
+  createdAt?: string;
+  cleanedAt?: string;
+}
+
+export interface InterviewTurnDto {
+  role?: string;
+  text?: string;
+  sequenceNo?: number;
+}
+
+export interface InterviewSessionResponse {
+  id?: string;
+  documentId?: string;
+  language?: string;
+  status?: string;
+  voice?: string;
+  startedAt?: string;
+  endedAt?: string;
+  transcriptId?: string;
+  cleanStatus?: string;
+  ingestedDocumentId?: string;
+  turns?: InterviewTurnDto[];
+}
+
+export interface CreateInterviewSessionRequest {
+  documentId?: string;
+  language?: string;
+  voice?: string;
+}
+
+export interface InterviewTurnBatchRequest {
+  turns?: InterviewTurnDto[];
+}
+
+export interface InterviewDocumentResponse {
+  id?: string;
+  originalFilename?: string;
+  mimeType?: string;
+  charCount?: number;
+  createdBy?: string;
+  createdAt?: string;
+}
+
+export interface InterviewTextDocumentRequest {
+  text?: string;
+  filename?: string;
+}
+
 export type AdminDocumentsUploadBody = {
   file: Blob;
   title?: string;
@@ -485,6 +540,16 @@ export type ExperimentsStartRun202 = {
 };
 
 export type AiAdminStatus200 = { [key: string]: unknown };
+
+export type InterviewTranscriptsIngestParams = {
+force?: boolean;
+};
+
+export type InterviewSessionsRealtimeSession200 = { [key: string]: unknown };
+
+export type InterviewDocumentsUploadBody = {
+  file: Blob;
+};
 
 export type authLoginResponse200 = {
   data: LoginResponse
@@ -2081,6 +2146,489 @@ export const authLogout = async ( options?: RequestInit): Promise<authLogoutResp
   {
     ...options,
     method: 'POST'
+
+
+  }
+);}
+
+
+
+export type interviewTranscriptsIngestResponse200 = {
+  data: IngestionResult
+  status: 200
+}
+
+export type interviewTranscriptsIngestResponseSuccess = (interviewTranscriptsIngestResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewTranscriptsIngestResponse = (interviewTranscriptsIngestResponseSuccess)
+
+export const getInterviewTranscriptsIngestUrl = (id: string,
+    params?: InterviewTranscriptsIngestParams,) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : String(value))
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0 ? `/admin/tools/interview/transcripts/${id}/ingest?${stringifiedParams}` : `/admin/tools/interview/transcripts/${id}/ingest`
+}
+
+/**
+ * @summary Ingest cleaned transcript into vector store
+ */
+export const interviewTranscriptsIngest = async (id: string,
+    params?: InterviewTranscriptsIngestParams, options?: RequestInit): Promise<interviewTranscriptsIngestResponse> => {
+
+  return customFetch<interviewTranscriptsIngestResponse>(getInterviewTranscriptsIngestUrl(id,params),
+  {
+    ...options,
+    method: 'POST'
+
+
+  }
+);}
+
+
+
+export type interviewTranscriptsCleanResponse200 = {
+  data: InterviewTranscriptResponse
+  status: 200
+}
+
+export type interviewTranscriptsCleanResponseSuccess = (interviewTranscriptsCleanResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewTranscriptsCleanResponse = (interviewTranscriptsCleanResponseSuccess)
+
+export const getInterviewTranscriptsCleanUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/transcripts/${id}/clean`
+}
+
+/**
+ * @summary Clean transcript for knowledge-base ingest
+ */
+export const interviewTranscriptsClean = async (id: string, options?: RequestInit): Promise<interviewTranscriptsCleanResponse> => {
+
+  return customFetch<interviewTranscriptsCleanResponse>(getInterviewTranscriptsCleanUrl(id),
+  {
+    ...options,
+    method: 'POST'
+
+
+  }
+);}
+
+
+
+export type interviewSessionsListResponse200 = {
+  data: InterviewSessionResponse[]
+  status: 200
+}
+
+export type interviewSessionsListResponseSuccess = (interviewSessionsListResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewSessionsListResponse = (interviewSessionsListResponseSuccess)
+
+export const getInterviewSessionsListUrl = () => {
+
+
+
+
+  return `/admin/tools/interview/sessions`
+}
+
+/**
+ * @summary List interview sessions
+ */
+export const interviewSessionsList = async ( options?: RequestInit): Promise<interviewSessionsListResponse> => {
+
+  return customFetch<interviewSessionsListResponse>(getInterviewSessionsListUrl(),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+export type createSession1Response200 = {
+  data: InterviewSessionResponse
+  status: 200
+}
+
+export type createSession1ResponseSuccess = (createSession1Response200) & {
+  headers: Headers;
+};
+;
+
+export type createSession1Response = (createSession1ResponseSuccess)
+
+export const getCreateSession1Url = () => {
+
+
+
+
+  return `/admin/tools/interview/sessions`
+}
+
+/**
+ * @summary Create interview session
+ */
+export const createSession1 = async (createInterviewSessionRequest: CreateInterviewSessionRequest, options?: RequestInit): Promise<createSession1Response> => {
+
+  return customFetch<createSession1Response>(getCreateSession1Url(),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(createInterviewSessionRequest)
+  }
+);}
+
+
+
+export type interviewSessionsAppendTurnsResponse200 = {
+  data: void
+  status: 200
+}
+
+export type interviewSessionsAppendTurnsResponseSuccess = (interviewSessionsAppendTurnsResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewSessionsAppendTurnsResponse = (interviewSessionsAppendTurnsResponseSuccess)
+
+export const getInterviewSessionsAppendTurnsUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/sessions/${id}/turns`
+}
+
+/**
+ * @summary Append transcript turns
+ */
+export const interviewSessionsAppendTurns = async (id: string,
+    interviewTurnBatchRequest: InterviewTurnBatchRequest, options?: RequestInit): Promise<interviewSessionsAppendTurnsResponse> => {
+
+  return customFetch<interviewSessionsAppendTurnsResponse>(getInterviewSessionsAppendTurnsUrl(id),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(interviewTurnBatchRequest)
+  }
+);}
+
+
+
+export type interviewSessionsRealtimeSessionResponse200 = {
+  data: InterviewSessionsRealtimeSession200
+  status: 200
+}
+
+export type interviewSessionsRealtimeSessionResponseSuccess = (interviewSessionsRealtimeSessionResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewSessionsRealtimeSessionResponse = (interviewSessionsRealtimeSessionResponseSuccess)
+
+export const getInterviewSessionsRealtimeSessionUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/sessions/${id}/realtime/session`
+}
+
+/**
+ * @summary Create admin interview Realtime WebRTC session
+ */
+export const interviewSessionsRealtimeSession = async (id: string,
+    interviewSessionsRealtimeSessionBody: string, options?: RequestInit): Promise<interviewSessionsRealtimeSessionResponse> => {
+
+  return customFetch<interviewSessionsRealtimeSessionResponse>(getInterviewSessionsRealtimeSessionUrl(id),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/sdp', ...options?.headers },
+    body: JSON.stringify(interviewSessionsRealtimeSessionBody)
+  }
+);}
+
+
+
+export type interviewSessionsFinalizeResponse200 = {
+  data: InterviewTranscriptResponse
+  status: 200
+}
+
+export type interviewSessionsFinalizeResponseSuccess = (interviewSessionsFinalizeResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewSessionsFinalizeResponse = (interviewSessionsFinalizeResponseSuccess)
+
+export const getInterviewSessionsFinalizeUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/sessions/${id}/finalize`
+}
+
+/**
+ * @summary Finalize interview session and save raw transcript
+ */
+export const interviewSessionsFinalize = async (id: string, options?: RequestInit): Promise<interviewSessionsFinalizeResponse> => {
+
+  return customFetch<interviewSessionsFinalizeResponse>(getInterviewSessionsFinalizeUrl(id),
+  {
+    ...options,
+    method: 'POST'
+
+
+  }
+);}
+
+
+
+export type interviewDocumentsUploadResponse200 = {
+  data: InterviewDocumentResponse
+  status: 200
+}
+
+export type interviewDocumentsUploadResponseSuccess = (interviewDocumentsUploadResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewDocumentsUploadResponse = (interviewDocumentsUploadResponseSuccess)
+
+export const getInterviewDocumentsUploadUrl = () => {
+
+
+
+
+  return `/admin/tools/interview/documents`
+}
+
+/**
+ * @summary Upload interview source document
+ */
+export const interviewDocumentsUpload = async (interviewDocumentsUploadBody?: InterviewDocumentsUploadBody, options?: RequestInit): Promise<interviewDocumentsUploadResponse> => {
+    const formData = new FormData();
+if(interviewDocumentsUploadBody?.file !== undefined) {
+ formData.append(`file`, interviewDocumentsUploadBody.file);
+ }
+
+  return customFetch<interviewDocumentsUploadResponse>(getInterviewDocumentsUploadUrl(),
+  {
+    ...options,
+    method: 'POST'
+    ,
+    body: formData
+  }
+);}
+
+
+
+export type interviewDocumentsCreateTextResponse200 = {
+  data: InterviewDocumentResponse
+  status: 200
+}
+
+export type interviewDocumentsCreateTextResponseSuccess = (interviewDocumentsCreateTextResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewDocumentsCreateTextResponse = (interviewDocumentsCreateTextResponseSuccess)
+
+export const getInterviewDocumentsCreateTextUrl = () => {
+
+
+
+
+  return `/admin/tools/interview/documents/text`
+}
+
+/**
+ * @summary Create interview source document from pasted text
+ */
+export const interviewDocumentsCreateText = async (interviewTextDocumentRequest: InterviewTextDocumentRequest, options?: RequestInit): Promise<interviewDocumentsCreateTextResponse> => {
+
+  return customFetch<interviewDocumentsCreateTextResponse>(getInterviewDocumentsCreateTextUrl(),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(interviewTextDocumentRequest)
+  }
+);}
+
+
+
+export type interviewTranscriptsGetResponse200 = {
+  data: InterviewTranscriptResponse
+  status: 200
+}
+
+export type interviewTranscriptsGetResponseSuccess = (interviewTranscriptsGetResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewTranscriptsGetResponse = (interviewTranscriptsGetResponseSuccess)
+
+export const getInterviewTranscriptsGetUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/transcripts/${id}`
+}
+
+/**
+ * @summary Get transcript
+ */
+export const interviewTranscriptsGet = async (id: string, options?: RequestInit): Promise<interviewTranscriptsGetResponse> => {
+
+  return customFetch<interviewTranscriptsGetResponse>(getInterviewTranscriptsGetUrl(id),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+export type interviewSessionsGetResponse200 = {
+  data: InterviewSessionResponse
+  status: 200
+}
+
+export type interviewSessionsGetResponseSuccess = (interviewSessionsGetResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewSessionsGetResponse = (interviewSessionsGetResponseSuccess)
+
+export const getInterviewSessionsGetUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/sessions/${id}`
+}
+
+/**
+ * @summary Get interview session with turns
+ */
+export const interviewSessionsGet = async (id: string, options?: RequestInit): Promise<interviewSessionsGetResponse> => {
+
+  return customFetch<interviewSessionsGetResponse>(getInterviewSessionsGetUrl(id),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+export type interviewSessionsDeleteResponse200 = {
+  data: void
+  status: 200
+}
+
+export type interviewSessionsDeleteResponseSuccess = (interviewSessionsDeleteResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewSessionsDeleteResponse = (interviewSessionsDeleteResponseSuccess)
+
+export const getInterviewSessionsDeleteUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/sessions/${id}`
+}
+
+/**
+ * @summary Soft-delete interview session
+ */
+export const interviewSessionsDelete = async (id: string, options?: RequestInit): Promise<interviewSessionsDeleteResponse> => {
+
+  return customFetch<interviewSessionsDeleteResponse>(getInterviewSessionsDeleteUrl(id),
+  {
+    ...options,
+    method: 'DELETE'
+
+
+  }
+);}
+
+
+
+export type interviewDocumentsGetResponse200 = {
+  data: InterviewDocumentResponse
+  status: 200
+}
+
+export type interviewDocumentsGetResponseSuccess = (interviewDocumentsGetResponse200) & {
+  headers: Headers;
+};
+;
+
+export type interviewDocumentsGetResponse = (interviewDocumentsGetResponseSuccess)
+
+export const getInterviewDocumentsGetUrl = (id: string,) => {
+
+
+
+
+  return `/admin/tools/interview/documents/${id}`
+}
+
+/**
+ * @summary Get interview source document metadata
+ */
+export const interviewDocumentsGet = async (id: string, options?: RequestInit): Promise<interviewDocumentsGetResponse> => {
+
+  return customFetch<interviewDocumentsGetResponse>(getInterviewDocumentsGetUrl(id),
+  {
+    ...options,
+    method: 'GET'
 
 
   }

--- a/frontend/homepage/src/composables/__tests__/useInterviewVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useInterviewVoice.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useInterviewVoice } from '../useInterviewVoice'
+
+vi.mock('@/lib/interview-voice', () => ({
+  appendInterviewTurns: vi.fn().mockResolvedValue(undefined),
+  exchangeInterviewRealtimeSdp: vi.fn(),
+}))
+
+vi.mock('@/composables/useRealtimeVoice', () => ({
+  useRealtimeVoice: vi.fn((_lang, _opts, _model, voiceOptions) => {
+    voiceOptions?.onTurnCommitted?.('user', 'hello')
+    return {
+      connectionState: ref('idle'),
+      errorMessage: ref(''),
+      sessionNotice: ref(''),
+      assistantTranscript: ref(''),
+      userTranscript: ref(''),
+      isModelSpeaking: ref(false),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      stopResponse: vi.fn(),
+      maxSessionMs: 180_000,
+    }
+  }),
+}))
+
+describe('useInterviewVoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('accumulates committed turns from realtime callbacks', async () => {
+    const sessionId = ref('sess-1')
+    const lang = ref<'en' | 'no'>('no')
+    const { committedTurns } = useInterviewVoice(sessionId, lang)
+    await nextTick()
+    expect(committedTurns.value).toHaveLength(1)
+    expect(committedTurns.value[0]?.role).toBe('user')
+    expect(committedTurns.value[0]?.text).toBe('hello')
+  })
+})

--- a/frontend/homepage/src/composables/useInterviewVoice.ts
+++ b/frontend/homepage/src/composables/useInterviewVoice.ts
@@ -1,0 +1,90 @@
+import { ref, type Ref } from 'vue'
+import type { RealtimeVoiceModelOption, RealtimeVoiceSessionOptions, SpeechUiLang } from '@/lib/realtime-voice'
+import { useRealtimeVoice } from '@/composables/useRealtimeVoice'
+import { appendInterviewTurns, exchangeInterviewRealtimeSdp, type InterviewTurn } from '@/lib/interview-voice'
+
+const SAVE_DEBOUNCE_MS = 8_000
+
+export function useInterviewVoice(
+  sessionId: Ref<string | null>,
+  language: Ref<SpeechUiLang>,
+  sessionOptions?: Readonly<Ref<RealtimeVoiceSessionOptions>>,
+  selectedModel?: Readonly<Ref<RealtimeVoiceModelOption | undefined>>,
+) {
+  const committedTurns = ref<InterviewTurn[]>([])
+  const pendingTurns = ref<InterviewTurn[]>([])
+  let sequenceCounter = 0
+  let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleSave() {
+    if (saveTimer !== null) clearTimeout(saveTimer)
+    saveTimer = setTimeout(() => {
+      void flushTurns()
+    }, SAVE_DEBOUNCE_MS)
+  }
+
+  async function flushTurns() {
+    const sid = sessionId.value
+    if (!sid || pendingTurns.value.length === 0) return
+    const batch = [...pendingTurns.value]
+    pendingTurns.value = []
+    try {
+      await appendInterviewTurns(sid, batch)
+    } catch {
+      pendingTurns.value = [...batch, ...pendingTurns.value]
+    }
+  }
+
+  function onTurnCommitted(role: 'user' | 'interviewer', text: string) {
+    const turn: InterviewTurn = {
+      role,
+      text,
+      sequenceNo: sequenceCounter++,
+    }
+    committedTurns.value = [...committedTurns.value, turn]
+    pendingTurns.value = [...pendingTurns.value, turn]
+    scheduleSave()
+  }
+
+  const voice = useRealtimeVoice(language, sessionOptions, selectedModel, {
+    onTurnCommitted,
+    exchangeSdp: (offerSdp, lang, opts, modelId) => {
+      const sid = sessionId.value
+      if (!sid) {
+        return Promise.resolve({
+          ok: false as const,
+          status: 400,
+          message: 'Missing interview session',
+        })
+      }
+      return exchangeInterviewRealtimeSdp(sid, offerSdp, lang, opts, modelId)
+    },
+  })
+
+  async function disconnectAndFlush() {
+    voice.disconnect()
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+    await flushTurns()
+  }
+
+  function resetTurns() {
+    committedTurns.value = []
+    pendingTurns.value = []
+    sequenceCounter = 0
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+  }
+
+  return {
+    ...voice,
+    committedTurns,
+    disconnectAndFlush,
+    flushTurns,
+    resetTurns,
+  }
+}

--- a/frontend/homepage/src/composables/useRealtimeVoice.ts
+++ b/frontend/homepage/src/composables/useRealtimeVoice.ts
@@ -51,6 +51,18 @@ function isLikelyGetUserMediaError(e: unknown): boolean {
   )
 }
 
+export type RealtimeTurnRole = 'user' | 'interviewer'
+
+export type UseRealtimeVoiceOptions = {
+  exchangeSdp?: (
+    offerSdp: string,
+    lang: SpeechUiLang,
+    sessionOpts?: RealtimeVoiceSessionOptions,
+    modelId?: string,
+  ) => Promise<{ ok: true; answerSdp: string } | RealtimeSdpFailure>
+  onTurnCommitted?: (role: RealtimeTurnRole, text: string) => void
+}
+
 /** Wait until ICE candidates are gathered (or timeout) so the SDP posted to the server includes candidates. */
 const ICE_GATHERING_TIMEOUT_MS = 8000
 const LIVE_LOOKUP_TIMEOUT_MS = 8_000
@@ -142,6 +154,7 @@ export function useRealtimeVoice(
   language: Ref<SpeechUiLang>,
   sessionOptions?: Readonly<Ref<RealtimeVoiceSessionOptions>>,
   selectedModel?: Readonly<Ref<RealtimeVoiceModelOption | undefined>>,
+  voiceOptions?: UseRealtimeVoiceOptions,
 ) {
   const connectionState = ref<RealtimeConnectionState>('idle')
   const errorMessage = ref('')
@@ -376,6 +389,10 @@ export function useRealtimeVoice(
       }
       if (t === 'response.output_audio_transcript.done' && typeof ev.transcript === 'string') {
         assistantTranscript.value = ev.transcript
+        const trimmed = ev.transcript.trim()
+        if (trimmed !== '') {
+          voiceOptions?.onTurnCommitted?.('interviewer', trimmed)
+        }
         return
       }
       if (t === 'conversation.item.input_audio_transcription.delta' && typeof ev.delta === 'string') {
@@ -387,6 +404,10 @@ export function useRealtimeVoice(
         typeof ev.transcript === 'string'
       ) {
         userTranscript.value = ev.transcript
+        const trimmed = ev.transcript.trim()
+        if (trimmed !== '') {
+          voiceOptions?.onTurnCommitted?.('user', trimmed)
+        }
       }
     } catch {
       /* ignore malformed */
@@ -463,7 +484,11 @@ export function useRealtimeVoice(
         throw new Error('Missing local SDP')
       }
 
-      const result = await exchangeRealtimeSdp(offerSdp, language.value, sessionOptions?.value, selectedModelId())
+      const exchange =
+        voiceOptions?.exchangeSdp ??
+        ((sdp: string, lang: SpeechUiLang, opts?: RealtimeVoiceSessionOptions, modelId?: string) =>
+          exchangeRealtimeSdp(sdp, lang, opts, modelId))
+      const result = await exchange(offerSdp, language.value, sessionOptions?.value, selectedModelId())
       if (!result.ok) {
         throw new Error(mapSdpFailureToUserMessage(language.value, result))
       }

--- a/frontend/homepage/src/lib/__tests__/interview-voice.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/interview-voice.spec.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCustomFetch = vi.hoisted(() => vi.fn())
+
+vi.mock('@/api/orval-mutator', () => ({
+  customFetch: mockCustomFetch,
+}))
+
+describe('interview-voice', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockCustomFetch.mockReset()
+  })
+
+  it('uploadInterviewDocument posts FormData and returns document', async () => {
+    const doc = {
+      id: 'doc1',
+      originalFilename: 'cv.pdf',
+      mimeType: 'application/pdf',
+      charCount: 42,
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    mockCustomFetch.mockResolvedValue({ status: 200, data: doc })
+
+    const { uploadInterviewDocument } = await import('../interview-voice')
+    const file = new File(['hello'], 'cv.pdf', { type: 'application/pdf' })
+
+    await expect(uploadInterviewDocument(file)).resolves.toEqual(doc)
+
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/documents', {
+      method: 'POST',
+      body: expect.any(FormData),
+    })
+  })
+
+  it('uploadInterviewDocument throws on non-200', async () => {
+    mockCustomFetch.mockResolvedValue({ status: 400, data: {} })
+    const { uploadInterviewDocument } = await import('../interview-voice')
+    const file = new File(['x'], 'cv.pdf')
+
+    await expect(uploadInterviewDocument(file)).rejects.toThrow('Upload failed (400)')
+  })
+
+  it('createInterviewTextDocument posts JSON body', async () => {
+    const doc = {
+      id: 'doc2',
+      originalFilename: 'notes.md',
+      charCount: 10,
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    mockCustomFetch.mockResolvedValue({ status: 200, data: doc })
+
+    const { createInterviewTextDocument } = await import('../interview-voice')
+    await expect(createInterviewTextDocument('hello world', 'notes.md')).resolves.toEqual(doc)
+
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/documents/text', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'hello world', filename: 'notes.md' }),
+    })
+  })
+
+  it('createInterviewSession posts documentId language and voice', async () => {
+    const session = {
+      id: 'sess1',
+      documentId: 'doc1',
+      language: 'no',
+      status: 'ACTIVE',
+      startedAt: '2026-01-01T00:00:00Z',
+    }
+    mockCustomFetch.mockResolvedValue({ status: 200, data: session })
+
+    const { createInterviewSession } = await import('../interview-voice')
+    await expect(createInterviewSession('doc1', 'no', 'cedar')).resolves.toEqual(session)
+
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ documentId: 'doc1', language: 'no', voice: 'cedar' }),
+    })
+  })
+
+  it('appendInterviewTurns posts turn batch', async () => {
+    mockCustomFetch.mockResolvedValue({ status: 200 })
+    const { appendInterviewTurns } = await import('../interview-voice')
+
+    await appendInterviewTurns('sess1', [
+      { role: 'interviewer', text: 'Hello?', sequenceNo: 0 },
+      { role: 'user', text: 'Hi', sequenceNo: 1 },
+    ])
+
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/sessions/sess1/turns', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        turns: [
+          { role: 'interviewer', text: 'Hello?', sequenceNo: 0 },
+          { role: 'user', text: 'Hi', sequenceNo: 1 },
+        ],
+      }),
+    })
+  })
+
+  it('finalizeInterviewTranscript returns transcript', async () => {
+    const transcript = {
+      id: 'tr1',
+      sessionId: 'sess1',
+      cleanStatus: 'PENDING',
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    mockCustomFetch.mockResolvedValue({ status: 200, data: transcript })
+
+    const { finalizeInterviewSession } = await import('../interview-voice')
+    await expect(finalizeInterviewSession('sess1')).resolves.toEqual(transcript)
+  })
+
+  it('cleanInterviewTranscript returns cleaned transcript', async () => {
+    const transcript = {
+      id: 'tr1',
+      sessionId: 'sess1',
+      cleanedText: 'clean',
+      cleanStatus: 'CLEANED',
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    mockCustomFetch.mockResolvedValue({ status: 200, data: transcript })
+
+    const { cleanInterviewTranscript } = await import('../interview-voice')
+    await expect(cleanInterviewTranscript('tr1')).resolves.toEqual(transcript)
+  })
+
+  it('ingestInterviewTranscript appends force query when requested', async () => {
+    mockCustomFetch.mockResolvedValue({ status: 200, data: { documentId: 'ing1' } })
+
+    const { ingestInterviewTranscript } = await import('../interview-voice')
+    await expect(ingestInterviewTranscript('tr1', true)).resolves.toEqual({ documentId: 'ing1' })
+
+    expect(mockCustomFetch).toHaveBeenCalledWith(
+      '/admin/tools/interview/transcripts/tr1/ingest?force=true',
+      { method: 'POST' },
+    )
+  })
+
+  it('exchangeInterviewRealtimeSdp returns SDP answer on success', async () => {
+    mockCustomFetch.mockResolvedValue({ status: 201, data: 'v=0 SDP_ANSWER' })
+    const { exchangeInterviewRealtimeSdp } = await import('../interview-voice')
+
+    await expect(exchangeInterviewRealtimeSdp('sess1', 'offer', 'en')).resolves.toEqual({
+      ok: true,
+      answerSdp: 'v=0 SDP_ANSWER',
+    })
+
+    const init = mockCustomFetch.mock.calls[0][1] as RequestInit & { headers: Record<string, string> }
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/sdp')
+    expect(init.headers['X-Chat-Language']).toBe('en')
+    expect(init.headers['X-Realtime-Voice']).toBe('marin')
+    expect(init.headers['X-Realtime-Reasoning-Effort']).toBe('low')
+    expect(init.body).toBe('offer')
+  })
+
+  it('exchangeInterviewRealtimeSdp sends selected voice reasoning and model', async () => {
+    mockCustomFetch.mockResolvedValue({ status: 200, data: 'v=0' })
+    const { exchangeInterviewRealtimeSdp } = await import('../interview-voice')
+
+    await exchangeInterviewRealtimeSdp(
+      'sess1',
+      'offer',
+      'no',
+      { voice: 'cedar', reasoningEffort: 'high' },
+      'gpt-realtime-2',
+    )
+
+    const init = mockCustomFetch.mock.calls[0][1] as RequestInit & { headers: Record<string, string> }
+    expect(init.headers['X-Chat-Language']).toBe('no')
+    expect(init.headers['X-Realtime-Voice']).toBe('cedar')
+    expect(init.headers['X-Realtime-Reasoning-Effort']).toBe('high')
+    expect(init.headers['X-Realtime-Model']).toBe('gpt-realtime-2')
+  })
+
+  it('exchangeInterviewRealtimeSdp returns failure with parsed error', async () => {
+    mockCustomFetch.mockResolvedValue({
+      status: 503,
+      data: { error: 'offline', code: 'CIRCUIT_OPEN' },
+    })
+    const { exchangeInterviewRealtimeSdp } = await import('../interview-voice')
+
+    await expect(exchangeInterviewRealtimeSdp('sess1', 'offer', 'no')).resolves.toEqual({
+      ok: false,
+      status: 503,
+      message: 'offline',
+      code: 'CIRCUIT_OPEN',
+    })
+  })
+
+  it('exchangeInterviewRealtimeSdp surfaces HTTP code when error body lacks error field', async () => {
+    mockCustomFetch.mockResolvedValue({ status: 400, data: {} })
+    const { exchangeInterviewRealtimeSdp } = await import('../interview-voice')
+
+    await expect(exchangeInterviewRealtimeSdp('sess1', 'offer', 'en')).resolves.toMatchObject({
+      ok: false,
+      status: 400,
+      message: 'HTTP 400',
+    })
+  })
+})

--- a/frontend/homepage/src/lib/interview-voice.ts
+++ b/frontend/homepage/src/lib/interview-voice.ts
@@ -1,0 +1,171 @@
+import { customFetch } from '@/api/orval-mutator'
+import type {
+  SpeechUiLang,
+  RealtimeVoiceSessionOptions,
+  RealtimeSdpFailure,
+  RealtimeVoiceChoice,
+  RealtimeReasoningEffort,
+} from '@/lib/realtime-voice'
+
+const DEFAULT_REALTIME_VOICE: RealtimeVoiceChoice = 'marin'
+const DEFAULT_REALTIME_REASONING_EFFORT: RealtimeReasoningEffort = 'low'
+
+export type InterviewTurn = {
+  role: 'user' | 'interviewer'
+  text: string
+  sequenceNo: number
+}
+
+export type InterviewDocument = {
+  id: string
+  originalFilename: string
+  mimeType?: string
+  charCount: number
+  createdBy?: string
+  createdAt: string
+}
+
+export type InterviewSession = {
+  id: string
+  documentId: string
+  language: string
+  status: string
+  voice?: string
+  startedAt: string
+  endedAt?: string
+  transcriptId?: string
+  cleanStatus?: string
+  ingestedDocumentId?: string
+  turns?: InterviewTurn[]
+}
+
+export type InterviewTranscript = {
+  id: string
+  sessionId: string
+  rawText?: string
+  cleanedText?: string
+  cleanStatus: string
+  ingestedDocumentId?: string
+  createdAt: string
+  cleanedAt?: string
+}
+
+export async function uploadInterviewDocument(file: File): Promise<InterviewDocument> {
+  const form = new FormData()
+  form.append('file', file)
+  const r = await customFetch<{ data: InterviewDocument; status: number }>(
+    '/admin/tools/interview/documents',
+    { method: 'POST', body: form },
+  )
+  if (r.status !== 200) throw new Error(`Upload failed (${r.status})`)
+  return r.data
+}
+
+export async function createInterviewTextDocument(text: string, filename?: string): Promise<InterviewDocument> {
+  const r = await customFetch<{ data: InterviewDocument; status: number }>(
+    '/admin/tools/interview/documents/text',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, filename }),
+    },
+  )
+  if (r.status !== 200) throw new Error(`Create document failed (${r.status})`)
+  return r.data
+}
+
+export async function createInterviewSession(
+  documentId: string,
+  language: SpeechUiLang,
+  voice?: string,
+): Promise<InterviewSession> {
+  const r = await customFetch<{ data: InterviewSession; status: number }>('/admin/tools/interview/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ documentId, language, voice }),
+  })
+  if (r.status !== 200) throw new Error(`Create session failed (${r.status})`)
+  return r.data
+}
+
+export async function appendInterviewTurns(sessionId: string, turns: InterviewTurn[]): Promise<void> {
+  const r = await customFetch<{ status: number }>(`/admin/tools/interview/sessions/${sessionId}/turns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      turns: turns.map((t) => ({ role: t.role, text: t.text, sequenceNo: t.sequenceNo })),
+    }),
+  })
+  if (r.status !== 200) throw new Error(`Save turns failed (${r.status})`)
+}
+
+export async function finalizeInterviewSession(sessionId: string): Promise<InterviewTranscript> {
+  const r = await customFetch<{ data: InterviewTranscript; status: number }>(
+    `/admin/tools/interview/sessions/${sessionId}/finalize`,
+    { method: 'POST' },
+  )
+  if (r.status !== 200) throw new Error(`Finalize failed (${r.status})`)
+  return r.data
+}
+
+export async function cleanInterviewTranscript(transcriptId: string): Promise<InterviewTranscript> {
+  const r = await customFetch<{ data: InterviewTranscript; status: number }>(
+    `/admin/tools/interview/transcripts/${transcriptId}/clean`,
+    { method: 'POST' },
+  )
+  if (r.status !== 200) throw new Error(`Clean failed (${r.status})`)
+  return r.data
+}
+
+export async function ingestInterviewTranscript(transcriptId: string, force = false): Promise<unknown> {
+  const q = force ? '?force=true' : ''
+  const r = await customFetch<{ data: unknown; status: number }>(
+    `/admin/tools/interview/transcripts/${transcriptId}/ingest${q}`,
+    { method: 'POST' },
+  )
+  if (r.status !== 200) throw new Error(`Ingest failed (${r.status})`)
+  return r.data
+}
+
+export async function exchangeInterviewRealtimeSdp(
+  sessionId: string,
+  offerSdp: string,
+  language: SpeechUiLang,
+  options?: Partial<RealtimeVoiceSessionOptions>,
+  modelId?: string,
+): Promise<{ ok: true; answerSdp: string } | RealtimeSdpFailure> {
+  const voice =
+    options?.voice === 'marin' || options?.voice === 'cedar' ? options.voice : DEFAULT_REALTIME_VOICE
+  const reasoning =
+    options?.reasoningEffort === 'low' ||
+    options?.reasoningEffort === 'medium' ||
+    options?.reasoningEffort === 'high'
+      ? options.reasoningEffort
+      : DEFAULT_REALTIME_REASONING_EFFORT
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/sdp',
+    'X-Chat-Language': language,
+    'X-Realtime-Voice': voice,
+    'X-Realtime-Reasoning-Effort': reasoning,
+  }
+  if (modelId && modelId.trim() !== '') {
+    headers['X-Realtime-Model'] = modelId.trim()
+  }
+  const r = await customFetch<{ data: unknown; status: number; headers?: Headers }>(
+    `/admin/tools/interview/sessions/${sessionId}/realtime/session`,
+    { method: 'POST', body: offerSdp, headers },
+  )
+  if (r.status >= 200 && r.status < 300 && typeof r.data === 'string') {
+    return { ok: true, answerSdp: r.data }
+  }
+  let msg = ''
+  let code: string | undefined
+  if (r.data && typeof r.data === 'object' && r.data !== null && 'error' in r.data) {
+    msg = String((r.data as { error?: unknown }).error ?? '')
+  }
+  const obj = r.data && typeof r.data === 'object' && r.data !== null ? (r.data as { code?: unknown }) : null
+  if (obj && 'code' in obj && obj.code != null && String(obj.code).trim() !== '') {
+    code = String(obj.code)
+  }
+  return { ok: false, status: r.status, message: msg || `HTTP ${r.status}`, ...(code ? { code } : {}) }
+}

--- a/frontend/homepage/src/router/createPortfolioRouter.ts
+++ b/frontend/homepage/src/router/createPortfolioRouter.ts
@@ -132,6 +132,12 @@ export function createPortfolioRouter(opts?: PortfolioRouterOptions): Router {
 				meta: { requiresAdmin: true },
 				component: () => import('../views/AdminExperimentsView.vue'),
 			},
+			{
+				path: '/admin/interview',
+				name: 'admin-interview',
+				meta: { requiresAdmin: true },
+				component: () => import('../views/AdminInterviewView.vue'),
+			},
 		],
 	})
 

--- a/frontend/homepage/src/views/AdminInterviewView.vue
+++ b/frontend/homepage/src/views/AdminInterviewView.vue
@@ -1,0 +1,390 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { RouterLink } from 'vue-router'
+import { Loader2, Mic, MicOff, Square } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
+import { useVoiceModelStore } from '@/stores/voice-model'
+import { useInterviewVoice } from '@/composables/useInterviewVoice'
+import {
+  fetchRealtimeVoiceStatus,
+  type RealtimeReasoningEffort,
+  type RealtimeVoiceChoice,
+} from '@/lib/realtime-voice'
+import {
+  cleanInterviewTranscript,
+  createInterviewSession,
+  createInterviewTextDocument,
+  finalizeInterviewSession,
+  ingestInterviewTranscript,
+  uploadInterviewDocument,
+  type InterviewDocument,
+  type InterviewTranscript,
+} from '@/lib/interview-voice'
+
+type WizardStep = 'source' | 'interview' | 'transcript' | 'clean'
+
+const auth = useAuthStore()
+const voiceModelStore = useVoiceModelStore()
+
+const step = ref<WizardStep>('source')
+const uiLang = ref<'en' | 'no'>('no')
+const pastedText = ref('')
+const pasteFilename = ref('interview-source.md')
+const busy = ref(false)
+const error = ref('')
+const status = ref('')
+
+const document = ref<InterviewDocument | null>(null)
+const sessionId = ref<string | null>(null)
+const transcript = ref<InterviewTranscript | null>(null)
+
+const liveAvailable = ref<boolean | null>(null)
+const selectedVoice = ref<RealtimeVoiceChoice>('marin')
+const selectedReasoning = ref<RealtimeReasoningEffort>('low')
+
+const sessionOptions = computed(() => ({
+  voice: selectedVoice.value,
+  reasoningEffort: selectedReasoning.value,
+}))
+const selectedVoiceModel = computed(() => voiceModelStore.selectedModel)
+
+const {
+  connectionState,
+  errorMessage,
+  sessionNotice,
+  assistantTranscript,
+  userTranscript,
+  isModelSpeaking,
+  committedTurns,
+  connect,
+  disconnectAndFlush,
+  stopResponse,
+  resetTurns,
+  flushTurns,
+} = useInterviewVoice(sessionId, uiLang, sessionOptions, selectedVoiceModel)
+
+const copy = computed(() => {
+  const en = uiLang.value === 'en'
+  return {
+    title: en ? 'Voice interview (about you)' : 'Stemmeintervju (om deg)',
+    source: en ? '1. Source document' : '1. Kildedokument',
+    interview: en ? '2. Live interview' : '2. Live intervju',
+    transcript: en ? '3. Transcript' : '3. Transkript',
+    clean: en ? '4. Clean & ingest' : '4. Rens og ingest',
+    upload: en ? 'Upload file' : 'Last opp fil',
+    paste: en ? 'Or paste text' : 'Eller lim inn tekst',
+    lang: en ? 'Interview language' : 'Intervjuspråk',
+    start: en ? 'Start interview' : 'Start intervju',
+    connect: en ? 'Connect microphone' : 'Koble til mikrofon',
+    disconnect: en ? 'End voice session' : 'Avslutt stemme',
+    finalize: en ? 'Save transcript' : 'Lagre transkript',
+    cleanBtn: en ? 'Clean transcript' : 'Rens transkript',
+    ingest: en ? 'Add to knowledge base' : 'Legg til i kontekstbase',
+    raw: en ? 'Raw transcript' : 'Rått transkript',
+    cleaned: en ? 'Cleaned document' : 'Renset dokument',
+  }
+})
+
+onMounted(async () => {
+  auth.restore()
+  const statusRes = await fetchRealtimeVoiceStatus()
+  liveAvailable.value = statusRes.liveEnabled && (await voiceModelStore.ensureModelsLoaded(), voiceModelStore.hasModels)
+  selectedVoice.value = statusRes.voice
+  selectedReasoning.value = statusRes.reasoningEffort
+})
+
+watch(errorMessage, (msg) => {
+  if (msg.trim() !== '') error.value = msg
+})
+
+async function handleFileUpload(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  busy.value = true
+  error.value = ''
+  try {
+    document.value = await uploadInterviewDocument(file)
+    status.value = `Dokument lagret (${document.value.charCount} tegn)`
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Upload failed'
+  } finally {
+    busy.value = false
+    input.value = ''
+  }
+}
+
+async function handlePasteDocument() {
+  if (!pastedText.value.trim()) return
+  busy.value = true
+  error.value = ''
+  try {
+    document.value = await createInterviewTextDocument(pastedText.value.trim(), pasteFilename.value)
+    status.value = `Tekst lagret (${document.value.charCount} tegn)`
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Create failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function startInterview() {
+  if (!document.value) return
+  busy.value = true
+  error.value = ''
+  try {
+    const session = await createInterviewSession(document.value.id, uiLang.value, selectedVoice.value)
+    sessionId.value = session.id
+    resetTurns()
+    step.value = 'interview'
+    status.value = 'Sesjon opprettet'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Session failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function goToTranscriptStep() {
+  await disconnectAndFlush()
+  step.value = 'transcript'
+}
+
+async function saveTranscript() {
+  if (!sessionId.value) return
+  busy.value = true
+  error.value = ''
+  try {
+    await flushTurns()
+    transcript.value = await finalizeInterviewSession(sessionId.value)
+    step.value = 'clean'
+    status.value = 'Transkript lagret'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Finalize failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function runClean() {
+  if (!transcript.value) return
+  busy.value = true
+  error.value = ''
+  try {
+    transcript.value = await cleanInterviewTranscript(transcript.value.id)
+    status.value = 'Transkript renset'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Clean failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function runIngest() {
+  if (!transcript.value) return
+  if (!confirm(uiLang.value === 'en' ? 'Add cleaned transcript to the knowledge base?' : 'Legge renset transkript til i kontekstbasen?')) {
+    return
+  }
+  busy.value = true
+  error.value = ''
+  try {
+    const result = await ingestInterviewTranscript(transcript.value.id, false)
+    status.value = `Ingest fullført: ${JSON.stringify(result)}`
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Ingest failed'
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-[hsl(220_20%_97%)] text-[hsl(220_25%_10%)] font-sans antialiased pb-12">
+    <nav
+      class="border-b border-gray-200/80 bg-white/90 backdrop-blur-sm px-4 py-3 text-sm flex flex-wrap gap-x-4 gap-y-1 items-center max-w-3xl mx-auto"
+    >
+      <RouterLink to="/" class="text-blue-600 hover:underline">Hjem</RouterLink>
+      <span class="text-gray-500">/</span>
+      <RouterLink to="/admin/tools" class="text-blue-600 hover:underline">Internal tools</RouterLink>
+      <span class="text-gray-500">/</span>
+      <strong class="text-gray-900">{{ copy.title }}</strong>
+    </nav>
+
+    <main id="main-content" class="mx-auto max-w-3xl px-4 pt-8">
+      <h1 class="text-2xl font-semibold tracking-tight text-gray-900 mb-2">{{ copy.title }}</h1>
+      <p class="text-sm text-gray-600 mb-6">
+        Last opp et dokument om deg, bli intervjuet med stemme, lagre transkriptet, rens det og legg det til i RAG.
+      </p>
+
+      <p v-if="status" class="text-sm text-green-700 mb-4">{{ status }}</p>
+      <p v-if="error" class="text-sm text-red-700 mb-4">{{ error }}</p>
+
+      <section v-if="step === 'source'" class="space-y-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-semibold">{{ copy.source }}</h2>
+
+        <div>
+          <label class="block text-sm font-medium mb-1">{{ copy.lang }}</label>
+          <select v-model="uiLang" class="border rounded px-2 py-1 text-sm">
+            <option value="no">Norsk</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium mb-1">{{ copy.upload }}</label>
+          <input type="file" accept=".pdf,.txt,.md,.doc,.docx" class="text-sm" @change="handleFileUpload" />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium mb-1">{{ copy.paste }}</label>
+          <input v-model="pasteFilename" class="border rounded px-2 py-1 text-sm mb-2 w-full max-w-xs" />
+          <textarea
+            v-model="pastedText"
+            rows="8"
+            class="w-full border rounded p-2 text-sm font-mono"
+            placeholder="Lim inn CV, notater eller annet stoff om deg…"
+          />
+          <button
+            type="button"
+            class="mt-2 rounded bg-gray-800 text-white px-3 py-1.5 text-sm disabled:opacity-50"
+            :disabled="busy || !pastedText.trim()"
+            @click="handlePasteDocument"
+          >
+            Lagre tekst
+          </button>
+        </div>
+
+        <p v-if="document" class="text-sm text-gray-700">
+          Aktivt dokument: <code class="bg-gray-100 px-1 rounded">{{ document.originalFilename }}</code>
+          ({{ document.charCount }} tegn)
+        </p>
+
+        <button
+          type="button"
+          class="rounded bg-blue-600 text-white px-4 py-2 text-sm font-medium disabled:opacity-50"
+          :disabled="busy || !document"
+          @click="startInterview"
+        >
+          <Loader2 v-if="busy" class="inline size-4 animate-spin mr-1" />
+          {{ copy.start }}
+        </button>
+      </section>
+
+      <section v-else-if="step === 'interview'" class="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-semibold">{{ copy.interview }}</h2>
+
+        <p v-if="liveAvailable === false" class="text-sm text-amber-800">
+          Realtime voice er ikke tilgjengelig. Sjekk PORTFOLIO_REALTIME_ENABLED og OPENAI_API_KEY.
+        </p>
+
+        <div class="flex flex-wrap gap-2 items-center">
+          <label class="text-sm">Stemme</label>
+          <select v-model="selectedVoice" class="border rounded px-2 py-1 text-sm" :disabled="connectionState !== 'idle'">
+            <option value="marin">Marin</option>
+            <option value="cedar">Cedar</option>
+          </select>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-if="connectionState === 'idle' || connectionState === 'error'"
+            type="button"
+            class="inline-flex items-center gap-1 rounded bg-blue-600 text-white px-3 py-2 text-sm"
+            :disabled="liveAvailable === false"
+            @click="connect"
+          >
+            <Mic class="size-4" /> {{ copy.connect }}
+          </button>
+          <button
+            v-else
+            type="button"
+            class="inline-flex items-center gap-1 rounded bg-gray-700 text-white px-3 py-2 text-sm"
+            @click="disconnectAndFlush"
+          >
+            <MicOff class="size-4" /> {{ copy.disconnect }}
+          </button>
+          <button
+            v-if="isModelSpeaking"
+            type="button"
+            class="inline-flex items-center gap-1 rounded border px-3 py-2 text-sm"
+            @click="stopResponse"
+          >
+            <Square class="size-4" /> Stopp
+          </button>
+        </div>
+
+        <p v-if="connectionState === 'connecting'" class="text-sm text-gray-600">Kobler til…</p>
+        <p v-if="sessionNotice" class="text-sm text-amber-800">{{ sessionNotice }}</p>
+
+        <div class="grid gap-3 sm:grid-cols-2">
+          <div class="rounded border p-3 text-sm">
+            <p class="font-medium text-gray-700 mb-1">Du</p>
+            <p class="text-gray-900 whitespace-pre-wrap">{{ userTranscript || '—' }}</p>
+          </div>
+          <div class="rounded border p-3 text-sm">
+            <p class="font-medium text-gray-700 mb-1">Intervjuer</p>
+            <p class="text-gray-900 whitespace-pre-wrap">{{ assistantTranscript || '—' }}</p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="rounded border border-blue-600 text-blue-700 px-4 py-2 text-sm"
+          @click="goToTranscriptStep"
+        >
+          Gå videre til transkript →
+        </button>
+      </section>
+
+      <section v-else-if="step === 'transcript'" class="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-semibold">{{ copy.transcript }}</h2>
+        <ul class="space-y-2 text-sm max-h-96 overflow-y-auto">
+          <li v-for="(t, i) in committedTurns" :key="i" class="rounded border p-2">
+            <span class="font-medium">{{ t.role === 'user' ? 'Kevin' : 'Intervjuer' }}:</span>
+            {{ t.text }}
+          </li>
+        </ul>
+        <button
+          type="button"
+          class="rounded bg-blue-600 text-white px-4 py-2 text-sm disabled:opacity-50"
+          :disabled="busy || committedTurns.length === 0"
+          @click="saveTranscript"
+        >
+          {{ copy.finalize }}
+        </button>
+      </section>
+
+      <section v-else class="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-semibold">{{ copy.clean }}</h2>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div>
+            <h3 class="text-sm font-medium mb-1">{{ copy.raw }}</h3>
+            <pre class="text-xs bg-gray-50 border rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ transcript?.rawText }}</pre>
+          </div>
+          <div>
+            <h3 class="text-sm font-medium mb-1">{{ copy.cleaned }}</h3>
+            <pre class="text-xs bg-gray-50 border rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap">{{ transcript?.cleanedText || '—' }}</pre>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="rounded bg-gray-800 text-white px-4 py-2 text-sm disabled:opacity-50"
+            :disabled="busy || !transcript"
+            @click="runClean"
+          >
+            {{ copy.cleanBtn }}
+          </button>
+          <button
+            type="button"
+            class="rounded bg-green-700 text-white px-4 py-2 text-sm disabled:opacity-50"
+            :disabled="busy || !transcript?.cleanedText"
+            @click="runIngest"
+          >
+            {{ copy.ingest }}
+          </button>
+        </div>
+      </section>
+    </main>
+  </div>
+</template>

--- a/frontend/homepage/src/views/AdminToolsView.vue
+++ b/frontend/homepage/src/views/AdminToolsView.vue
@@ -116,6 +116,17 @@ onMounted(() => {
           <li
             class="rounded-xl border border-gray-200 bg-white p-5 shadow-[0_1px_3px_rgb(0_0_0/0.06)] hover:border-gray-300 transition-colors"
           >
+            <RouterLink to="/admin/interview" class="block group">
+              <span class="text-base font-semibold text-blue-600 group-hover:underline">Voice interview</span>
+              <p class="text-sm text-gray-600 mt-2 leading-relaxed">
+                Last opp et dokument om deg, bli intervjuet med OpenAI Realtime (STT+TTS), lagre transkript, rens det og
+                ingest til pgvector.
+              </p>
+            </RouterLink>
+          </li>
+          <li
+            class="rounded-xl border border-gray-200 bg-white p-5 shadow-[0_1px_3px_rgb(0_0_0/0.06)] hover:border-gray-300 transition-colors"
+          >
             <RouterLink to="/admin/experiments" class="block group">
               <span class="text-base font-semibold text-blue-600 group-hover:underline">Experiments</span>
               <p class="text-sm text-gray-600 mt-2 leading-relaxed">

--- a/frontend/homepage/vitest.config.ts
+++ b/frontend/homepage/vitest.config.ts
@@ -41,6 +41,7 @@ export default mergeConfig(
           'src/views/ProjectsView.vue',
           'src/components/voice/**',
           'src/composables/**',
+          'src/film-demo/**',
         ],
         // Vitest 4 switched to AST-based v8 analysis; numbers shifted down vs the old v8-to-istanbul pipeline.
         // Branch % stays lowest on template-heavy Vue (many ternaries). If the branch gate fails, add tests

--- a/scripts/sync-local-env.ps1
+++ b/scripts/sync-local-env.ps1
@@ -86,6 +86,8 @@ $rootUpdates = @{
     PORTFOLIO_REALTIME_ENABLED   = $(if ($backend['PORTFOLIO_REALTIME_ENABLED']) { $backend['PORTFOLIO_REALTIME_ENABLED'] } else { 'true' })
     PORTFOLIO_JWT_SECRET         = $(if ($backend['PORTFOLIO_JWT_SECRET']) { $backend['PORTFOLIO_JWT_SECRET'] } else { 'dev-only-change-me-use-32-chars-minimum!!' })
     AI_BUDGET_ANON_SALT          = $(if ($backend['AI_BUDGET_ANON_SALT']) { $backend['AI_BUDGET_ANON_SALT'] } else { 'portfolio-ai-budget-local-dev' })
+    ADMIN_BOOTSTRAP_USERNAME     = $(if ($backend['ADMIN_BOOTSTRAP_USERNAME']) { $backend['ADMIN_BOOTSTRAP_USERNAME'] } else { 'admin' })
+    ADMIN_BOOTSTRAP_PASSWORD     = $(if ($backend['ADMIN_BOOTSTRAP_PASSWORD']) { $backend['ADMIN_BOOTSTRAP_PASSWORD'] } else { 'admin' })
 }
 Merge-EnvFile $rootEnv $rootUpdates
 Write-Host "Updated repo-root .env for Docker Compose."


### PR DESCRIPTION
## Summary
- Adds an admin-only voice interview tool at `/admin/interview` where you upload a document about yourself, get interviewed via OpenAI Realtime (STT+TTS), and save the conversation.
- Persists interview sessions/transcripts in Postgres (Flyway V15) and provides a clean + ingest flow to add sanitized transcript facts into pgvector.
- Reuses existing security patterns (admin JWT, rate limits, budget controls) with dedicated admin realtime SDP endpoint.

## Test plan
- [x] Backend unit tests: InterviewControllerTest, InterviewTranscriptCleanerServiceTest
- [x] Frontend type-check passes
- [x] OpenAPI/Orval regenerated for interview endpoints
- [ ] Manual: log in as admin, upload doc, run voice session, finalize, clean, ingest
- [ ] CI tests workflow green
