### PR TITLE
CHORE: ignore local interview-questions directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 docs/
 frontend/homepage/docs/
 
+# Interview question bank (local practice material)
+interview-questions/
+
 # Git hooks (local setup)
 lefthook.yml
 


### PR DESCRIPTION
## Summary
- Ignore the local `interview-questions/` practice bank so personal interview material stays out of git.

## Test plan
- [x] Confirm only `.gitignore` changed
- [ ] After merge, verify `interview-questions/` remains untracked locally