### PR TITLE
FIX: align SPA CSRF token handling

### DIFF
--- a/backend/src/main/java/com/kevinmazali/portfolio/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/SecurityConfig.java
@@ -25,7 +25,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -62,12 +61,11 @@ public class SecurityConfig {
         if (disableCsrfForTests) {
             http.csrf(AbstractHttpConfigurer::disable);
         } else {
-            CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
-            csrfTokenRepository.setCookieName("XSRF-TOKEN");
-            csrfTokenRepository.setHeaderName("X-XSRF-TOKEN");
+            // spa(): CookieCsrfTokenRepository (XSRF-TOKEN / X-XSRF-TOKEN) + SpaCsrfTokenRequestHandler
+            // so the SPA can send the raw cookie value in the header (not the BREACH-masked form token).
             http.csrf(
                 csrf ->
-                    csrf.csrfTokenRepository(csrfTokenRepository)
+                    csrf.spa()
                         .ignoringRequestMatchers(
                             "/ask",
                             "/feedback",

--- a/backend/src/test/java/com/kevinmazali/portfolio/security/SecuritySpaCsrfIT.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/security/SecuritySpaCsrfIT.java
@@ -1,0 +1,155 @@
+package com.kevinmazali.portfolio.security;
+
+import com.kevinmazali.portfolio.model.interview.InterviewDocumentResponse;
+import com.kevinmazali.portfolio.service.DocumentIngestionService;
+import com.kevinmazali.portfolio.service.InterviewDocumentService;
+import com.kevinmazali.portfolio.service.InterviewSessionService;
+import com.kevinmazali.portfolio.testsupport.VectorStoreTestConfiguration;
+import jakarta.servlet.http.Cookie;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Contract: SPA sends the raw {@code XSRF-TOKEN} cookie value as {@code X-XSRF-TOKEN}.
+ * Requires CSRF enabled ({@code portfolio.test.disable-csrf=false}) unlike WebMvc slices.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(VectorStoreTestConfiguration.class)
+@TestPropertySource(
+    properties = {
+      "spring.autoconfigure.exclude=org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreAutoConfiguration",
+      "spring.datasource.url=jdbc:h2:mem:spacsrfit;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
+      "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+      "spring.ai.openai.api-key=test-placeholder-key-for-context-tests-only",
+      "spring.ai.openai.chat.enabled=true",
+      "spring.ai.anthropic.api-key=test-anthropic-api-key-not-real",
+      "portfolio.chat.default-model-id=gpt-5.4-mini",
+      "portfolio.session.jwt-secret=test-jwt-secret-at-least-32-characters-long",
+      "portfolio.test.disable-csrf=false",
+      "server.port=0",
+    })
+class SecuritySpaCsrfIT {
+
+  @MockitoBean private DocumentIngestionService documentIngestionService;
+  @MockitoBean private InterviewDocumentService interviewDocumentService;
+  @MockitoBean private InterviewSessionService interviewSessionService;
+
+  @Autowired private WebApplicationContext webApplicationContext;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+        MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(SecurityMockMvcConfigurers.springSecurity())
+            .build();
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void interviewTextPost_withMatchingRawCsrfCookieAndHeader_succeeds() throws Exception {
+    when(interviewDocumentService.storeText(eq("Q1"), eq("q.md"), eq("admin")))
+        .thenReturn(
+            new InterviewDocumentResponse(
+                "doc1", "q.md", "text/plain", 2, "admin", Instant.now()));
+
+    Cookie xsrf = primeCsrfCookie();
+
+    mockMvc
+        .perform(
+            post("/admin/tools/interview/documents/text")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"text\":\"Q1\",\"filename\":\"q.md\"}")
+                .cookie(xsrf)
+                .header("X-XSRF-TOKEN", xsrf.getValue()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void interviewUploadPost_withMatchingRawCsrfCookieAndHeader_succeeds() throws Exception {
+    when(interviewDocumentService.storeMultipart(any(), eq("admin")))
+        .thenReturn(
+            new InterviewDocumentResponse(
+                "doc2", "q.md", "text/markdown", 5, "admin", Instant.now()));
+
+    Cookie xsrf = primeCsrfCookie();
+    MockMultipartFile file =
+        new MockMultipartFile("file", "q.md", "text/markdown", "hello".getBytes());
+
+    mockMvc
+        .perform(
+            multipart("/admin/tools/interview/documents")
+                .file(file)
+                .cookie(xsrf)
+                .header("X-XSRF-TOKEN", xsrf.getValue()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void interviewTextPost_withoutCsrfHeader_isForbidden() throws Exception {
+    Cookie xsrf = primeCsrfCookie();
+
+    mockMvc
+        .perform(
+            post("/admin/tools/interview/documents/text")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"text\":\"Q1\",\"filename\":\"q.md\"}")
+                .cookie(xsrf))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = "ADMIN")
+  void interviewTextPost_withMismatchedCsrfHeader_isForbidden() throws Exception {
+    Cookie xsrf = primeCsrfCookie();
+
+    mockMvc
+        .perform(
+            post("/admin/tools/interview/documents/text")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"text\":\"Q1\",\"filename\":\"q.md\"}")
+                .cookie(xsrf)
+                .header("X-XSRF-TOKEN", "not-the-cookie-value"))
+        .andExpect(status().isForbidden());
+  }
+
+  private Cookie primeCsrfCookie() throws Exception {
+    MvcResult result = mockMvc.perform(get("/auth/me")).andExpect(status().isOk()).andReturn();
+    Cookie xsrf = result.getResponse().getCookie("XSRF-TOKEN");
+    assertNotNull(xsrf, "GET /auth/me must set XSRF-TOKEN for SPA CSRF priming");
+    assertNotNull(xsrf.getValue());
+    return xsrf;
+  }
+}

--- a/frontend/homepage/cypress/e2e/admin-interview-smoke.cy.ts
+++ b/frontend/homepage/cypress/e2e/admin-interview-smoke.cy.ts
@@ -1,15 +1,30 @@
 describe('Admin interview smoke', () => {
   beforeEach(() => {
-    cy.window().then((win) => {
-      win.sessionStorage.setItem(
-        'auth',
-        JSON.stringify({ username: 'admin', role: 'ADMIN' }),
-      )
-    })
+    cy.intercept('GET', '**/api/auth/me', {
+      statusCode: 200,
+      body: { username: 'admin', role: 'ADMIN' },
+    }).as('authMe')
+
+    cy.intercept('GET', '**/api/realtime/status', {
+      statusCode: 200,
+      body: {
+        liveEnabled: false,
+        voice: 'marin',
+        reasoningEffort: 'low',
+      },
+    }).as('realtimeStatus')
   })
 
   it('loads interview admin page and shows wizard', () => {
-    cy.visit('/admin/interview')
+    cy.visit('/admin/interview', {
+      onBeforeLoad(win) {
+        win.sessionStorage.setItem(
+          'auth',
+          JSON.stringify({ username: 'admin', role: 'ADMIN' }),
+        )
+      },
+    })
+    cy.wait('@authMe')
     cy.contains('Stemmeintervju', { matchCase: false })
     cy.contains('Spørsmål', { matchCase: false })
     cy.contains('Last opp fil med spørsmål', { matchCase: false })

--- a/frontend/homepage/cypress/e2e/admin-smoke.cy.ts
+++ b/frontend/homepage/cypress/e2e/admin-smoke.cy.ts
@@ -16,6 +16,11 @@ describe('Admin smoke', () => {
   }
 
   beforeEach(() => {
+    cy.intercept('GET', '**/api/auth/me', {
+      statusCode: 200,
+      body: { username: 'admin', role: 'ADMIN' },
+    }).as('authMe')
+
     cy.intercept('GET', '**/api/health/chroma', {
       statusCode: 200,
       body: {
@@ -51,6 +56,7 @@ describe('Admin smoke', () => {
         seedAdminSession(win)
       },
     })
+    cy.wait('@authMe')
     cy.wait('@chromaHealth')
     cy.contains('Internal tools').should('be.visible')
     cy.contains('Document pipeline').should('be.visible')
@@ -60,6 +66,7 @@ describe('Admin smoke', () => {
         seedAdminSession(win)
       },
     })
+    cy.wait('@authMe')
     cy.wait('@adminDocumentsList')
     cy.wait('@adminCollections')
     cy.contains('Document pipeline').should('be.visible')

--- a/frontend/homepage/src/__tests__/App.spec.ts
+++ b/frontend/homepage/src/__tests__/App.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import type { Router } from 'vue-router'
@@ -6,11 +6,23 @@ import App from '../App.vue'
 import { createPortfolioRouter } from '../router/createPortfolioRouter'
 import Navbar from '../components/Navbar.vue'
 import { useLangStore } from '../stores/lang'
+import { authMe } from '@/api/generated/portfolio'
+
+vi.mock('@/api/generated/portfolio', async (importOriginal) => {
+	const mod = await importOriginal<typeof import('@/api/generated/portfolio')>()
+	return { ...mod, authMe: vi.fn() }
+})
 
 describe('App shell', () => {
 	beforeEach(() => {
 		sessionStorage.clear()
 		localStorage.clear()
+		vi.mocked(authMe).mockReset()
+		vi.mocked(authMe).mockResolvedValue({
+			status: 200,
+			data: { username: 'admin', role: 'ADMIN' },
+			headers: new Headers(),
+		} as never)
 	})
 
 	function mountAppShell(router: Router) {
@@ -46,6 +58,7 @@ describe('App shell', () => {
 		const { wrapper } = mountAppShell(router)
 		await router.push('/admin/tools')
 		await flushPromises()
+		expect(authMe).toHaveBeenCalled()
 		expect(wrapper.findComponent(Navbar).exists()).toBe(false)
 	})
 

--- a/frontend/homepage/src/lib/__tests__/interview-voice.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/interview-voice.spec.ts
@@ -34,11 +34,23 @@ describe('interview-voice', () => {
   })
 
   it('uploadInterviewDocument throws on non-200', async () => {
-    mockCustomFetch.mockResolvedValue({ status: 400, data: {} })
+    mockCustomFetch.mockResolvedValue({
+      status: 403,
+      data: { error: 'Access denied', code: 'FORBIDDEN' },
+    })
     const { uploadInterviewDocument } = await import('../interview-voice')
     const file = new File(['x'], 'cv.pdf')
 
-    await expect(uploadInterviewDocument(file)).rejects.toThrow('Upload failed (400)')
+    await expect(uploadInterviewDocument(file)).rejects.toThrow('Access denied')
+  })
+
+  it('createInterviewTextDocument throws structured 403 message', async () => {
+    mockCustomFetch.mockResolvedValue({
+      status: 403,
+      data: { error: 'Access denied', code: 'FORBIDDEN' },
+    })
+    const { createInterviewTextDocument } = await import('../interview-voice')
+    await expect(createInterviewTextDocument('hello')).rejects.toThrow('Access denied')
   })
 
   it('createInterviewTextDocument posts JSON body', async () => {

--- a/frontend/homepage/src/lib/interview-voice.ts
+++ b/frontend/homepage/src/lib/interview-voice.ts
@@ -1,4 +1,5 @@
 import { customFetch } from '@/api/orval-mutator'
+import { formatAdminHttpError } from '@/lib/api-error'
 import type {
   SpeechUiLang,
   RealtimeVoiceSessionOptions,
@@ -57,7 +58,7 @@ export async function uploadInterviewDocument(file: File): Promise<InterviewDocu
     '/admin/tools/interview/documents',
     { method: 'POST', body: form },
   )
-  if (r.status !== 200) throw new Error(`Upload failed (${r.status})`)
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
   return r.data
 }
 
@@ -70,7 +71,7 @@ export async function createInterviewTextDocument(text: string, filename?: strin
       body: JSON.stringify({ text, filename }),
     },
   )
-  if (r.status !== 200) throw new Error(`Create document failed (${r.status})`)
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
   return r.data
 }
 
@@ -84,19 +85,22 @@ export async function createInterviewSession(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ documentId, language, voice }),
   })
-  if (r.status !== 200) throw new Error(`Create session failed (${r.status})`)
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
   return r.data
 }
 
 export async function appendInterviewTurns(sessionId: string, turns: InterviewTurn[]): Promise<void> {
-  const r = await customFetch<{ status: number }>(`/admin/tools/interview/sessions/${sessionId}/turns`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      turns: turns.map((t) => ({ role: t.role, text: t.text, sequenceNo: t.sequenceNo })),
-    }),
-  })
-  if (r.status !== 200) throw new Error(`Save turns failed (${r.status})`)
+  const r = await customFetch<{ status: number; data?: unknown }>(
+    `/admin/tools/interview/sessions/${sessionId}/turns`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        turns: turns.map((t) => ({ role: t.role, text: t.text, sequenceNo: t.sequenceNo })),
+      }),
+    },
+  )
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
 }
 
 export async function finalizeInterviewSession(sessionId: string): Promise<InterviewTranscript> {
@@ -104,7 +108,7 @@ export async function finalizeInterviewSession(sessionId: string): Promise<Inter
     `/admin/tools/interview/sessions/${sessionId}/finalize`,
     { method: 'POST' },
   )
-  if (r.status !== 200) throw new Error(`Finalize failed (${r.status})`)
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
   return r.data
 }
 
@@ -113,7 +117,7 @@ export async function cleanInterviewTranscript(transcriptId: string): Promise<In
     `/admin/tools/interview/transcripts/${transcriptId}/clean`,
     { method: 'POST' },
   )
-  if (r.status !== 200) throw new Error(`Clean failed (${r.status})`)
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
   return r.data
 }
 
@@ -123,7 +127,7 @@ export async function ingestInterviewTranscript(transcriptId: string, force = fa
     `/admin/tools/interview/transcripts/${transcriptId}/ingest${q}`,
     { method: 'POST' },
   )
-  if (r.status !== 200) throw new Error(`Ingest failed (${r.status})`)
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
   return r.data
 }
 

--- a/frontend/homepage/src/router/__tests__/adminRouteGuard.spec.ts
+++ b/frontend/homepage/src/router/__tests__/adminRouteGuard.spec.ts
@@ -1,13 +1,20 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { authMe } from '@/api/generated/portfolio'
 import { registerAdminRouteGuard } from '../guards'
+
+vi.mock('@/api/generated/portfolio', async (importOriginal) => {
+	const mod = await importOriginal<typeof import('@/api/generated/portfolio')>()
+	return { ...mod, authMe: vi.fn() }
+})
 
 describe('registerAdminRouteGuard', () => {
 	beforeEach(() => {
 		sessionStorage.clear()
 		setActivePinia(createPinia())
+		vi.mocked(authMe).mockReset()
 	})
 
 	function buildRouter() {
@@ -27,21 +34,56 @@ describe('registerAdminRouteGuard', () => {
 		return router
 	}
 
-	it('redirects non-admin away from admin route', async () => {
-		const router = buildRouter()
-		await router.push('/admin/tools')
-		expect(router.currentRoute.value.path).toBe('/')
-	})
-
-	it('allows admin to open admin route', async () => {
+	it('redirects when server session is not admin', async () => {
 		sessionStorage.setItem(
 			'auth',
 			JSON.stringify({ username: 'a', role: 'ADMIN' }),
 		)
+		vi.mocked(authMe).mockResolvedValue({
+			status: 401,
+			data: { error: 'Not authenticated' },
+			headers: new Headers(),
+		} as never)
+
+		const router = buildRouter()
+		await router.push('/admin/tools')
+		expect(router.currentRoute.value.path).toBe('/')
+		expect(authMe).toHaveBeenCalled()
+	})
+
+	it('allows admin after server session validation and CSRF priming via authMe', async () => {
+		sessionStorage.setItem(
+			'auth',
+			JSON.stringify({ username: 'stale', role: 'ADMIN' }),
+		)
+		vi.mocked(authMe).mockResolvedValue({
+			status: 200,
+			data: { username: 'admin', role: 'ADMIN' },
+			headers: new Headers(),
+		} as never)
+
 		const router = buildRouter()
 		await router.push('/admin/tools')
 		expect(router.currentRoute.value.path).toBe('/admin/tools')
+		expect(authMe).toHaveBeenCalled()
 		const auth = useAuthStore()
+		expect(auth.username).toBe('admin')
 		expect(auth.role).toBe('ADMIN')
+	})
+
+	it('redirects non-admin role from server', async () => {
+		sessionStorage.setItem(
+			'auth',
+			JSON.stringify({ username: 'u', role: 'ADMIN' }),
+		)
+		vi.mocked(authMe).mockResolvedValue({
+			status: 200,
+			data: { username: 'u', role: 'USER' },
+			headers: new Headers(),
+		} as never)
+
+		const router = buildRouter()
+		await router.push('/admin/tools')
+		expect(router.currentRoute.value.path).toBe('/')
 	})
 })

--- a/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
+++ b/frontend/homepage/src/router/__tests__/routerIndex.spec.ts
@@ -1,11 +1,23 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
+import { authMe } from '@/api/generated/portfolio'
 import { createPortfolioRouter } from '../createPortfolioRouter'
+
+vi.mock('@/api/generated/portfolio', async (importOriginal) => {
+	const mod = await importOriginal<typeof import('@/api/generated/portfolio')>()
+	return { ...mod, authMe: vi.fn() }
+})
 
 describe('application router (index)', () => {
 	beforeEach(() => {
 		sessionStorage.clear()
 		setActivePinia(createPinia())
+		vi.mocked(authMe).mockReset()
+		vi.mocked(authMe).mockResolvedValue({
+			status: 200,
+			data: { username: 'admin', role: 'ADMIN' },
+			headers: new Headers(),
+		} as never)
 	})
 
 	it('registers portfolio and admin route names', () => {
@@ -97,7 +109,7 @@ describe('application router (index)', () => {
 		expect(router.currentRoute.value.name).toBe('feedback')
 	})
 
-	it('allows admin routes when ADMIN session is restored', async () => {
+	it('allows admin routes when ADMIN session is validated via authMe', async () => {
 		sessionStorage.setItem(
 			'auth',
 			JSON.stringify({ username: 'admin', role: 'ADMIN' }),
@@ -106,6 +118,7 @@ describe('application router (index)', () => {
 
 		await router.push('/admin/tools')
 		expect(router.currentRoute.value.name).toBe('admin-tools')
+		expect(authMe).toHaveBeenCalled()
 
 		await router.push('/admin/pipeline')
 		expect(router.currentRoute.value.name).toBe('admin-pipeline')

--- a/frontend/homepage/src/router/guards.ts
+++ b/frontend/homepage/src/router/guards.ts
@@ -2,17 +2,19 @@ import type { Router } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 
 /**
- * Blocks navigation to routes with meta.requiresAdmin unless the SPA has a restored ADMIN session
- * (see auth store: JSON + Basic token in sessionStorage after POST /auth/login).
+ * Blocks navigation to routes with meta.requiresAdmin unless the server session is ADMIN.
+ * Calls GET /auth/me to validate the httpOnly cookie and prime XSRF-TOKEN before mutations.
  */
 export function registerAdminRouteGuard(router: Router) {
-	router.beforeEach((to) => {
-		if (to.meta.requiresAdmin) {
-			const auth = useAuthStore()
-			auth.restore()
-			if (auth.role !== 'ADMIN') {
-				return { path: '/' }
-			}
+	router.beforeEach(async (to) => {
+		if (!to.meta.requiresAdmin) {
+			return true
+		}
+		const auth = useAuthStore()
+		auth.restore()
+		const isAdmin = await auth.ensureAdminSession()
+		if (!isAdmin) {
+			return { path: '/' }
 		}
 		return true
 	})

--- a/frontend/homepage/src/stores/__tests__/auth.spec.ts
+++ b/frontend/homepage/src/stores/__tests__/auth.spec.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import { authLogin, authLogout } from '@/api/generated/portfolio'
+import { authLogin, authLogout, authMe } from '@/api/generated/portfolio'
 import { useAuthStore } from '../auth'
 
 vi.mock('@/api/generated/portfolio', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@/api/generated/portfolio')>()
-  return { ...mod, authLogin: vi.fn(), authLogout: vi.fn() }
+  return { ...mod, authLogin: vi.fn(), authLogout: vi.fn(), authMe: vi.fn() }
 })
 
 describe('auth store', () => {
@@ -14,6 +14,12 @@ describe('auth store', () => {
     sessionStorage.clear()
     vi.mocked(authLogin).mockReset()
     vi.mocked(authLogout).mockReset()
+    vi.mocked(authMe).mockReset()
+    vi.mocked(authMe).mockResolvedValue({
+      status: 200,
+      data: { username: 'GOAT', role: 'ADMIN' },
+      headers: new Headers(),
+    } as never)
   })
 
   it('stores username and role after successful login', async () => {
@@ -31,13 +37,13 @@ describe('auth store', () => {
     expect(store.isAdmin).toBe(true)
     expect(sessionStorage.getItem('auth')).toContain('"username":"GOAT"')
     expect(sessionStorage.getItem('auth')).not.toContain('basicToken')
+    expect(authMe).toHaveBeenCalled()
   })
 
   it('throws on failed login', async () => {
     vi.mocked(authLogin).mockResolvedValue({
       status: 401,
       data: { error: 'Invalid credentials' },
-      headers: new Headers(),
     } as never)
 
     const store = useAuthStore()
@@ -78,5 +84,27 @@ describe('auth store', () => {
     store.restore()
     expect(store.username).toBe('kevin')
     expect(store.role).toBe('USER')
+  })
+
+  it('ensureAdminSession refreshes role from server and returns false on 401', async () => {
+    const store = useAuthStore()
+    store.$patch({ username: 'stale', role: 'ADMIN' })
+
+    vi.mocked(authMe).mockResolvedValueOnce({
+      status: 200,
+      data: { username: 'admin', role: 'ADMIN' },
+      headers: new Headers(),
+    } as never)
+    await expect(store.ensureAdminSession()).resolves.toBe(true)
+    expect(store.username).toBe('admin')
+
+    vi.mocked(authMe).mockResolvedValueOnce({
+      status: 401,
+      data: { error: 'Not authenticated' },
+      headers: new Headers(),
+    } as never)
+    await expect(store.ensureAdminSession()).resolves.toBe(false)
+    expect(store.role).toBeNull()
+    expect(sessionStorage.getItem('auth')).toBeNull()
   })
 })

--- a/frontend/homepage/src/stores/auth.ts
+++ b/frontend/homepage/src/stores/auth.ts
@@ -17,6 +17,31 @@ export const useAuthStore = defineStore('auth', {
     isAdmin: (state) => state.role === 'ADMIN',
   },
   actions: {
+    clearLocal() {
+      this.username = null
+      this.role = null
+      sessionStorage.removeItem('auth')
+    },
+    /**
+     * Validates the httpOnly session via GET /auth/me (also primes XSRF-TOKEN for admin mutations)
+     * and refreshes client role from the server. Returns true only for an ADMIN session.
+     */
+    async ensureAdminSession(): Promise<boolean> {
+      try {
+        const r = await authMe()
+        if (r.status !== 200) {
+          this.clearLocal()
+          return false
+        }
+        this.username = r.data.username
+        this.role = r.data.role as 'USER' | 'ADMIN'
+        sessionStorage.setItem('auth', JSON.stringify({ username: this.username, role: this.role }))
+        return this.role === 'ADMIN'
+      } catch {
+        this.clearLocal()
+        return false
+      }
+    },
     async login(username: string, password: string) {
       const r = await authLogin({ username, password })
       if (r.status !== 200) {
@@ -29,7 +54,7 @@ export const useAuthStore = defineStore('auth', {
       try {
         await authMe()
       } catch {
-        // Session cookie is set; CSRF priming is best-effort
+        // Session cookie is set; CSRF priming is best-effort until the admin route guard runs.
       }
     },
     async logout() {
@@ -38,9 +63,7 @@ export const useAuthStore = defineStore('auth', {
       } catch {
         // Clear local state even if the network call fails
       }
-      this.username = null
-      this.role = null
-      sessionStorage.removeItem('auth')
+      this.clearLocal()
     },
     /** Hydrates Pinia from sessionStorage on hard refresh (router guard calls this before admin routes). */
     restore() {


### PR DESCRIPTION
## Summary
- Align Spring Security CSRF with SPA `csrf.spa()` so raw `XSRF-TOKEN` cookie values in `X-XSRF-TOKEN` succeed for admin mutations.
- Validate admin routes via `GET /auth/me` (server session + CSRF priming) instead of trusting `sessionStorage` alone.
- Surface structured API errors for interview upload/save failures.

## Root cause
Production returned 403 on `POST /admin/tools/interview/documents` and `.../documents/text` because the default XOR CSRF request handler rejected the SPA's raw cookie header, and the interview page did not guarantee CSRF cookie priming.

## Test plan
- [x] `SecuritySpaCsrfIT` (matching cookie/header succeeds; missing/mismatched header is 403)
- [x] Frontend guard/auth/interview-voice unit tests
- [ ] CI green
- [ ] After merge: verify save/upload on production admin interview page