### PR TITLE
feat: bachelor thesis grade A (subtle UI + AI)

### DIFF
--- a/backend/src/main/resources/prompts/realtime-voice-en.txt
+++ b/backend/src/main/resources/prompts/realtime-voice-en.txt
@@ -7,8 +7,8 @@ Rules (same intent as the text chatbot):
 - Start from this compact public profile card:
 {profile_card}
 - Use the profile card directly for simple questions. If the user asks for precise public facts about Kevin's studies, projects, course areas, work experience, or portfolio details, call `lookup_kevin_info` with a concise query.
-- Do not call tools for grades, private details, sensitive information, or questions outside Kevin's public profile. For document-grounded deep answers, suggest the text chat on the site.
-- Never invent specific grades, employers, dates, or private details. For grades, use a light refusal consistent with the site's policy. For sensitive private topics, decline politely.
+- Call `lookup_kevin_info` for the grade on the bachelor's thesis Foresight AI (IDATT2901); it is public (grade A). Do not call tools for other course grades, private details, sensitive information, or questions outside Kevin's public profile. For document-grounded deep answers, suggest the text chat on the site.
+- Never invent specific grades, employers, dates, or private details. For other course grades, use a light refusal consistent with the site's policy. For sensitive private topics, decline politely.
 - If the question is not about Kevin or his profile, briefly say you focus on Kevin and suggest a topic.
 - If you are unsure what the user said or the transcription seems unclear, politely ask them to repeat or rephrase before attempting an answer. Never guess at unclear input.
 - If `lookup_kevin_info` returns no relevant results or very weak results, say you do not have information about that specific topic rather than guessing. Suggest a topic you can help with.

--- a/backend/src/main/resources/prompts/realtime-voice-no.txt
+++ b/backend/src/main/resources/prompts/realtime-voice-no.txt
@@ -7,8 +7,8 @@ Regler (samme hensikt som tekstchatten):
 - Start med dette komprimerte offentlige profilkortet:
 {profile_card}
 - Bruk profilkortet direkte ved enkle spørsmål. Hvis brukeren ber om presise offentlige fakta om Kevin sine studier, prosjekter, kursområder, arbeidserfaring eller portefølje, kall `lookup_kevin_info` med en kort søkefrase.
-- Ikke kall verktøy for karakterer, private detaljer, sensitiv informasjon eller spørsmål utenfor Kevin sin offentlige profil. For dokumentforankrede dybdesvar, foreslå tekstchatten på sida.
-- Oppfinn ikke karakterer, arbeidsgivere, datoer eller private detaljer. For karakterer: avvis vittig. For sensitivt: avvis høflig.
+- Kall `lookup_kevin_info` for karakter på bacheloroppgaven Foresight AI (IDATT2901); den er offentlig (A). Ikke kall verktøy for andre emnekarakterer, private detaljer, sensitiv informasjon eller spørsmål utenfor Kevin sin offentlige profil. For dokumentforankrede dybdesvar, foreslå tekstchatten på sida.
+- Oppfinn ikke karakterer, arbeidsgivere, datoer eller private detaljer. For andre emnekarakterer: avvis vittig. For sensitivt: avvis høflig.
 - Hvis spørsmålet ikke handler om Kevin eller profilen hans, si kort at du bare svarer om Kevin og foreslå et tema.
 - Hvis du er usikker på hva brukeren sa, eller transkripsjonen virker uklar, be høflig om å få det gjentatt eller omformulert før du svarer. Ikke gjett når input er uklar.
 - Hvis `lookup_kevin_info` ikke gir relevante treff eller bare svake treff, si at du ikke har informasjon om akkurat det temaet i stedet for å gjette. Foreslå et tema du kan hjelpe med.

--- a/backend/src/main/resources/realtime/kevin-profile.json
+++ b/backend/src/main/resources/realtime/kevin-profile.json
@@ -2,10 +2,10 @@
   "version": 1,
   "languages": {
     "no": {
-      "profileCard": "Kevin studerer dataingeniør ved NTNU i Trondheim, med retning systemutvikling. Han bygger denne porteføljen som et personlig AI- og RAG-prosjekt med Vue, TypeScript, Spring Boot, Spring AI, OpenAI og PostgreSQL/pgvector. Voice-boten kan svare kort om offentlig informasjon om studier, prosjekter, kursområder og relevant arbeidserfaring. Den skal ikke dele karakterer eller private detaljer."
+      "profileCard": "Kevin studerer dataingeniør ved NTNU i Trondheim, med retning systemutvikling. Han bygger denne porteføljen som et personlig AI- og RAG-prosjekt med Vue, TypeScript, Spring Boot, Spring AI, OpenAI og PostgreSQL/pgvector. Voice-boten kan svare kort om offentlig informasjon om studier, prosjekter, kursområder og relevant arbeidserfaring. Karakteren A på bacheloroppgaven Foresight AI (IDATT2901) er offentlig; andre emnekarakterer deles ikke."
     },
     "en": {
-      "profileCard": "Kevin studies data engineering at NTNU in Trondheim, focused on system development. He built this portfolio as a personal AI and RAG project using Vue, TypeScript, Spring Boot, Spring AI, OpenAI, and PostgreSQL/pgvector. The voice bot can answer briefly about public information on his studies, projects, course areas, and relevant work experience. It must not share grades or private details."
+      "profileCard": "Kevin studies data engineering at NTNU in Trondheim, focused on system development. He built this portfolio as a personal AI and RAG project using Vue, TypeScript, Spring Boot, Spring AI, OpenAI, and PostgreSQL/pgvector. The voice bot can answer briefly about public information on his studies, projects, course areas, and relevant work experience. Grade A on the bachelor's thesis Foresight AI (IDATT2901) is public; other course grades are not shared."
     }
   },
   "facts": [
@@ -153,6 +153,19 @@
       "tags": ["courses", "kurs", "programming", "databases", "algorithms", "full-stack", "machine learning", "c++", "mobile"]
     },
     {
+      "id": "bachelor-thesis-grade",
+      "category": "education",
+      "title": {
+        "no": "Karakter på bacheloroppgaven",
+        "en": "Bachelor's thesis grade"
+      },
+      "text": {
+        "no": "Kevin fikk karakter A på bacheloroppgaven Foresight AI (IDATT2901, vår 2026) ved NTNU, utviklet i samarbeid med Piscada AS i Trondheim.",
+        "en": "Kevin received grade A on his bachelor's thesis Foresight AI (IDATT2901, spring 2026) at NTNU, developed in collaboration with Piscada AS in Trondheim."
+      },
+      "tags": ["bachelor", "bacheloroppgave", "bachelor's thesis", "foresight", "foresight ai", "idatt2901", "grade", "grades", "karakter", "karakterer", "oppgave", "thesis", "ntnu", "piscada"]
+    },
+    {
       "id": "privacy-boundaries",
       "category": "policy",
       "title": {
@@ -160,8 +173,8 @@
         "en": "Voice answer boundaries"
       },
       "text": {
-        "no": "Voice-boten skal ikke oppgi karakterer, familieinformasjon, private detaljer eller andre sensitive opplysninger. For karakterer skal den avvise lett og vennlig.",
-        "en": "The voice bot must not share grades, family information, private details, or other sensitive information. For grades, it should decline lightly and politely."
+        "no": "Voice-boten kan oppgi karakter A på bacheloroppgaven Foresight AI (IDATT2901). For andre emnekarakterer, familieinformasjon, private detaljer eller sensitive opplysninger skal den avvise lett og vennlig.",
+        "en": "The voice bot may share grade A on the bachelor's thesis Foresight AI (IDATT2901). For other course grades, family information, private details, or sensitive information, it should decline lightly and politely."
       },
       "tags": ["privacy", "personvern", "grades", "karakterer", "private", "sensitive"]
     }

--- a/backend/src/main/resources/templates/rag-prompt-template-anthropic.st
+++ b/backend/src/main/resources/templates/rag-prompt-template-anthropic.st
@@ -20,7 +20,8 @@ Rules:
   • Kevin built it as an interactive portfolio that presents him while also exploring Spring AI and RAG.
   • Visitors can ask a chatbot (trained on documents about Kevin) to learn more about him.
   • The project serves both as a personal showcase and as a demonstration of AI technology.
-- If the user asks which grades Kevin has received in a course, do not reveal them. Instead, reply with a lighthearted or witty remark that makes it clear this is private information only available to application committees. The response must be in the same language as the question:
+- If the user asks about the grade on Kevin's bachelor's thesis, Foresight AI, or IDATT2901, answer using the documents when they contain it (grade A, spring 2026).
+- If the user asks which grades Kevin has received in any other course, do not reveal them. Instead, reply with a lighthearted or witty remark that makes it clear this is private information only available to application committees. The response must be in the same language as the question:
   • Example in Norwegian: "Godt forsøk, men Kevins karakterer er bare for søknadskomiteer å se."
   • Example in English: "Nice try, but Kevin's grades are only for application committees to see."
 - If the user asks about sensitive or private information (e.g., where Kevin was born, where he grew up, family details, or similar), respond politely in the same language as the question that Kevin prefers not to share this due to privacy considerations.

--- a/backend/src/main/resources/templates/rag-prompt-template-openai.st
+++ b/backend/src/main/resources/templates/rag-prompt-template-openai.st
@@ -34,7 +34,9 @@ The DOCUMENTS section below contains information about Kevin as a person, his ba
 
   • The project serves both as a personal showcase and as a demonstration of AI technology.
 
-- If the user asks which grades Kevin has received in a course, do not reveal them. Instead, reply with a lighthearted or witty remark that makes it clear this is private information only available to application committees. The response must be in the same language as the question:
+- If the user asks about the grade on Kevin's bachelor's thesis, Foresight AI, or IDATT2901, answer using the DOCUMENTS when they contain it (grade A, spring 2026).
+
+- If the user asks which grades Kevin has received in any other course, do not reveal them. Instead, reply with a lighthearted or witty remark that makes it clear this is private information only available to application committees. The response must be in the same language as the question:
 
   • Example in Norwegian: "Godt forsøk, men Kevin sine karakterer er bare for søknadskomitéer å se."
 

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/EvaluatorServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/EvaluatorServiceTest.java
@@ -322,6 +322,30 @@ class EvaluatorServiceTest {
     assertEquals(1.0, s.score(), 1e-6);
   }
 
+  @Test
+  void evaluateLanguageConsistencyBachelorThesisGradeNorwegian() {
+    stubOpenAiReturns("{\"score\": 1.0, \"label\": \"consistent\", \"explanation\": \"Full Norwegian response.\"}");
+
+    EvaluationScore s = evaluatorService.evaluateLanguageConsistency(
+        OPENAI_EVAL,
+        "Hvilken karakter fikk Kevin på bacheloroppgaven?",
+        "Kevin fikk karakter A på bacheloroppgaven Foresight AI (IDATT2901, vår 2026) ved NTNU, utviklet i samarbeid med Piscada AS.");
+
+    assertEquals(1.0, s.score(), 1e-6);
+  }
+
+  @Test
+  void evaluateLanguageConsistencyBachelorThesisGradeEnglish() {
+    stubOpenAiReturns("{\"score\": 1.0, \"label\": \"consistent\", \"explanation\": \"Full English response.\"}");
+
+    EvaluationScore s = evaluatorService.evaluateLanguageConsistency(
+        OPENAI_EVAL,
+        "What grade did Kevin get on his bachelor's thesis?",
+        "Kevin received grade A on his bachelor's thesis Foresight AI (IDATT2901, spring 2026) at NTNU, developed with Piscada AS.");
+
+    assertEquals(1.0, s.score(), 1e-6);
+  }
+
   private void stubOpenAiReturns(String text) {
     ChatResponse r = mock(ChatResponse.class, RETURNS_DEEP_STUBS);
     when(r.getResult().getOutput().getText()).thenReturn(text);

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/RagPromptLanguageRulesTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/RagPromptLanguageRulesTest.java
@@ -108,6 +108,21 @@ class RagPromptLanguageRulesTest {
       "templates/rag-prompt-template-openai.st",
       "templates/rag-prompt-template-anthropic.st"
   })
+  void templateContainsBachelorThesisGradeException(String path) throws IOException {
+    String template = loadTemplate(path);
+    assertTrue(
+        template.contains("IDATT2901") || template.contains("Foresight AI"),
+        path + " must allow disclosing the bachelor's thesis grade");
+    assertTrue(
+        template.toLowerCase().contains("any other course"),
+        path + " must still refuse grades for other courses");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "templates/rag-prompt-template-openai.st",
+      "templates/rag-prompt-template-anthropic.st"
+  })
   void templateContainsBilingualOffTopicResponse(String path) throws IOException {
     String template = loadTemplate(path);
     assertTrue(

--- a/frontend/homepage/src/components/project/ProjectBachelorSection.vue
+++ b/frontend/homepage/src/components/project/ProjectBachelorSection.vue
@@ -22,15 +22,21 @@ const hero = computed(() =>
 		? {
 				title: 'Bacheloroppgaven',
 				lead:
-					'Denne porteføljen er et aktivt arbeid i utvikling. Jeg tilpasser innhold, struktur og AI-atferd fortløpende med læring fra bacheloroppgaven (2026) hos Piscada AS i Trondheim, slik at siden blir tydeligere og mer treffsikker over tid.',
-				lastUpdated: 'Sist oppdatert: april 2026',
+					'Bacheloroppgaven Foresight AI ble levert våren 2026 hos Piscada AS i Trondheim. Porteføljen er fortsatt et aktivt arbeid i utvikling — jeg tilpasser innhold, struktur og AI-atferd med det jeg lærte der, slik at siden blir tydeligere og mer treffsikker over tid.',
+				lastUpdated: 'Sist oppdatert: juni 2026',
 			}
 		: {
 				title: "Bachelor's thesis",
 				lead:
-					"This portfolio is an active work in progress. I continuously adapt content, structure, and AI behavior using learnings from my bachelor's thesis (2026) at Piscada AS in Trondheim so the site becomes clearer and more accurate over time.",
-				lastUpdated: 'Last updated: April 2026',
+					"The bachelor's thesis Foresight AI was delivered in spring 2026 at Piscada AS in Trondheim. This portfolio remains an active work in progress — I keep adapting content, structure, and AI behavior using what I learned there so the site becomes clearer and more accurate over time.",
+				lastUpdated: 'Last updated: June 2026',
 			},
+)
+
+const gradeStamp = computed(() =>
+	isNo.value
+		? { letter: 'A', label: 'IDATT2901 · vår 2026' }
+		: { letter: 'A', label: 'IDATT2901 · spring 2026' },
 )
 
 const videoSection = computed(() =>
@@ -81,6 +87,13 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 						'Konklusjonen var at slike assistenter kan forbedre tilgang til energiinnsikt, men krever transparent forankring, godt grensesnittdesign og kontinuerlig evaluering.',
 					],
 				},
+				{
+					category: 'Avslutning',
+					title: 'Sensor og alfabet',
+					body: [
+						'Våren 2026 ble Foresight AI sensurert ved NTNU. På det skala-systemet vi bruker der, endte vi på første bokstav — bokstavelig talt.',
+					],
+				},
 			]
 		: [
 				{
@@ -106,6 +119,13 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 						'Context-aware retrieval made energy data easier to understand, and features such as TL;DR summaries, citations, and chart annotations improved trust and interpretation.',
 						'RAG did not fully remove hallucinations, and we observed a clear trade-off between quality, latency, and token cost, meaning no single model was best in every scenario.',
 						'Overall, the project indicates that LLM assistants can improve access to energy insights when paired with transparent grounding, careful interface design, and continuous evaluation.',
+					],
+				},
+				{
+					category: 'Wrap-up',
+					title: 'Assessment and alphabet',
+					body: [
+						'In spring 2026, Foresight AI was assessed at NTNU. On the letter scale they use there, we landed on the first letter — literally.',
 					],
 				},
 			],
@@ -135,6 +155,18 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 				<p class="text-gray-600 max-w-3xl mx-auto leading-relaxed text-sm sm:text-base">
 					{{ hero.lead }}
 				</p>
+				<div
+					class="mt-5 inline-flex flex-col items-center gap-1.5"
+					:aria-label="`${gradeStamp.letter}, ${gradeStamp.label}`"
+				>
+					<span
+						class="inline-flex h-11 w-11 items-center justify-center rounded-full border-2 border-blue-600/40 bg-blue-50/80 text-xl font-bold text-blue-700 shadow-sm"
+						aria-hidden="true"
+					>
+						{{ gradeStamp.letter }}
+					</span>
+					<span class="text-xs font-medium tracking-wide text-slate-500">{{ gradeStamp.label }}</span>
+				</div>
 				<p class="mt-3 text-xs text-gray-500">{{ hero.lastUpdated }}</p>
 			</div>
 
@@ -211,7 +243,10 @@ const narrativeCards = computed<NarrativeCard[]>(() =>
 								variant="secondary"
 								class="text-xs border border-blue-300/30 text-blue-700 bg-blue-50/70"
 							>
-								{{ card.category }}
+								<span
+									v-if="card.category === 'Avslutning' || card.category === 'Wrap-up'"
+									class="font-semibold text-blue-700"
+								>{{ card.category.charAt(0) }}</span><span>{{ card.category.slice(1) }}</span>
 							</Badge>
 						</div>
 						<CardTitle class="text-xl text-gray-900">{{ card.title }}</CardTitle>

--- a/frontend/homepage/src/components/project/ProjectFutureWorkSection.vue
+++ b/frontend/homepage/src/components/project/ProjectFutureWorkSection.vue
@@ -105,9 +105,9 @@ const hero = computed(() =>
 				lead:
 					'En forskningsforankret roadmap for det som kommer videre: RAG med vektorlagring, chat, flere modeller, dokument- og chunk-administrasjon, og promptversjoner. Portef\u00f8ljen oppdateres fortl\u00f8pende.',
 				contextBefore:
-					'Roadmapen viser hva jeg prioriterer mens jeg kontinuerlig tilpasser portef\u00f8ljen med l\u00e6ring fra bacheloroppgaven (2026) hos Piscada AS i Trondheim og arbeid p\u00e5 ',
+					'Roadmapen viser hva jeg prioriterer mens jeg kontinuerlig tilpasser portef\u00f8ljen med l\u00e6ring fra den ferdige bacheloroppgaven (A, v\u00e5r 2026) hos Piscada AS i Trondheim og arbeid p\u00e5 ',
 				contextLinkText: 'Foresight AI',
-				contextAfter: ', som jeg utvikler sammen med en annen i teamet.',
+				contextAfter: '.',
 				contextLinkHref: foresightAiProductUrl,
 			}
 		: {
@@ -115,9 +115,9 @@ const hero = computed(() =>
 				lead:
 					'A research-backed roadmap for what comes next: RAG with a vector store, chat, multiple models, document and chunk administration, and prompt versioning. This portfolio keeps evolving.',
 				contextBefore:
-					"This roadmap reflects what I prioritize while continuously adapting the portfolio based on learnings from my bachelor's thesis (2026) at Piscada AS in Trondheim and work on ",
+					"This roadmap reflects what I prioritize while continuously adapting the portfolio based on learnings from my completed bachelor's thesis (grade A, spring 2026) at Piscada AS in Trondheim and work on ",
 				contextLinkText: 'Foresight AI',
-				contextAfter: ', which I develop with another teammate.',
+				contextAfter: '.',
 				contextLinkHref: foresightAiProductUrl,
 			},
 )

--- a/frontend/homepage/src/components/project/__tests__/ProjectBachelorSection.spec.ts
+++ b/frontend/homepage/src/components/project/__tests__/ProjectBachelorSection.spec.ts
@@ -16,6 +16,8 @@ describe('ProjectBachelorSection', () => {
     await flushPromises()
     expect(wrapper.text()).toContain("Bachelor's thesis")
     expect(wrapper.text()).toMatch(/Piscada|Trondheim/i)
+    expect(wrapper.text()).toContain('IDATT2901')
+    expect(wrapper.text()).toContain('first letter')
   })
 
   it('renders Norwegian bachelor hero', async () => {
@@ -27,5 +29,7 @@ describe('ProjectBachelorSection', () => {
     })
     await flushPromises()
     expect(wrapper.text()).toContain('Bacheloroppgaven')
+    expect(wrapper.text()).toContain('IDATT2901')
+    expect(wrapper.text()).toContain('første bokstav')
   })
 })

--- a/frontend/homepage/src/types/courses.en.json
+++ b/frontend/homepage/src/types/courses.en.json
@@ -166,7 +166,8 @@
       "courseName": "Bachelor Project",
       "credits": 22.5,
       "semester": "Semester 6 (Spring 2026)",
-      "status": "ongoing"
+      "status": "completed",
+      "grade": "A"
     },
     {
       "id": "sem6-ingt2301",

--- a/frontend/homepage/src/types/courses.no.json
+++ b/frontend/homepage/src/types/courses.no.json
@@ -166,7 +166,8 @@
       "courseName": "Bacheloroppgave",
       "credits": 22.5,
       "semester": "Semester 6 (Vår 2026)",
-      "status": "ongoing"
+      "status": "completed",
+      "grade": "A"
     },
     {
       "id": "sem6-ingt2301",

--- a/frontend/homepage/src/types/projects.en.json
+++ b/frontend/homepage/src/types/projects.en.json
@@ -13,7 +13,7 @@
     {
       "id": "portfolio-project-2025",
       "projectName": "AboutMe — portfolio & AI",
-      "projectDescription": "Personal site and digital CV with a built-in AI demo: ask questions in chat or use live voice, with answers grounded in documents about me. Built with Vue and Spring Boot on PostgreSQL; still evolving alongside my bachelor's thesis work (2026).",
+      "projectDescription": "Personal site and digital CV with a built-in AI demo: ask questions in chat or use live voice, with answers grounded in documents about me. Built with Vue and Spring Boot on PostgreSQL; still evolving following my bachelor's thesis (2026).",
       "startDate": "2025-09-01",
       "endDate": null,
       "technologies": ["Vue", "TypeScript", "Spring Boot", "PostgreSQL", "OpenAI", "Docker"],

--- a/frontend/homepage/src/types/projects.no.json
+++ b/frontend/homepage/src/types/projects.no.json
@@ -13,7 +13,7 @@
     {
       "id": "portfolio-project-2025",
       "projectName": "AboutMe — portefølje og AI",
-      "projectDescription": "Personlig nettside og digital CV med innebygd AI-demo: tekstchat og live stemme, med svar basert på dokumenter om meg. Bygget med Vue og Spring Boot på PostgreSQL; utvikles fortløpende i parallell med bacheloroppgaven (2026).",
+      "projectDescription": "Personlig nettside og digital CV med innebygd AI-demo: tekstchat og live stemme, med svar basert på dokumenter om meg. Bygget med Vue og Spring Boot på PostgreSQL; utvikles fortløpende etter bacheloroppgaven (2026).",
       "startDate": "2025-09-01",
       "endDate": null,
       "technologies": ["Vue", "TypeScript", "Spring Boot", "PostgreSQL", "OpenAI", "Docker"],

--- a/frontend/homepage/src/views/ChatView.vue
+++ b/frontend/homepage/src/views/ChatView.vue
@@ -188,7 +188,7 @@ const popupCopy = computed(() =>
   language.value === 'no'
     ? {
         title: 'Porteføljen oppdateres fortløpende',
-        body: 'Chatten og kunnskapsgrunnlaget endrer seg etter hvert som jeg lærer mer i bacheloroppgaven. Svarene blir gjerne mer treffsikre over tid.',
+        body: 'Chatten og kunnskapsgrunnlaget endrer seg etter hvert som jeg tar med meg læring fra bacheloroppgaven. Svarene blir gjerne mer treffsikre over tid.',
         aiNote:
           'Du snakker med en AI-assistent — ikke meg direkte. Svarene kan være unøyaktige.',
         recommendation: 'Lurer du på hva som skjer akkurat nå? Ta en titt på prosjektsiden.',
@@ -197,7 +197,7 @@ const popupCopy = computed(() =>
       }
     : {
         title: 'This portfolio keeps evolving',
-        body: "I'm updating this chat and its knowledge base as I learn more in my bachelor's thesis. Answers should get sharper over time.",
+        body: "I'm updating this chat and its knowledge base as I apply what I learned from my bachelor's thesis. Answers should get sharper over time.",
         aiNote:
           'You are chatting with an AI assistant — not me directly. Replies may be inaccurate.',
         recommendation: 'Curious what I am working on? Check the project page.',


### PR DESCRIPTION
## Summary
- Add subtle A presentation on the bachelor thesis section (stamp + wordplay card)
- Mark IDATT2901 as completed with grade A in course data
- Allow AI chat/voice to disclose bachelor thesis grade A; other course grades still declined

## Test plan
- [ ] Open `/how#bachelor` — verify A stamp, IDATT2901 label, and first-letter copy (NO/EN)
- [ ] Ask chat about bachelor thesis grade — should answer A
- [ ] Ask chat about other course grades — should still decline wittily
- [ ] Run frontend tests (`ProjectBachelorSection.spec.ts`)
- [ ] Run backend tests (`RagPromptLanguageRulesTest`, `EvaluatorServiceTest`)
