### PR TITLE
Add AI workflow video accordion to How page

### DIFF
--- a/frontend/homepage/src/components/project/ProjectHowAiWorkflowSection.vue
+++ b/frontend/homepage/src/components/project/ProjectHowAiWorkflowSection.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useLangStore } from '@/stores/lang'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Bot, Sparkles, Link2 } from 'lucide-vue-next'
+
+const langStore = useLangStore()
+const isNo = computed(() => langStore.language === 'no')
+
+const YOUTUBE_EMBED_ID = 'C87ITeVS9hs'
+const YOUTUBE_WATCH_URL = `https://www.youtube.com/watch?v=${YOUTUBE_EMBED_ID}`
+
+const hero = computed(() =>
+	isNo.value
+		? {
+				title: 'Slik bruker jeg AI uten å slippe ansvaret',
+				lead:
+					'Målet er ikke å la AI tenke for meg, men å bruke den som støtte mens jeg beholder ansvar for arkitektur, beslutninger og kvalitet.',
+			}
+		: {
+				title: 'How I use AI without outsourcing the thinking',
+				lead:
+					'The goal is not to let AI think for me, but to use it as support while I stay responsible for architecture, decisions, and quality.',
+			},
+)
+
+const videoSection = computed(() =>
+	isNo.value
+		? {
+				heading: 'Fra idé til kode med struktur',
+				description:
+					'Videoen viser en strukturert utviklingsflyt: problem og brukere først, deretter use case og domenemodell, BDD med Gherkin og TDD — og hvordan AI-verktøy som Claude, Cursor og Codex kobles inn via MCP, skills og subagents uten at design og kvalitet settes bort.',
+				badge: 'Metode',
+				iframeTitle: 'YouTube-video om AI-støttet utviklingsflyt',
+				watchLabel: 'Åpne på YouTube (ny fane)',
+			}
+		: {
+				heading: 'From idea to code with structure',
+				description:
+					'The video walks through a structured development workflow: problem and users first, then use cases and domain modeling, BDD with Gherkin and TDD — and how AI tools such as Claude, Cursor, and Codex connect through MCP, skills, and subagents without handing off design or quality.',
+				badge: 'Method',
+				iframeTitle: 'YouTube video about AI-supported development workflow',
+				watchLabel: 'Watch on YouTube (opens in a new tab)',
+			},
+)
+</script>
+
+<template>
+	<div class="relative pb-8">
+		<div class="relative z-10 mx-auto max-w-4xl px-4 py-4 sm:px-6 lg:px-8">
+			<div
+				v-motion
+				:initial="{ opacity: 0, y: 24 }"
+				:visible-once="{ opacity: 1, y: 0, transition: { duration: 550 } }"
+				class="text-center mb-10"
+			>
+				<div
+					class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-700 text-white shadow-lg shadow-blue-500/25 mb-5"
+				>
+					<Bot class="w-8 h-8" aria-hidden="true" />
+				</div>
+				<h2
+					class="text-3xl sm:text-4xl font-bold mb-3 bg-gradient-to-r from-blue-600 via-blue-700 to-blue-800 bg-clip-text text-transparent"
+				>
+					{{ hero.title }}
+				</h2>
+				<p class="text-gray-600 max-w-3xl mx-auto leading-relaxed text-sm sm:text-base">
+					{{ hero.lead }}
+				</p>
+			</div>
+
+			<div
+				v-motion
+				:initial="{ opacity: 0, y: 20 }"
+				:visible-once="{ opacity: 1, y: 0, transition: { duration: 550, delay: 120 } }"
+			>
+				<Card
+					class="border-2 border-transparent bg-white/90 backdrop-blur-sm shadow-lg shadow-slate-900/5 overflow-hidden"
+				>
+					<CardHeader class="space-y-2 pb-2">
+						<div class="flex flex-wrap items-center gap-2">
+							<Badge
+								variant="secondary"
+								class="text-xs border border-blue-300/30 text-blue-700 bg-blue-50/70"
+							>
+								{{ videoSection.badge }}
+							</Badge>
+						</div>
+						<CardTitle class="text-xl text-gray-900 flex items-center gap-2">
+							<Sparkles class="w-5 h-5 text-blue-600 shrink-0" aria-hidden="true" />
+							{{ videoSection.heading }}
+						</CardTitle>
+						<p class="text-sm text-gray-600 leading-relaxed">{{ videoSection.description }}</p>
+					</CardHeader>
+					<CardContent class="space-y-4 pt-0">
+						<div
+							class="relative w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-900 aspect-video shadow-inner"
+						>
+							<iframe
+								class="absolute inset-0 h-full w-full"
+								:src="`https://www.youtube.com/embed/${YOUTUBE_EMBED_ID}`"
+								:title="videoSection.iframeTitle"
+								allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+								allowfullscreen
+								referrerpolicy="strict-origin-when-cross-origin"
+							></iframe>
+						</div>
+						<p class="text-center">
+							<a
+								:href="YOUTUBE_WATCH_URL"
+								class="inline-flex items-center gap-1.5 text-sm font-medium text-blue-700 underline underline-offset-2 hover:text-blue-900"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<Link2 class="w-4 h-4 shrink-0" aria-hidden="true" />
+								{{ videoSection.watchLabel }}
+							</a>
+						</p>
+					</CardContent>
+				</Card>
+			</div>
+		</div>
+	</div>
+</template>

--- a/frontend/homepage/src/components/project/__tests__/ProjectHowAiWorkflowSection.spec.ts
+++ b/frontend/homepage/src/components/project/__tests__/ProjectHowAiWorkflowSection.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { MotionPlugin } from '@vueuse/motion'
+import ProjectHowAiWorkflowSection from '../ProjectHowAiWorkflowSection.vue'
+import { useLangStore } from '@/stores/lang'
+
+describe('ProjectHowAiWorkflowSection', () => {
+  it('renders English workflow hero and embed', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('en')
+    const wrapper = mount(ProjectHowAiWorkflowSection, {
+      global: { plugins: [pinia, MotionPlugin] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('How I use AI without outsourcing the thinking')
+    expect(wrapper.find('iframe').attributes('src')).toContain('C87ITeVS9hs')
+  })
+
+  it('renders Norwegian workflow hero', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    useLangStore().setLanguage('no')
+    const wrapper = mount(ProjectHowAiWorkflowSection, {
+      global: { plugins: [pinia, MotionPlugin] },
+    })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Slik bruker jeg AI uten å slippe ansvaret')
+  })
+})

--- a/frontend/homepage/src/views/HowView.vue
+++ b/frontend/homepage/src/views/HowView.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { ChevronDown, FolderKanban } from 'lucide-vue-next'
 import { useLangStore } from '@/stores/lang'
 import ProjectBachelorSection from '@/components/project/ProjectBachelorSection.vue'
+import ProjectHowAiWorkflowSection from '@/components/project/ProjectHowAiWorkflowSection.vue'
 import ProjectFutureWorkSection from '@/components/project/ProjectFutureWorkSection.vue'
 
 const langStore = useLangStore()
@@ -14,21 +15,22 @@ const hero = computed(() =>
   isNo.value
     ? {
         title: 'Hvordan',
-        lead: 'Hvordan portefoljen er bygget: bachelorkontekst og videre arbeid.',
+        lead: 'Hvordan portefoljen er bygget: bachelorkontekst, AI-støttet utviklingsflyt og videre arbeid.',
       }
     : {
         title: 'How',
-        lead: 'How the portfolio is built: bachelor context and future work.',
+        lead: 'How the portfolio is built: bachelor context, AI-supported development workflow, and future work.',
       },
 )
 
 const labels = computed(() =>
   isNo.value
-    ? { bachelor: 'Bacheloroppgaven', future: 'Videre arbeid' }
-    : { bachelor: "Bachelor's thesis", future: 'Future work' },
+    ? { bachelor: 'Bacheloroppgaven', workflow: 'AI i utviklingsflyten', future: 'Videre arbeid' }
+    : { bachelor: "Bachelor's thesis", workflow: 'AI in the development workflow', future: 'Future work' },
 )
 
 const bachelorOpen = ref(false)
+const workflowOpen = ref(false)
 const futureOpen = ref(false)
 
 function scrollToSection(elementId: string) {
@@ -43,6 +45,9 @@ function applyRouteHash(hash: string | undefined) {
   if (h === 'bachelor') {
     bachelorOpen.value = true
     scrollToSection('accordion-bachelor')
+  } else if (h === 'ai-workflow') {
+    workflowOpen.value = true
+    scrollToSection('accordion-ai-workflow')
   } else if (h === 'future-work') {
     futureOpen.value = true
     scrollToSection('accordion-future-work')
@@ -92,6 +97,29 @@ watch(
             class="border-t border-slate-200/80"
           >
             <ProjectBachelorSection />
+          </div>
+        </section>
+
+        <section id="accordion-ai-workflow" class="rounded-2xl border border-slate-200/80 bg-white/90 shadow-lg shadow-slate-900/5 overflow-hidden">
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition hover:bg-slate-50/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600"
+            :aria-expanded="workflowOpen"
+            aria-controls="panel-ai-workflow"
+            id="section-ai-workflow"
+            @click="workflowOpen = !workflowOpen"
+          >
+            <span class="text-lg font-semibold text-slate-900">{{ labels.workflow }}</span>
+            <ChevronDown class="h-5 w-5 shrink-0 text-slate-500 transition-transform duration-200" :class="{ 'rotate-180': workflowOpen }" aria-hidden="true" />
+          </button>
+          <div
+            v-show="workflowOpen"
+            id="panel-ai-workflow"
+            role="region"
+            aria-labelledby="section-ai-workflow"
+            class="border-t border-slate-200/80"
+          >
+            <ProjectHowAiWorkflowSection />
           </div>
         </section>
 

--- a/frontend/homepage/src/views/__tests__/portfolioViews.spec.ts
+++ b/frontend/homepage/src/views/__tests__/portfolioViews.spec.ts
@@ -281,6 +281,7 @@ describe('portfolio views (smoke)', () => {
 		const wrapper = await mountHowViewWithRoute('#future-work')
 		await flushPromises()
 		expect(wrapper.text()).toContain('How')
+		expect(wrapper.text()).toContain('AI in the development workflow')
 		expect(wrapper.text()).toContain('Future work')
 		expect(wrapper.text()).not.toContain('Heathen Army (Vikings blog)')
 		expect(wrapper.text()).toContain('References (arXiv)')
@@ -289,6 +290,15 @@ describe('portfolio views (smoke)', () => {
 		await toggles[0].trigger('click')
 		await flushPromises()
 		expect(wrapper.text()).toContain("Bachelor's thesis")
+	})
+
+	it('opens HowView AI workflow accordion from route hash', async () => {
+		const wrapper = await mountHowViewWithRoute('#ai-workflow')
+		await flushPromises()
+		expect(wrapper.text()).toContain('How I use AI without outsourcing the thinking')
+		const iframe = wrapper.find('#panel-ai-workflow iframe')
+		expect(iframe.exists()).toBe(true)
+		expect(iframe.attributes('src')).toContain('C87ITeVS9hs')
 	})
 
 	it('renders HeathenArmyView and opens gallery details', async () => {


### PR DESCRIPTION
## Summary
- Adds a third accordion on `/how` between Bachelor and Future work with embedded YouTube video `C87ITeVS9hs`
- Introduces `ProjectHowAiWorkflowSection` with bilingual NO/EN copy about structured AI-supported development workflow
- Supports deep link `/how#ai-workflow` and updates How page hero lead
- Adds unit tests for the new section and HowView hash routing

## Test plan
- [x] `npm run test:unit -- run` on `ProjectHowAiWorkflowSection.spec.ts` and `portfolioViews.spec.ts` (16 tests passing)
- [ ] Open `/how` and expand the middle accordion; confirm video loads
- [ ] Open `/how#ai-workflow` and confirm the section opens automatically
- [ ] Switch language NO/EN and verify copy
- [ ] Confirm Bachelor and Future work accordions still behave as before