### PR TITLE
FEATURE: longer voice interviews with resume and stronger models

### DIFF
--- a/backend/src/main/java/com/kevinmazali/portfolio/PortfolioApplication.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/PortfolioApplication.java
@@ -6,6 +6,7 @@ import com.kevinmazali.portfolio.config.AiLimitsProperties;
 import com.kevinmazali.portfolio.config.AskRateLimitProperties;
 import com.kevinmazali.portfolio.config.DatasetGenerateRateLimitProperties;
 import com.kevinmazali.portfolio.config.ExperimentRunRateLimitProperties;
+import com.kevinmazali.portfolio.config.InterviewProperties;
 import com.kevinmazali.portfolio.config.PostHogProperties;
 import com.kevinmazali.portfolio.config.RealtimeLookupRateLimitProperties;
 import com.kevinmazali.portfolio.config.RealtimeProperties;
@@ -30,6 +31,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     AskRateLimitProperties.class,
     ExperimentRunRateLimitProperties.class,
     DatasetGenerateRateLimitProperties.class,
+    InterviewProperties.class,
     PostHogProperties.class,
     RealtimeProperties.class,
     RealtimeRateLimitProperties.class,

--- a/backend/src/main/java/com/kevinmazali/portfolio/config/InterviewProperties.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/InterviewProperties.java
@@ -1,0 +1,55 @@
+package com.kevinmazali.portfolio.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Admin voice-interview defaults for Realtime input transcription and post-save cleaning.
+ */
+@ConfigurationProperties(prefix = "portfolio.interview")
+public class InterviewProperties {
+
+  /** OpenAI Realtime input audio transcription model. */
+  private String transcriptionModel = "gpt-4o-transcribe";
+
+  /** Chat model used to normalize cleaned interview transcripts for ingest. */
+  private String cleanModel = "gpt-5.4-mini";
+
+  private int cleanMaxTokens = 8192;
+
+  public String getTranscriptionModel() {
+    return transcriptionModel;
+  }
+
+  public void setTranscriptionModel(String transcriptionModel) {
+    this.transcriptionModel = transcriptionModel;
+  }
+
+  public String getCleanModel() {
+    return cleanModel;
+  }
+
+  public void setCleanModel(String cleanModel) {
+    this.cleanModel = cleanModel;
+  }
+
+  public int getCleanMaxTokens() {
+    return cleanMaxTokens;
+  }
+
+  public void setCleanMaxTokens(int cleanMaxTokens) {
+    this.cleanMaxTokens = cleanMaxTokens;
+  }
+
+  public String resolvedTranscriptionModel() {
+    return StringUtils.hasText(transcriptionModel) ? transcriptionModel.trim() : "gpt-4o-transcribe";
+  }
+
+  public String resolvedCleanModel() {
+    return StringUtils.hasText(cleanModel) ? cleanModel.trim() : "gpt-5.4-mini";
+  }
+
+  public int resolvedCleanMaxTokens() {
+    return cleanMaxTokens > 0 ? cleanMaxTokens : 8192;
+  }
+}

--- a/backend/src/main/java/com/kevinmazali/portfolio/config/WebConfig.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/config/WebConfig.java
@@ -382,8 +382,8 @@ public class WebConfig {
 
     private Bucket newInterviewRealtimeBucket() {
         Bandwidth limit = Bandwidth.builder()
-            .capacity(5)
-            .refillGreedy(5, Duration.ofHours(1))
+            .capacity(20)
+            .refillGreedy(20, Duration.ofHours(1))
             .build();
         return Bucket.builder().addLimit(limit).build();
     }

--- a/backend/src/main/java/com/kevinmazali/portfolio/controller/InterviewController.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/controller/InterviewController.java
@@ -106,6 +106,12 @@ public class InterviewController {
     return ResponseEntity.ok(interviewSessionService.finalizeSession(id));
   }
 
+  @Operation(summary = "Reopen a finalized interview session for more voice turns")
+  @PostMapping("/sessions/{id}/reopen")
+  public ResponseEntity<InterviewSessionResponse> reopenSession(@PathVariable String id) {
+    return ResponseEntity.ok(interviewSessionService.reopenSession(id));
+  }
+
   @Operation(summary = "Create admin interview Realtime WebRTC session")
   @PostMapping(value = "/sessions/{id}/realtime/session", consumes = {"application/sdp", "text/plain"})
   public ResponseEntity<?> createRealtimeSession(

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionService.java
@@ -3,6 +3,7 @@ package com.kevinmazali.portfolio.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.config.InterviewProperties;
 import com.kevinmazali.portfolio.config.RealtimeProperties;
 import com.kevinmazali.portfolio.exception.RealtimeErrorCode;
 import com.kevinmazali.portfolio.exception.RealtimeSessionException;
@@ -33,6 +34,7 @@ public class InterviewRealtimeSessionService {
   private static final String OPENAI_REALTIME_CALLS = "https://api.openai.com/v1/realtime/calls";
 
   private final RealtimeProperties realtimeProperties;
+  private final InterviewProperties interviewProperties;
   private final AiBudgetService aiBudgetService;
   private final AiBudgetProperties budgetProperties;
   private final AiCircuitBreaker aiCircuitBreaker;
@@ -49,6 +51,7 @@ public class InterviewRealtimeSessionService {
 
   public InterviewRealtimeSessionService(
       RealtimeProperties realtimeProperties,
+      InterviewProperties interviewProperties,
       AiBudgetService aiBudgetService,
       AiBudgetProperties budgetProperties,
       AiCircuitBreaker aiCircuitBreaker,
@@ -58,6 +61,7 @@ public class InterviewRealtimeSessionService {
       InterviewSessionRepository sessionRepository,
       @Value("${spring.ai.openai.api-key:}") String openAiApiKey) {
     this.realtimeProperties = realtimeProperties;
+    this.interviewProperties = interviewProperties;
     this.aiBudgetService = aiBudgetService;
     this.budgetProperties = budgetProperties;
     this.aiCircuitBreaker = aiCircuitBreaker;
@@ -219,7 +223,7 @@ public class InterviewRealtimeSessionService {
 
     ObjectNode input = objectMapper.createObjectNode();
     ObjectNode transcription = objectMapper.createObjectNode();
-    transcription.put("model", "whisper-1");
+    transcription.put("model", interviewProperties.resolvedTranscriptionModel());
     input.set("transcription", transcription);
 
     ObjectNode turnDetection = objectMapper.createObjectNode();

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewSessionService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewSessionService.java
@@ -79,7 +79,7 @@ public class InterviewSessionService {
   }
 
   public InterviewSessionResponse getSession(String sessionId) {
-    InterviewSessionEntity session = requireActiveSession(sessionId);
+    InterviewSessionEntity session = requireExistingSession(sessionId);
     List<InterviewTurnDto> turns = loadTurns(sessionId);
     InterviewTranscriptEntity transcript = transcriptRepository.findBySessionId(sessionId).orElse(null);
     return toResponse(session, turns, transcript);
@@ -87,7 +87,7 @@ public class InterviewSessionService {
 
   @Transactional
   public void appendTurns(String sessionId, InterviewTurnBatchRequest request) {
-    requireActiveSession(sessionId);
+    requireLiveSession(sessionId);
     if (request == null || request.turns() == null || request.turns().isEmpty()) {
       return;
     }
@@ -117,23 +117,46 @@ public class InterviewSessionService {
 
   @Transactional
   public InterviewTranscriptResponse finalizeSession(String sessionId) {
-    InterviewSessionEntity session = requireActiveSession(sessionId);
+    InterviewSessionEntity session = requireExistingSession(sessionId);
+    if (!STATUS_ACTIVE.equals(session.getStatus()) && !STATUS_FINALIZED.equals(session.getStatus())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Session cannot be finalized");
+    }
     List<InterviewTurnDto> turns = loadTurns(sessionId);
     String raw = transcriptCleanerService.structureRawTranscript(turns);
-    String transcriptId = UUID.randomUUID().toString().replace("-", "");
     InterviewTranscriptEntity transcript =
-        InterviewTranscriptEntity.builder()
-            .id(transcriptId)
-            .sessionId(sessionId)
-            .rawText(raw)
-            .cleanStatus(CLEAN_PENDING)
-            .createdAt(Instant.now())
-            .build();
+        transcriptRepository
+            .findBySessionId(sessionId)
+            .orElseGet(
+                () ->
+                    InterviewTranscriptEntity.builder()
+                        .id(UUID.randomUUID().toString().replace("-", ""))
+                        .sessionId(sessionId)
+                        .createdAt(Instant.now())
+                        .build());
+    transcript.setRawText(raw);
+    transcript.setCleanStatus(CLEAN_PENDING);
+    transcript.setCleanedText(null);
+    transcript.setCleanedAt(null);
+    transcript.setIngestedDocumentId(null);
     transcriptRepository.save(transcript);
     session.setStatus(STATUS_FINALIZED);
     session.setEndedAt(Instant.now());
     sessionRepository.save(session);
     return toTranscriptResponse(transcript);
+  }
+
+  @Transactional
+  public InterviewSessionResponse reopenSession(String sessionId) {
+    InterviewSessionEntity session = requireExistingSession(sessionId);
+    if (!STATUS_FINALIZED.equals(session.getStatus())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only finalized sessions can be reopened");
+    }
+    session.setStatus(STATUS_ACTIVE);
+    session.setEndedAt(null);
+    sessionRepository.save(session);
+    List<InterviewTurnDto> turns = loadTurns(sessionId);
+    InterviewTranscriptEntity transcript = transcriptRepository.findBySessionId(sessionId).orElse(null);
+    return toResponse(session, turns, transcript);
   }
 
   @Transactional
@@ -201,7 +224,10 @@ public class InterviewSessionService {
     sessionRepository.save(session);
   }
 
-  InterviewSessionEntity requireActiveSession(String sessionId) {
+  /**
+   * Returns a non-deleted session (ACTIVE or FINALIZED). Soft-deleted sessions are not found.
+   */
+  InterviewSessionEntity requireExistingSession(String sessionId) {
     InterviewSessionEntity session =
         sessionRepository
             .findById(sessionId)
@@ -210,6 +236,20 @@ public class InterviewSessionService {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found");
     }
     return session;
+  }
+
+  /** Live voice and turn append require an ACTIVE, non-deleted session. */
+  InterviewSessionEntity requireLiveSession(String sessionId) {
+    InterviewSessionEntity session = requireExistingSession(sessionId);
+    if (!STATUS_ACTIVE.equals(session.getStatus())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Interview session is not active");
+    }
+    return session;
+  }
+
+  /** @deprecated Prefer {@link #requireExistingSession(String)} or {@link #requireLiveSession(String)}. */
+  InterviewSessionEntity requireActiveSession(String sessionId) {
+    return requireExistingSession(sessionId);
   }
 
   private InterviewTranscriptEntity requireTranscript(String transcriptId) {

--- a/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerService.java
+++ b/backend/src/main/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerService.java
@@ -1,6 +1,7 @@
 package com.kevinmazali.portfolio.service;
 
 import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.config.InterviewProperties;
 import com.kevinmazali.portfolio.model.SanitizeResult;
 import com.kevinmazali.portfolio.model.interview.InterviewTurnDto;
 import com.kevinmazali.portfolio.util.AiRequestContext;
@@ -30,6 +31,7 @@ public class InterviewTranscriptCleanerService {
   private final AiBudgetService aiBudgetService;
   private final AiBudgetProperties budgetProperties;
   private final AiCircuitBreaker aiCircuitBreaker;
+  private final InterviewProperties interviewProperties;
 
   private volatile String cleanPromptEn;
   private volatile String cleanPromptNo;
@@ -40,13 +42,15 @@ public class InterviewTranscriptCleanerService {
       ObjectProvider<OpenAiChatModel> openAiChatModel,
       AiBudgetService aiBudgetService,
       AiBudgetProperties budgetProperties,
-      AiCircuitBreaker aiCircuitBreaker) {
+      AiCircuitBreaker aiCircuitBreaker,
+      InterviewProperties interviewProperties) {
     this.noiseCleaner = noiseCleaner;
     this.piiSanitizerProvider = piiSanitizerProvider;
     this.openAiChatModel = openAiChatModel;
     this.aiBudgetService = aiBudgetService;
     this.budgetProperties = budgetProperties;
     this.aiCircuitBreaker = aiCircuitBreaker;
+    this.interviewProperties = interviewProperties;
   }
 
   public String structureRawTranscript(List<InterviewTurnDto> turns) {
@@ -92,8 +96,10 @@ public class InterviewTranscriptCleanerService {
     try {
       aiCircuitBreaker.assertClosed();
       aiBudgetService.assertWithinBudget(budgetUserId, anonymous);
+      String cleanModel = interviewProperties.resolvedCleanModel();
+      int maxTokens = interviewProperties.resolvedCleanMaxTokens();
       OpenAiChatOptions options =
-          OpenAiChatOptions.builder().model("gpt-4o-mini").maxTokens(2000).temperature(0.2).build();
+          OpenAiChatOptions.builder().model(cleanModel).maxTokens(maxTokens).temperature(0.2).build();
       ChatResponse response = model.call(new Prompt(promptText, options));
       String output =
           response.getResult() != null && response.getResult().getOutput() != null
@@ -104,9 +110,9 @@ public class InterviewTranscriptCleanerService {
       }
       aiBudgetService.recordUsage(
           budgetUserId,
-          "gpt-4o-mini",
+          cleanModel,
           500,
-          1500,
+          Math.min(1500, maxTokens),
           anonymous,
           null,
           "interview_transcript_clean");

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -138,6 +138,10 @@ portfolio:
       window-seconds: 300
   chat:
     default-model-id: gpt-5.4-mini
+  interview:
+    transcription-model: gpt-4o-transcribe
+    clean-model: gpt-5.4-mini
+    clean-max-tokens: 8192
   # OpenAI Realtime (WebRTC) — disabled by default; set PORTFOLIO_REALTIME_ENABLED=true and OPENAI_API_KEY to enable.
   realtime:
     enabled: ${PORTFOLIO_REALTIME_ENABLED:false}

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewRealtimeSessionServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.config.InterviewProperties;
 import com.kevinmazali.portfolio.config.RealtimeProperties;
 import com.kevinmazali.portfolio.exception.RealtimeErrorCode;
 import com.kevinmazali.portfolio.exception.RealtimeSessionException;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -44,6 +46,7 @@ class InterviewRealtimeSessionServiceTest {
   @Mock private InterviewSessionRepository sessionRepository;
 
   private RealtimeProperties realtimeProperties;
+  private InterviewProperties interviewProperties;
   private AiBudgetProperties budgetProperties;
   private InterviewRealtimeSessionService service;
 
@@ -58,6 +61,8 @@ class InterviewRealtimeSessionServiceTest {
     realtimeProperties.setReservationInputTokens(100);
     realtimeProperties.setReservationOutputTokens(200);
 
+    interviewProperties = new InterviewProperties();
+
     budgetProperties = new AiBudgetProperties();
     budgetProperties.setAnonIdentitySalt("test-salt");
     budgetProperties.setEnabled(false);
@@ -70,6 +75,7 @@ class InterviewRealtimeSessionServiceTest {
     service =
         new InterviewRealtimeSessionService(
             realtimeProperties,
+            interviewProperties,
             aiBudgetService,
             budgetProperties,
             aiCircuitBreaker,
@@ -98,6 +104,23 @@ class InterviewRealtimeSessionServiceTest {
   }
 
   @Test
+  void createInterviewCall_usesConfiguredTranscriptionModel() throws Exception {
+    stubActiveSession("sess1", "doc1");
+    when(interviewDocumentService.contextForSession("doc1")).thenReturn("Document context");
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn("v=0");
+    ArgumentCaptor<java.net.http.HttpRequest> captor =
+        ArgumentCaptor.forClass(java.net.http.HttpRequest.class);
+    when(openAiRealtimeHttpInvoker.invoke(captor.capture())).thenReturn(response);
+
+    service.createInterviewCall("sess1", "v=0", "en", null, null, null);
+
+    String raw = drainHttpBody(captor.getValue());
+    assertThat(raw).contains("\"model\":\"gpt-4o-transcribe\"");
+  }
+
+  @Test
   void createInterviewCall_rejectsWhenRealtimeDisabled() throws Exception {
     realtimeProperties.setEnabled(false);
 
@@ -113,6 +136,7 @@ class InterviewRealtimeSessionServiceTest {
     InterviewRealtimeSessionService svc =
         new InterviewRealtimeSessionService(
             realtimeProperties,
+            interviewProperties,
             aiBudgetService,
             budgetProperties,
             aiCircuitBreaker,
@@ -175,5 +199,41 @@ class InterviewRealtimeSessionServiceTest {
                     .voice("marin")
                     .startedAt(Instant.now())
                     .build()));
+  }
+
+  private static String drainHttpBody(java.net.http.HttpRequest request) throws Exception {
+    java.util.concurrent.Flow.Publisher<java.nio.ByteBuffer> publisher =
+        request.bodyPublisher().orElseThrow();
+    java.util.concurrent.CompletableFuture<java.io.ByteArrayOutputStream> done =
+        new java.util.concurrent.CompletableFuture<>();
+    publisher.subscribe(
+        new java.util.concurrent.Flow.Subscriber<>() {
+          private java.util.concurrent.Flow.Subscription subscription;
+          final java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+
+          @Override
+          public void onSubscribe(java.util.concurrent.Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(java.nio.ByteBuffer item) {
+            byte[] chunk = new byte[item.remaining()];
+            item.get(chunk);
+            out.writeBytes(chunk);
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            done.completeExceptionally(throwable);
+          }
+
+          @Override
+          public void onComplete() {
+            done.complete(out);
+          }
+        });
+    return done.get().toString(java.nio.charset.StandardCharsets.UTF_8);
   }
 }

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewSessionServiceTest.java
@@ -139,6 +139,7 @@ class InterviewSessionServiceTest {
                     .text("Answer")
                     .sequenceNo(0)
                     .build()));
+    when(transcriptRepository.findBySessionId("sess1")).thenReturn(Optional.empty());
     when(transcriptCleanerService.structureRawTranscript(any())).thenReturn("raw transcript");
     when(transcriptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
     when(sessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -152,6 +153,98 @@ class InterviewSessionServiceTest {
     verify(sessionRepository).save(sessionCaptor.capture());
     assertThat(sessionCaptor.getValue().getStatus()).isEqualTo(InterviewSessionService.STATUS_FINALIZED);
     assertThat(sessionCaptor.getValue().getEndedAt()).isNotNull();
+  }
+
+  @Test
+  void finalizeSession_upsertsExistingTranscriptAndResetsCleanState() {
+    stubActiveSession("sess1");
+    when(turnRepository.findBySessionIdOrderBySequenceNoAsc("sess1"))
+        .thenReturn(
+            List.of(
+                InterviewTranscriptTurnEntity.builder()
+                    .sessionId("sess1")
+                    .role("user")
+                    .text("More")
+                    .sequenceNo(1)
+                    .build()));
+    InterviewTranscriptEntity existing =
+        InterviewTranscriptEntity.builder()
+            .id("tr-existing")
+            .sessionId("sess1")
+            .rawText("old")
+            .cleanedText("old cleaned")
+            .cleanStatus(InterviewSessionService.CLEAN_CLEANED)
+            .ingestedDocumentId("ing1")
+            .cleanedAt(Instant.now())
+            .createdAt(Instant.now())
+            .build();
+    when(transcriptRepository.findBySessionId("sess1")).thenReturn(Optional.of(existing));
+    when(transcriptCleanerService.structureRawTranscript(any())).thenReturn("updated raw");
+    when(transcriptRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(sessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var response = service.finalizeSession("sess1");
+
+    assertThat(response.id()).isEqualTo("tr-existing");
+    assertThat(response.rawText()).isEqualTo("updated raw");
+    assertThat(response.cleanStatus()).isEqualTo(InterviewSessionService.CLEAN_PENDING);
+    assertThat(response.cleanedText()).isNull();
+    assertThat(response.ingestedDocumentId()).isNull();
+    assertThat(existing.getCleanedAt()).isNull();
+  }
+
+  @Test
+  void reopenSession_setsActiveAndClearsEndedAt() {
+    InterviewSessionEntity session =
+        InterviewSessionEntity.builder()
+            .id("sess1")
+            .documentId("doc1")
+            .language("en")
+            .status(InterviewSessionService.STATUS_FINALIZED)
+            .startedAt(Instant.now())
+            .endedAt(Instant.now())
+            .build();
+    when(sessionRepository.findById("sess1")).thenReturn(Optional.of(session));
+    when(sessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(turnRepository.findBySessionIdOrderBySequenceNoAsc("sess1")).thenReturn(List.of());
+    when(transcriptRepository.findBySessionId("sess1")).thenReturn(Optional.empty());
+
+    InterviewSessionResponse response = service.reopenSession("sess1");
+
+    assertThat(response.status()).isEqualTo(InterviewSessionService.STATUS_ACTIVE);
+    assertThat(response.endedAt()).isNull();
+    assertThat(session.getStatus()).isEqualTo(InterviewSessionService.STATUS_ACTIVE);
+    assertThat(session.getEndedAt()).isNull();
+  }
+
+  @Test
+  void reopenSession_rejectsActiveSession() {
+    stubActiveSession("sess1");
+
+    assertThatThrownBy(() -> service.reopenSession("sess1"))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Only finalized");
+  }
+
+  @Test
+  void appendTurns_rejectsFinalizedSession() {
+    when(sessionRepository.findById("sess1"))
+        .thenReturn(
+            Optional.of(
+                InterviewSessionEntity.builder()
+                    .id("sess1")
+                    .documentId("doc1")
+                    .language("en")
+                    .status(InterviewSessionService.STATUS_FINALIZED)
+                    .startedAt(Instant.now())
+                    .build()));
+
+    assertThatThrownBy(
+            () ->
+                service.appendTurns(
+                    "sess1", new InterviewTurnBatchRequest(List.of(new InterviewTurnDto("user", "hi", 0)))))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("not active");
   }
 
   @Test

--- a/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerServiceTest.java
+++ b/backend/src/test/java/com/kevinmazali/portfolio/service/InterviewTranscriptCleanerServiceTest.java
@@ -1,6 +1,7 @@
 package com.kevinmazali.portfolio.service;
 
 import com.kevinmazali.portfolio.config.AiBudgetProperties;
+import com.kevinmazali.portfolio.config.InterviewProperties;
 import com.kevinmazali.portfolio.model.interview.InterviewTurnDto;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,8 @@ class InterviewTranscriptCleanerServiceTest {
             mock(ObjectProvider.class),
             mock(AiBudgetService.class),
             new AiBudgetProperties(),
-            mock(AiCircuitBreaker.class));
+            mock(AiCircuitBreaker.class),
+            new InterviewProperties());
 
     String raw =
         service.structureRawTranscript(
@@ -46,7 +48,8 @@ class InterviewTranscriptCleanerServiceTest {
             openAiProvider,
             mock(AiBudgetService.class),
             new AiBudgetProperties(),
-            mock(AiCircuitBreaker.class));
+            mock(AiCircuitBreaker.class),
+            new InterviewProperties());
 
     String cleaned = service.cleanForIngest("Kevin studies at NTNU.\n\nPage 1 of 1\n", "en");
     assertThat(cleaned).contains("NTNU");

--- a/frontend/homepage/src/components/voice/RealtimeVoicePanel.vue
+++ b/frontend/homepage/src/components/voice/RealtimeVoicePanel.vue
@@ -75,8 +75,8 @@ const copy = computed(() => {
     assistant: en ? 'AI assistant (transcript)' : 'AI-assistent (transkripsjon)',
     warningTitle: en ? 'Tips for clearer voice' : 'Tips for klarere stemme',
     warningBody: en
-      ? 'Use a headset in a quiet place when you can. Raise speaking patience if you get cut off mid-sentence. Each live session ends after about 5 minutes — reconnect to continue. Prefer typing? Use text chat instead.'
-      : 'Bruk headset på et stille sted når du kan. Øk snakkepause hvis du blir avbrutt midt i setningen. Hver live-økt avsluttes etter ca. 5 minutter — koble til på nytt for å fortsette. Foretrekker du å skrive? Bruk tekstchat.',
+      ? `Use a headset in a quiet place when you can. Raise speaking patience if you get cut off mid-sentence. Each live session ends after about ${Math.round(maxSessionMs / 60_000)} minutes — reconnect to continue. Prefer typing? Use text chat instead.`
+      : `Bruk headset på et stille sted når du kan. Øk snakkepause hvis du blir avbrutt midt i setningen. Hver live-økt avsluttes etter ca. ${Math.round(maxSessionMs / 60_000)} minutter — koble til på nytt for å fortsette. Foretrekker du å skrive? Bruk tekstchat.`,
   }
 })
 

--- a/frontend/homepage/src/composables/__tests__/useInterviewVoice.spec.ts
+++ b/frontend/homepage/src/composables/__tests__/useInterviewVoice.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@/composables/useRealtimeVoice', () => ({
       connect: vi.fn(),
       disconnect: vi.fn(),
       stopResponse: vi.fn(),
-      maxSessionMs: 300_000,
+      maxSessionMs: voiceOptions?.maxSessionMs ?? 300_000,
     }
   }),
 }))
@@ -38,5 +38,33 @@ describe('useInterviewVoice', () => {
     expect(committedTurns.value).toHaveLength(1)
     expect(committedTurns.value[0]?.role).toBe('user')
     expect(committedTurns.value[0]?.text).toBe('hello')
+  })
+
+  it('passes 30-minute maxSessionMs to useRealtimeVoice', async () => {
+    const { useRealtimeVoice } = await import('../useRealtimeVoice')
+    const sessionId = ref('sess-1')
+    const lang = ref<'en' | 'no'>('no')
+    const api = useInterviewVoice(sessionId, lang)
+    expect(useRealtimeVoice).toHaveBeenCalledWith(
+      lang,
+      undefined,
+      undefined,
+      expect.objectContaining({ maxSessionMs: 1_800_000 }),
+    )
+    expect(api.maxSessionMs).toBe(1_800_000)
+  })
+
+  it('hydrateTurns restores committed turns and sequence counter', async () => {
+    const sessionId = ref('sess-1')
+    const lang = ref<'en' | 'no'>('no')
+    const { hydrateTurns, committedTurns } = useInterviewVoice(sessionId, lang)
+    hydrateTurns([
+      { role: 'interviewer', text: 'Q1', sequenceNo: 2 },
+      { role: 'user', text: 'A1', sequenceNo: 5 },
+    ])
+    expect(committedTurns.value).toEqual([
+      { role: 'interviewer', text: 'Q1', sequenceNo: 2 },
+      { role: 'user', text: 'A1', sequenceNo: 5 },
+    ])
   })
 })

--- a/frontend/homepage/src/composables/useInterviewVoice.ts
+++ b/frontend/homepage/src/composables/useInterviewVoice.ts
@@ -1,5 +1,6 @@
 import { ref, type Ref } from 'vue'
 import type { RealtimeVoiceModelOption, RealtimeVoiceSessionOptions, SpeechUiLang } from '@/lib/realtime-voice'
+import { INTERVIEW_REALTIME_SESSION_MAX_MS } from '@/lib/realtime-voice'
 import { useRealtimeVoice } from '@/composables/useRealtimeVoice'
 import { appendInterviewTurns, exchangeInterviewRealtimeSdp, type InterviewTurn } from '@/lib/interview-voice'
 
@@ -48,6 +49,7 @@ export function useInterviewVoice(
 
   const voice = useRealtimeVoice(language, sessionOptions, selectedModel, {
     onTurnCommitted,
+    maxSessionMs: INTERVIEW_REALTIME_SESSION_MAX_MS,
     exchangeSdp: (offerSdp, lang, opts, modelId) => {
       const sid = sessionId.value
       if (!sid) {
@@ -80,11 +82,31 @@ export function useInterviewVoice(
     }
   }
 
+  function hydrateTurns(turns: InterviewTurn[]) {
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+    pendingTurns.value = []
+    const normalized = turns
+      .filter((t) => t.text?.trim())
+      .map((t) => ({
+        role: (t.role === 'interviewer' ? 'interviewer' : 'user') as 'user' | 'interviewer',
+        text: t.text.trim(),
+        sequenceNo: typeof t.sequenceNo === 'number' ? t.sequenceNo : 0,
+      }))
+      .sort((a, b) => a.sequenceNo - b.sequenceNo)
+    committedTurns.value = normalized
+    sequenceCounter =
+      normalized.reduce((max, t) => Math.max(max, t.sequenceNo), -1) + 1
+  }
+
   return {
     ...voice,
     committedTurns,
     disconnectAndFlush,
     flushTurns,
     resetTurns,
+    hydrateTurns,
   }
 }

--- a/frontend/homepage/src/composables/useRealtimeVoice.ts
+++ b/frontend/homepage/src/composables/useRealtimeVoice.ts
@@ -61,6 +61,8 @@ export type UseRealtimeVoiceOptions = {
     modelId?: string,
   ) => Promise<{ ok: true; answerSdp: string } | RealtimeSdpFailure>
   onTurnCommitted?: (role: RealtimeTurnRole, text: string) => void
+  /** Client-enforced live session cap; defaults to {@link REALTIME_SESSION_MAX_MS}. */
+  maxSessionMs?: number
 }
 
 /** Wait until ICE candidates are gathered (or timeout) so the SDP posted to the server includes candidates. */
@@ -156,6 +158,7 @@ export function useRealtimeVoice(
   selectedModel?: Readonly<Ref<RealtimeVoiceModelOption | undefined>>,
   voiceOptions?: UseRealtimeVoiceOptions,
 ) {
+  const maxSessionMs = voiceOptions?.maxSessionMs ?? REALTIME_SESSION_MAX_MS
   const connectionState = ref<RealtimeConnectionState>('idle')
   const errorMessage = ref('')
   /** Non-error notice (e.g. session time limit). */
@@ -506,7 +509,7 @@ export function useRealtimeVoice(
 
       sessionTimer = setTimeout(() => {
         disconnect('timeout')
-      }, REALTIME_SESSION_MAX_MS)
+      }, maxSessionMs)
     } catch (e) {
       captureClientException(e)
       teardownMedia()
@@ -566,10 +569,11 @@ export function useRealtimeVoice(
     teardownMedia()
     connectionState.value = 'idle'
     if (reason === 'timeout') {
+      const minutes = Math.max(1, Math.round(maxSessionMs / 60_000))
       sessionNotice.value =
         language.value === 'no'
-          ? 'Tidsbegrensning nådd (5 min). Start på nytt om du vil fortsette.'
-          : 'Time limit reached (5 minutes). Connect again to continue.'
+          ? `Tidsbegrensning nådd (${minutes} min). Start på nytt om du vil fortsette.`
+          : `Time limit reached (${minutes} minutes). Connect again to continue.`
     } else {
       sessionNotice.value = ''
     }
@@ -593,6 +597,6 @@ export function useRealtimeVoice(
     connect,
     disconnect: () => disconnect('user'),
     stopResponse,
-    maxSessionMs: REALTIME_SESSION_MAX_MS,
+    maxSessionMs,
   }
 }

--- a/frontend/homepage/src/lib/__tests__/interview-voice.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/interview-voice.spec.ts
@@ -126,6 +126,43 @@ describe('interview-voice', () => {
     await expect(finalizeInterviewSession('sess1')).resolves.toEqual(transcript)
   })
 
+  it('listInterviewSessions returns sessions array', async () => {
+    const sessions = [
+      {
+        id: 'sess1',
+        documentId: 'doc1',
+        language: 'no',
+        status: 'FINALIZED',
+        startedAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+    mockCustomFetch.mockResolvedValue({ status: 200, data: sessions })
+    const { listInterviewSessions } = await import('../interview-voice')
+    await expect(listInterviewSessions()).resolves.toEqual(sessions)
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/sessions', { method: 'GET' })
+  })
+
+  it('getInterviewSession and reopenInterviewSession hit session paths', async () => {
+    const session = {
+      id: 'sess1',
+      documentId: 'doc1',
+      language: 'no',
+      status: 'ACTIVE',
+      startedAt: '2026-01-01T00:00:00Z',
+      turns: [{ role: 'user', text: 'Hi', sequenceNo: 0 }],
+    }
+    mockCustomFetch.mockResolvedValue({ status: 200, data: session })
+    const { getInterviewSession, reopenInterviewSession } = await import('../interview-voice')
+
+    await expect(getInterviewSession('sess1')).resolves.toEqual(session)
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/sessions/sess1', { method: 'GET' })
+
+    await expect(reopenInterviewSession('sess1')).resolves.toEqual(session)
+    expect(mockCustomFetch).toHaveBeenCalledWith('/admin/tools/interview/sessions/sess1/reopen', {
+      method: 'POST',
+    })
+  })
+
   it('cleanInterviewTranscript returns cleaned transcript', async () => {
     const transcript = {
       id: 'tr1',

--- a/frontend/homepage/src/lib/__tests__/realtime-voice.spec.ts
+++ b/frontend/homepage/src/lib/__tests__/realtime-voice.spec.ts
@@ -189,7 +189,8 @@ describe('realtime-voice', () => {
   })
 
   it('REALTIME_SESSION_MAX_MS is five minutes', async () => {
-    const { REALTIME_SESSION_MAX_MS } = await import('../realtime-voice')
+    const { REALTIME_SESSION_MAX_MS, INTERVIEW_REALTIME_SESSION_MAX_MS } = await import('../realtime-voice')
     expect(REALTIME_SESSION_MAX_MS).toBe(300000)
+    expect(INTERVIEW_REALTIME_SESSION_MAX_MS).toBe(1_800_000)
   })
 })

--- a/frontend/homepage/src/lib/interview-voice.ts
+++ b/frontend/homepage/src/lib/interview-voice.ts
@@ -89,6 +89,42 @@ export async function createInterviewSession(
   return r.data
 }
 
+export async function listInterviewSessions(): Promise<InterviewSession[]> {
+  const r = await customFetch<{ data: InterviewSession[]; status: number }>(
+    '/admin/tools/interview/sessions',
+    { method: 'GET' },
+  )
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
+  return Array.isArray(r.data) ? r.data : []
+}
+
+export async function getInterviewSession(sessionId: string): Promise<InterviewSession> {
+  const r = await customFetch<{ data: InterviewSession; status: number }>(
+    `/admin/tools/interview/sessions/${sessionId}`,
+    { method: 'GET' },
+  )
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
+  return r.data
+}
+
+export async function reopenInterviewSession(sessionId: string): Promise<InterviewSession> {
+  const r = await customFetch<{ data: InterviewSession; status: number }>(
+    `/admin/tools/interview/sessions/${sessionId}/reopen`,
+    { method: 'POST' },
+  )
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
+  return r.data
+}
+
+export async function getInterviewTranscript(transcriptId: string): Promise<InterviewTranscript> {
+  const r = await customFetch<{ data: InterviewTranscript; status: number }>(
+    `/admin/tools/interview/transcripts/${transcriptId}`,
+    { method: 'GET' },
+  )
+  if (r.status !== 200) throw new Error(formatAdminHttpError(r.status, r.data))
+  return r.data
+}
+
 export async function appendInterviewTurns(sessionId: string, turns: InterviewTurn[]): Promise<void> {
   const r = await customFetch<{ status: number; data?: unknown }>(
     `/admin/tools/interview/sessions/${sessionId}/turns`,

--- a/frontend/homepage/src/lib/realtime-voice.ts
+++ b/frontend/homepage/src/lib/realtime-voice.ts
@@ -260,9 +260,11 @@ export async function exchangeRealtimeSdp(
   return parseRealtimeApiFailure(r)
 }
 
-/** Auto-disconnect after this many ms (aligned with backend cost controls). */
-/** Client-enforced live session cap (aligned with UI copy). */
+/** Client-enforced live session cap for public voice (aligned with UI copy). */
 export const REALTIME_SESSION_MAX_MS = 300_000
+
+/** Client-enforced live session cap for admin voice interviews. */
+export const INTERVIEW_REALTIME_SESSION_MAX_MS = 1_800_000
 
 type RealtimeFetchFailureResponse = {
   status: number

--- a/frontend/homepage/src/views/AdminInterviewView.vue
+++ b/frontend/homepage/src/views/AdminInterviewView.vue
@@ -15,9 +15,14 @@ import {
   createInterviewSession,
   createInterviewTextDocument,
   finalizeInterviewSession,
+  getInterviewSession,
+  getInterviewTranscript,
   ingestInterviewTranscript,
+  listInterviewSessions,
+  reopenInterviewSession,
   uploadInterviewDocument,
   type InterviewDocument,
+  type InterviewSession,
   type InterviewTranscript,
 } from '@/lib/interview-voice'
 
@@ -37,6 +42,7 @@ const status = ref('')
 const document = ref<InterviewDocument | null>(null)
 const sessionId = ref<string | null>(null)
 const transcript = ref<InterviewTranscript | null>(null)
+const pastSessions = ref<InterviewSession[]>([])
 
 const liveAvailable = ref<boolean | null>(null)
 const selectedVoice = ref<RealtimeVoiceChoice>('marin')
@@ -57,10 +63,12 @@ const {
   userTranscript,
   isModelSpeaking,
   committedTurns,
+  maxSessionMs,
   connect,
   disconnectAndFlush,
   stopResponse,
   resetTurns,
+  hydrateTurns,
   flushTurns,
 } = useInterviewVoice(sessionId, uiLang, sessionOptions, selectedVoiceModel)
 
@@ -74,6 +82,8 @@ const activeQuestionCount = computed(() => {
   if (pastedText.value.trim()) return countQuestions(pastedText.value)
   return document.value ? null : 0
 })
+
+const maxSessionMinutes = computed(() => Math.round(maxSessionMs / 60_000))
 
 const copy = computed(() => {
   const en = uiLang.value === 'en'
@@ -104,8 +114,23 @@ const copy = computed(() => {
     ingest: en ? 'Add to knowledge base' : 'Legg til i kontekstbase',
     raw: en ? 'Raw transcript' : 'Rått transkript',
     cleaned: en ? 'Cleaned document' : 'Renset dokument',
+    pastSessions: en ? 'Previous sessions' : 'Tidligere sesjoner',
+    continueSession: en ? 'Continue' : 'Fortsett',
+    continueInterview: en ? 'Continue interview' : 'Fortsett intervju',
+    noPastSessions: en ? 'No previous sessions yet.' : 'Ingen tidligere sesjoner ennå.',
+    sessionCap: en
+      ? `Live voice sessions last up to ~${maxSessionMinutes.value} minutes.`
+      : `Live stemmeøkter varer opptil ca. ${maxSessionMinutes.value} minutter.`,
   }
 })
+
+async function refreshPastSessions() {
+  try {
+    pastSessions.value = await listInterviewSessions()
+  } catch {
+    pastSessions.value = []
+  }
+}
 
 onMounted(async () => {
   auth.restore()
@@ -113,11 +138,75 @@ onMounted(async () => {
   liveAvailable.value = statusRes.liveEnabled && (await voiceModelStore.ensureModelsLoaded(), voiceModelStore.hasModels)
   selectedVoice.value = statusRes.voice
   selectedReasoning.value = statusRes.reasoningEffort
+  await refreshPastSessions()
 })
 
 watch(errorMessage, (msg) => {
   if (msg.trim() !== '') error.value = msg
 })
+
+function formatSessionLabel(session: InterviewSession): string {
+  const started = session.startedAt ? new Date(session.startedAt).toLocaleString() : session.id
+  return `${started} · ${session.status}${session.cleanStatus ? ` · ${session.cleanStatus}` : ''}`
+}
+
+async function applyResumedSession(session: InterviewSession) {
+  sessionId.value = session.id
+  if (session.language === 'en' || session.language === 'no') {
+    uiLang.value = session.language
+  }
+  if (session.voice === 'marin' || session.voice === 'cedar') {
+    selectedVoice.value = session.voice
+  }
+  hydrateTurns(session.turns ?? [])
+  if (session.transcriptId) {
+    try {
+      transcript.value = await getInterviewTranscript(session.transcriptId)
+    } catch {
+      transcript.value = null
+    }
+  } else {
+    transcript.value = null
+  }
+  step.value = 'interview'
+}
+
+async function continuePastSession(session: InterviewSession) {
+  busy.value = true
+  error.value = ''
+  try {
+    let live = session
+    if (session.status === 'FINALIZED') {
+      live = await reopenInterviewSession(session.id)
+    } else if (session.status === 'ACTIVE') {
+      live = await getInterviewSession(session.id)
+    } else {
+      throw new Error(uiLang.value === 'en' ? 'Session cannot be continued' : 'Sesjonen kan ikke fortsettes')
+    }
+    await applyResumedSession(live)
+    status.value = uiLang.value === 'en' ? 'Session resumed' : 'Sesjon gjenopptatt'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Resume failed'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function continueInterviewFromClean() {
+  if (!sessionId.value) return
+  busy.value = true
+  error.value = ''
+  try {
+    await disconnectAndFlush()
+    const live = await reopenInterviewSession(sessionId.value)
+    await applyResumedSession(live)
+    status.value = uiLang.value === 'en' ? 'Interview continued' : 'Intervju fortsetter'
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Reopen failed'
+  } finally {
+    busy.value = false
+  }
+}
 
 async function handleFileUpload(event: Event) {
   const input = event.target as HTMLInputElement
@@ -174,9 +263,11 @@ async function startInterview() {
     if (!doc) return
     const session = await createInterviewSession(doc.id, uiLang.value, selectedVoice.value)
     sessionId.value = session.id
+    transcript.value = null
     resetTurns()
     step.value = 'interview'
     status.value = 'Sesjon opprettet'
+    await refreshPastSessions()
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Session failed'
   } finally {
@@ -198,6 +289,7 @@ async function saveTranscript() {
     transcript.value = await finalizeInterviewSession(sessionId.value)
     step.value = 'clean'
     status.value = 'Transkript lagret'
+    await refreshPastSessions()
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Finalize failed'
   } finally {
@@ -229,6 +321,7 @@ async function runIngest() {
   try {
     const result = await ingestInterviewTranscript(transcript.value.id, false)
     status.value = `Ingest fullført: ${JSON.stringify(result)}`
+    await refreshPastSessions()
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Ingest failed'
   } finally {
@@ -308,10 +401,33 @@ async function runIngest() {
           <Loader2 v-if="busy" class="inline size-4 animate-spin mr-1" />
           {{ copy.start }}
         </button>
+
+        <div class="border-t border-gray-100 pt-4 space-y-2">
+          <h3 class="text-sm font-semibold text-gray-800">{{ copy.pastSessions }}</h3>
+          <p v-if="pastSessions.length === 0" class="text-sm text-gray-500">{{ copy.noPastSessions }}</p>
+          <ul v-else class="space-y-2">
+            <li
+              v-for="s in pastSessions"
+              :key="s.id"
+              class="flex flex-wrap items-center justify-between gap-2 rounded border border-gray-200 px-3 py-2 text-sm"
+            >
+              <span class="text-gray-700">{{ formatSessionLabel(s) }}</span>
+              <button
+                type="button"
+                class="rounded border border-blue-600 text-blue-700 px-2 py-1 text-xs disabled:opacity-50"
+                :disabled="busy || (s.status !== 'ACTIVE' && s.status !== 'FINALIZED')"
+                @click="continuePastSession(s)"
+              >
+                {{ copy.continueSession }}
+              </button>
+            </li>
+          </ul>
+        </div>
       </section>
 
       <section v-else-if="step === 'interview'" class="space-y-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
         <h2 class="text-lg font-semibold">{{ copy.interview }}</h2>
+        <p class="text-sm text-gray-600">{{ copy.sessionCap }}</p>
 
         <p v-if="liveAvailable === false" class="text-sm text-amber-800">
           Realtime voice er ikke tilgjengelig. Sjekk PORTFOLIO_REALTIME_ENABLED og OPENAI_API_KEY.
@@ -367,6 +483,14 @@ async function runIngest() {
           </div>
         </div>
 
+        <div v-if="committedTurns.length" class="rounded border p-3 text-sm max-h-48 overflow-y-auto space-y-1">
+          <p class="font-medium text-gray-700 mb-1">Lagrede turns</p>
+          <p v-for="(t, i) in committedTurns" :key="i" class="text-gray-800">
+            <span class="font-medium">{{ t.role === 'user' ? 'Kevin' : 'Intervjuer' }}:</span>
+            {{ t.text }}
+          </p>
+        </div>
+
         <button
           type="button"
           class="rounded border border-blue-600 text-blue-700 px-4 py-2 text-sm"
@@ -407,6 +531,14 @@ async function runIngest() {
           </div>
         </div>
         <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="rounded border border-blue-600 text-blue-700 px-4 py-2 text-sm disabled:opacity-50"
+            :disabled="busy || !sessionId"
+            @click="continueInterviewFromClean"
+          >
+            {{ copy.continueInterview }}
+          </button>
           <button
             type="button"
             class="rounded bg-gray-800 text-white px-4 py-2 text-sm disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Raise admin interview live sessions to 30 minutes (public voice stays at 5) and relax interview Realtime mint rate limit to 20/hour.
- Use configurable stronger models: `gpt-4o-transcribe` for interview STT and `gpt-5.4-mini` (8192 max tokens) for transcript cleaning.
- Support continuing after save via upsert finalize, `POST .../reopen`, in-wizard «Fortsett intervju», and a previous-sessions list.

## Test plan
- [x] Backend unit tests: InterviewSessionService (upsert/reopen/ACTIVE gates), InterviewRealtimeSessionService (transcription model), InterviewTranscriptCleanerService
- [x] Frontend unit tests: interview maxSessionMs, list/get/reopen clients, hydrateTurns
- [x] Frontend type-check
- [ ] Smoke admin interview: start > speak > save > Fortsett intervju > add turns > re-save > clean > ingest
- [ ] Resume a FINALIZED session from the previous-sessions list